### PR TITLE
Download pod logs

### DIFF
--- a/scrape.yaml
+++ b/scrape.yaml
@@ -1,3 +1,5 @@
+general_config:
+  kubeconfig: "kubeconfig.yaml"
 scrape_config:
   $__rate_interval: "121s"
   step: "60s"

--- a/src/metrics/kubernetes.py
+++ b/src/metrics/kubernetes.py
@@ -47,7 +47,7 @@ class KubernetesManager:
         path_location_result = path.prepare_path(location + pod_name + ".log")
 
         if path_location_result.is_ok():
-            with open(f"{path_location_result.ok}", "w") as log_file:
+            with open(f"{path_location_result.ok_value}", "w") as log_file:
                 log_file.write(logs)
             logger.debug(f"Logs from pod {pod_name} downloaded successfully.")
         else:

--- a/src/metrics/kubernetes.py
+++ b/src/metrics/kubernetes.py
@@ -7,6 +7,7 @@ from typing import List, Tuple
 from kubernetes.client import V1PodList, V1Service
 from kubernetes.stream import portforward
 
+# Project Imports
 from src.utils import path
 
 logger = logging.getLogger(__name__)

--- a/src/metrics/scrapper.py
+++ b/src/metrics/scrapper.py
@@ -3,7 +3,6 @@ import socket
 import logging
 from typing import Dict
 from result import Ok, Err
-from kubernetes.client import CoreV1Api
 
 # Project Imports
 from src.metrics import scrape_utils
@@ -15,12 +14,12 @@ logger = logging.getLogger(__name__)
 
 
 class Scrapper:
-    def __init__(self, api: CoreV1Api, url: str, query_config_file: str):
+    def __init__(self, kube_config: str, url: str, query_config_file: str):
         self._url = url
         self._query_config = None
         self._query_config_file = query_config_file
         self._set_query_config()
-        self._k8s = kubernetes.KubernetesManager(api)
+        self._k8s = kubernetes.KubernetesManager(kube_config)
 
     def query_and_dump_metrics(self):
         # https://github.com/kubernetes-client/python/blob/master/examples/pod_portforward.py


### PR DESCRIPTION
`kubernetes.config.` is something that is not pickable by python, but we need this configuration to access to the API. 
I could do several things here, but most of them were about taking out the configuration and hence the API access from the class.
This was a very specific case where it is one of the very few occasions we will want to do something asynchronously in the cluster. I decided to create a static method in the class, so we don't have to take out the client and its configuration outside the class. This allows us to do calls asynchronously, since each call will create a new client configuration instead of trying to pickle it.
