### PR TITLE
Add deploy to BaseExperiment and add --dry-run

### DIFF
--- a/deployments/deployment.py
+++ b/deployments/deployment.py
@@ -9,7 +9,7 @@ from kubernetes import config
 from kubernetes.client import ApiClient
 from ruamel import yaml
 
-from kube_utils import init_logger
+from kube_utils import init_logger, set_config_file
 from registry import registry as experiment_registry
 
 logger = logging.getLogger(__name__)
@@ -25,6 +25,7 @@ def run_experiment(
     if not kube_config:
         kube_config = "~/.kube/config"
     config.load_kube_config(config_file=kube_config)
+    set_config_file(kube_config)
     api_client = ApiClient()
 
     try:

--- a/deployments/deployment/builders.py
+++ b/deployments/deployment/builders.py
@@ -39,7 +39,7 @@ def build_deployment(
         extra_values_paths = []
     if cli_values is None:
         cli_values = CommentedMap()
-    name = name.replace("_", "-")
+    name = name.replace("_", "-").replace("/", "-")
 
     logger.debug(f"Removing work dir: {workdir}")
     try:


### PR DESCRIPTION
Moving logic for deployments into BaseExperiment makes the derived experiment classes less cluttered. It also allows us to automatically add `self.log_event` for deployments, add cleanup hooks, and check for a clean namespace on first deployment.

This should be merged in after https://github.com/vacp2p/10ksim/pull/131