### PR TITLE
Message store check

### DIFF
--- a/deployment/docker/store/Dockerfile
+++ b/deployment/docker/store/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-alpine
+
+ADD ./store_msg_retriever.py /app/store_msg_retriever.py
+
+RUN pip install requests

--- a/deployment/docker/store/store_msg_retriever.py
+++ b/deployment/docker/store/store_msg_retriever.py
@@ -1,0 +1,84 @@
+# Python Imports
+import argparse
+import logging
+import requests
+import socket
+import time
+from typing import Dict, List
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+def check_dns_time(node: str) -> str:
+    start_time = time.time()
+    name, port = node.split(":")
+    ip_address = socket.gethostbyname(name)
+    elapsed = (time.time() - start_time) * 1000
+    logging.info(f"{name} DNS Response took {elapsed} ms")
+
+    return f"{ip_address}:{port}"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Waku storage retriever")
+    parser.add_argument('-c', '--contentTopics', type=str, help='Content topic', default="kubekube")
+    parser.add_argument('-p', '--pubsubTopic', type=str, help='Pubsub topic',
+                        default="/waku/2/rs/2/0")
+    parser.add_argument('-ps', '--pageSize', type=int,
+                        help='Number of messages to retrieve per page', default=60)
+    parser.add_argument('-cs', '--cursor', type=str,
+                        help='Cursor field intended for pagination purposes. ', default="")
+
+    return parser.parse_args()
+
+
+def next_cursor(data: Dict) -> str | None:
+    cursor = data.get('cursor')
+    if not cursor:
+        logging.info("No more messages")
+        return None
+
+    return cursor
+
+
+def fetch_all_messages(base_url: str, initial_params: Dict, headers: Dict) -> List[str]:
+    all_messages = []
+    params = initial_params.copy()
+
+    while True:
+        response = requests.get(base_url, headers=headers, params=params)
+        if response.status_code != 200:
+            logging.error(f"Error fetching data: {response.status_code}")
+            break
+
+        data = response.json()
+        logging.info(data)
+        all_messages.extend([message['messageHash'] for message in data['messages']])
+
+        cursor = next_cursor(params)
+        if not cursor:
+            break
+        data["cursor"] = cursor
+
+    return all_messages
+
+
+def main():
+    args = parse_args()
+    args_dict = vars(args)
+    logging.info(f"Arguments: {args_dict}")
+
+    service = "zerotesting-service:8645"
+    node = check_dns_time(service)
+    url = f"http://{node}/store/v3/messages"
+    logging.info(f"Query to {url}")
+    headers = {"accept": "application/json"}
+
+    messages = fetch_all_messages(url, args_dict, headers)
+    logging.info("List of messages")
+    # We do a print here, so it is easier to parse when reading from victoria logs
+    print(messages)
+
+
+if __name__ == "__main__":
+    main()

--- a/deployment/docker/store/store_msg_retriever.py
+++ b/deployment/docker/store/store_msg_retriever.py
@@ -33,7 +33,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def next_cursor(data: Dict) -> str | None:
-    cursor = data.get('cursor')
+    cursor = data.get('paginationCursor')
     if not cursor:
         logging.info("No more messages")
         return None
@@ -55,10 +55,10 @@ def fetch_all_messages(base_url: str, initial_params: Dict, headers: Dict) -> Li
         logging.info(data)
         all_messages.extend([message['messageHash'] for message in data['messages']])
 
-        cursor = next_cursor(params)
+        cursor = next_cursor(data)
         if not cursor:
             break
-        data["cursor"] = cursor
+        params["cursor"] = cursor
 
     return all_messages
 

--- a/example_log_analysis.py
+++ b/example_log_analysis.py
@@ -7,11 +7,12 @@ from src.mesh_analysis.waku_message_log_analyzer import WakuMessageLogAnalyzer
 
 if __name__ == '__main__':
     # Timestamp of the simulation
-    timestamp = "[2024-08-05T15:45:00, 2024-08-05T15:49:00]"
+    timestamp = "[2024-08-14T11:11:00, 2024-08-14T12:05:00]"
     # Example of data analysis from cluster
-    # log_analyzer = WakuMessageLogAnalyzer(timestamp, dump_analysis_dir='test_logs_victoria')
+    log_analyzer = WakuMessageLogAnalyzer(timestamp, dump_analysis_dir='store')
     # Example of data analysis from local
-    log_analyzer = WakuMessageLogAnalyzer(local_folder_to_analyze='data', dump_analysis_dir='test_logs_victoria')
+    # log_analyzer = WakuMessageLogAnalyzer(local_folder_to_analyze='lpt_duptest_debug', dump_analysis_dir='lpt_duptest_debug/notion')
 
-    log_analyzer.analyze_message_logs()
+    log_analyzer.analyze_message_logs(True)
+    log_analyzer.check_store_messages()
     log_analyzer.analyze_message_timestamps(time_difference_threshold=2)


### PR DESCRIPTION
PR to add store message analysis.

I created a container to connect to a random node in the network and perform a `get /store/v3/messages` request to a random node in the deployment.
This container will run after a simulation is finished. 
The return of this request should be the same message hashes than the log analysis.
Tested and passed on 100 nodes + 5 store deployment, 60 messages at 1msg/s.