### PR TITLE
Allow custom condition in wait_for_rollout

### DIFF
--- a/src/deployments/core/kube_utils.py
+++ b/src/deployments/core/kube_utils.py
@@ -18,15 +18,16 @@ from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
 from functools import lru_cache, partial
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Protocol, Tuple, Union
 
 import dateparser
 import ruamel.yaml
 from kubernetes import client, utils
-from kubernetes.client import ApiClient, V1Probe
+from kubernetes.client import ApiClient, ApiException, V1ObjectMeta, V1Pod, V1Probe
 from kubernetes.client.models import V1Node
 from kubernetes.client.rest import ApiException
 from kubernetes.utils import FailToCreateError
+from pydantic import NonNegativeInt
 from ruamel import yaml
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
@@ -160,7 +161,7 @@ def _extract_kind_and_name(kube_yaml: dict) -> Tuple[str, str]:
 def _kind_api_map(operation: str) -> Dict[str, Tuple[str, str]]:
     kind_map = {
         "Deployment": ("apps", "deployment"),
-        "StatefulSet": ("apps", "statefulset"),
+        "StatefulSet": ("apps", "stateful_set"),
         "DaemonSet": ("apps", "daemonset"),
         "ReplicaSet": ("apps", "replicaset"),
         "Job": ("batch", "job"),
@@ -228,7 +229,12 @@ def _kubectl_replace(kube_yaml: dict, namespace: str):
 
 
 def kubectl_apply(
-    kube_yaml: yaml.YAMLObject, namespace: str, *, config_file=None, dry_run=False, exist_ok=False
+    kube_yaml: yaml.YAMLObject,
+    namespace: str,
+    *,
+    config_file=None,
+    dry_run=False,
+    exist_ok=False,
 ):
     """Attempts to apply a yaml, similar to the command `kubectl apply`.
 
@@ -389,7 +395,9 @@ def cleanup_resources(
             api_client
         ).delete_namespaced_replication_controller(name, namespace),
         "Job": lambda name: client.BatchV1Api(api_client).delete_namespaced_job(
-            name, namespace, body=client.V1DeleteOptions(propagation_policy="Foreground")
+            name,
+            namespace,
+            body=client.V1DeleteOptions(propagation_policy="Foreground"),
         ),
         "CronJob": lambda name: client.BatchV1beta1Api(api_client).delete_namespaced_cron_job(
             name, namespace
@@ -530,23 +538,33 @@ def get_cleanup(
     return cleanup
 
 
+class K8sObject(Protocol):
+    metadata: V1ObjectMeta
+    kind: str
+
+
 def poll_rollout_status(
-    kind: str,
-    name: str,
-    namespace: str,
+    deployment: dict | K8sObject,
     api_client,
-    # TODO [extend condition checks]: union lambda
-    pod_status_condition: Optional[Tuple[str, str]] = None,
-    # TODO [extend condition checks]: lambda
-) -> bool:
+    *,
+    pod_status_condition: Optional[Tuple[str, str] | Callable[[V1Pod], bool]] = None,
+) -> Tuple[int, int]:
     """
     Poll the rollout status for the given resource.
 
-    Returns: True if the resource is ready, False otherwise.
+    :pod_ready_condition: Logic for checking if a pod is ready.
+    If given a Callable checks `pod_ready_condition(pod : V1Pod)`.
+    If given a Tuple, checks the `pod.status.conditions` for `key == value`.
+    If None and  `kind == StatefulSet` checks `available_replicas`.
+    If None and `kind == Pod` uses `("Ready", "True")`.
 
-    For pod, returns True if a pod status can be found such that
-    kind == pod_ready_condition[0] and status == pod_ready_condition[1].
+    For deployments/statefulsets/daemonsets: returns (available_replicas, desired_replicas)
+    For pods: returns (1, 1) if condition matches, (0, 1) otherwise.
     """
+    deployment = k8s_obj_to_dict(deployment)
+    namespace = deployment["metadata"]["namespace"]
+    name = deployment["metadata"]["name"]
+    kind = deployment["kind"]
 
     kind = kind.lower()
 
@@ -554,52 +572,32 @@ def poll_rollout_status(
         obj = client.AppsV1Api(api_client).read_namespaced_deployment(name, namespace)
         desired = obj.spec.replicas or 0
         available = obj.status.available_replicas or 0
-        return available == desired
+        return available, desired
 
     elif kind == "statefulset":
-        obj = client.AppsV1Api(api_client).read_namespaced_stateful_set(name, namespace)
-        desired = obj.spec.replicas or 0
-        available = getattr(obj.status, "available_replicas", None)
-        if available is None:
-            available = getattr(obj.status, "ready_replicas", 0)
-        return available == desired
+        if pod_status_condition is None:
+            # By default, just check if pods are ready according to statefulset's available_replicas.
+            obj = client.AppsV1Api(api_client).read_namespaced_stateful_set(name, namespace)
+            desired = obj.spec.replicas or 0
+            available = getattr(obj.status, "available_replicas", None)
+            if available is None:
+                available = getattr(obj.status, "ready_replicas", 0)
+            return available, desired
+        pods = get_pods_for_statefulset(name, namespace, api_client)
+        available = [check_pod_condition(pod, pod_status_condition) for pod in pods]
+        return (sum(available), len(pods))
 
     elif kind == "daemonset":
         obj = client.AppsV1Api(api_client).read_namespaced_daemon_set(name, namespace)
         desired = obj.status.desired_number_scheduled or 0
         available = obj.status.number_available or 0
-        return available == desired
-
-    # TODO [extend condition checks]: example lambda:
-    # def container_cond(status):
-    #     try:
-    #         if status.name == "publisher-container" and status.state.terminated.reason == "Completed":
-    #             return True
-    #     except AttributeError:
-    #         pass
-    #     return False
+        return available, desired
 
     elif kind == "pod":
-        if pod_status_condition is None:
-            # TODO [extend condition checks]: add to comment: or container
-            # status check.
-            raise ValueError("Polling a pod requires a status condition.")
-        key, value = pod_status_condition
         v1 = client.CoreV1Api(api_client)
         pod = v1.read_namespaced_pod(name, namespace)
-
-        # for status in pod.status.container_statuses:
-        #     # TODO [extend condition checks]: use lambda here
-        #     container_cond(status)
-
-        conditions = pod.status.conditions or []
-        for cond in conditions:
-            # TODO [extend condition checks]: use lambda here
-            if cond.type == key:
-                if cond.status == value:
-                    return True
-
-        return False
+        available = check_pod_condition(pod, pod_status_condition)
+        return int(available), 1
 
     elif kind == "service":
         # Services don't have a rollout status, they are immediately available
@@ -609,25 +607,40 @@ def poll_rollout_status(
         raise ValueError(f"Unsupported kind: `{kind}`")
 
 
-# TODO: Make kind, name, namespace optional and derive from deployment.yaml.
 async def wait_for_rollout(
-    kind: str,
-    name: str,
-    namespace: str,
+    deployment: dict | K8sObject,
+    api_client,
+    *,
     timeout: int = 300,
-    api_client=None,
-    pod_ready_condition: Optional[Tuple[str, str]] = None,
     polling_interval: int = 8,
+    pod_ready_condition: Optional[Tuple[str, str] | Callable[[V1Pod], bool]] = None,
+    condition: Optional[Callable[[NonNegativeInt, NonNegativeInt], bool]] = None,
 ):
     """
     Wait for a rollout of a Kubernetes workload, or a pod ready condition.
 
     :timeout: Timeout in seconds.
 
-    :pod_ready_condition: If set, wait for pod's Ready condition to match ('True' or 'False').
+    :condition: Used to determine if the rollout is done.
+    `condition(ready, total) -> bool`, should return `True` for ready and `False` for not ready.
+    If None, uses `ready == total` by default.
+
+    :pod_ready_condition: Logic for checking if a pod is ready.
+    If `Callable`, checks `pod_ready_condition(pod : V1Pod)`.
+    If `Tuple`, checks the `pod.status.conditions` for `key == value`.
+    If `None` and  `kind == StatefulSet`, checks `available_replicas`.
+    If `None` and `kind == Pod`, uses `("Ready", "True")`.
 
     Raises TimeoutError if timeout is exceeded.
     """
+    deployment = k8s_obj_to_dict(deployment)
+    namespace = deployment["metadata"]["namespace"]
+    name = deployment["metadata"]["name"]
+    kind = deployment["kind"]
+
+    if condition is None:
+        condition = lambda ready, total: ready == total
+
     start_time = time.time()
     target_desc = (
         f"pod `{name}` Ready=`{pod_ready_condition}`"
@@ -638,10 +651,8 @@ async def wait_for_rollout(
 
     while True:
         try:
-            ready = poll_rollout_status(
-                kind,
-                name,
-                namespace,
+            ready, total = poll_rollout_status(
+                deployment,
                 api_client,
                 pod_status_condition=pod_ready_condition,
             )
@@ -650,17 +661,53 @@ async def wait_for_rollout(
             await asyncio.sleep(polling_interval)
             continue
 
-        logger.info(f"Waiting: {target_desc} ready=`{ready}`...")
+        logger.info(f"Waiting: {target_desc} ready=`{ready}` total=`{total}`...")
 
-        if ready:
+        if condition(ready, total):
             logger.info(f"{target_desc} is ready.")
-            return
+            return ready, total
 
         elapsed = time.time() - start_time
         if elapsed > timeout:
             raise TimeoutError(f"Timeout waiting for: `{target_desc}`.")
 
         await asyncio.sleep(polling_interval)
+
+
+def get_pods_for_statefulset(name: str, namespace: str, api_client=None):
+    api_client = api_client or client.ApiClient()
+    apps_api = client.AppsV1Api(api_client)
+    core_api = client.CoreV1Api(api_client)
+
+    sts = apps_api.read_namespaced_stateful_set(name=name, namespace=namespace)
+
+    selector = []
+    if sts.spec.selector and sts.spec.selector.match_labels:
+        selector.extend(f"{key}={value}" for key, value in sts.spec.selector.match_labels.items())
+
+    label_selector = ",".join(selector)
+
+    return core_api.list_namespaced_pod(
+        namespace=namespace,
+        label_selector=label_selector,
+    ).items
+
+
+def check_pod_condition(
+    pod: List[V1Pod], condition: Optional[Tuple[str, str] | Callable[[V1Pod], bool]] = None
+):
+    if condition is None:
+        condition = ("Ready", "True")
+
+    if isinstance(condition, tuple):
+        conditions = pod.status.conditions or []
+        key, value = condition
+        if any(cond.type == key and cond.status == value for cond in conditions):
+            return 1
+        else:
+            return 0
+    else:
+        return condition(pod)
 
 
 def poll_namespace_has_objects(
@@ -790,7 +837,7 @@ def dict_to_v1probe(probe_dict: dict) -> V1Probe:
     return dict_to_k8s_object(probe_dict, "V1Probe")
 
 
-def k8s_obj_to_dict(deployment: K8sModelStr) -> dict:
+def k8s_obj_to_dict(deployment: Any) -> dict:
     api_client = client.ApiClient()
     return api_client.sanitize_for_serialization(deployment)
 

--- a/src/deployments/core/kube_utils.py
+++ b/src/deployments/core/kube_utils.py
@@ -18,7 +18,7 @@ from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
 from functools import lru_cache, partial
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Literal, Optional, Tuple, Union
 
 import dateparser
 import ruamel.yaml
@@ -681,23 +681,42 @@ async def wait_for_rollout(
         await asyncio.sleep(polling_interval)
 
 
-def get_pods_for_statefulset(name: str, namespace: str, api_client=None):
+def get_pods_for_statefulset(name: str, namespace: str, api_client=None) -> Iterable[V1Pod]:
     api_client = api_client or client.ApiClient()
     apps_api = client.AppsV1Api(api_client)
     core_api = client.CoreV1Api(api_client)
 
-    sts = apps_api.read_namespaced_stateful_set(name=name, namespace=namespace)
+    kwargs = {
+        "namespace": namespace,
+    }
 
-    selector = []
-    if sts.spec.selector and sts.spec.selector.match_labels:
-        selector.extend(f"{key}={value}" for key, value in sts.spec.selector.match_labels.items())
+    statefulset = apps_api.read_namespaced_stateful_set(name=name, namespace=namespace)
+    selector = statefulset.spec.selector
+    labels = selector.match_labels if selector and selector.match_labels else None
+    if labels is not None:
+        kwargs["label_selector"] = ",".join(f"{k}={v}" for k, v in labels.items())
 
-    label_selector = ",".join(selector)
+    def has_matching_owner(obj: V1Pod):
+        def is_ss_owner(owner):
+            return all(
+                [
+                    owner.kind == "StatefulSet",
+                    owner.api_version == "apps/v1",
+                    owner.name == statefulset.metadata.name,
+                    owner.uid == statefulset.metadata.uid,
+                    getattr(owner, "controller", True),
+                ]
+            )
 
-    return core_api.list_namespaced_pod(
-        namespace=namespace,
-        label_selector=label_selector,
-    ).items
+        owners = obj.metadata.owner_references
+        if not owners:
+            return False
+        return any(is_ss_owner(owner) for owner in owners)
+
+    return filter(
+        lambda obj: has_matching_owner(obj),
+        core_api.list_namespaced_pod(**kwargs).items,
+    )
 
 
 def check_pod_condition(

--- a/src/deployments/core/kube_utils.py
+++ b/src/deployments/core/kube_utils.py
@@ -18,20 +18,40 @@ from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
 from functools import lru_cache, partial
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Protocol, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Tuple, Union
 
 import dateparser
 import ruamel.yaml
 from kubernetes import client, utils
-from kubernetes.client import ApiClient, ApiException, V1ObjectMeta, V1Pod, V1Probe
+from kubernetes.client import (
+    ApiClient,
+    ApiException,
+    V1CronJob,
+    V1DaemonSet,
+    V1Deployment,
+    V1Job,
+    V1Pod,
+    V1PodTemplateSpec,
+    V1Probe,
+    V1StatefulSet,
+)
 from kubernetes.client.models import V1Node
 from kubernetes.client.rest import ApiException
 from kubernetes.utils import FailToCreateError
-from pydantic import NonNegativeInt
 from ruamel import yaml
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 # Project Imports
+
+V1Deployable = Union[
+    V1PodTemplateSpec,
+    V1Pod,
+    V1Deployment,
+    V1StatefulSet,
+    V1DaemonSet,
+    V1Job,
+    V1CronJob,
+]
 
 
 def get_log_level(verbosity: Union[str, int]) -> int:
@@ -206,10 +226,13 @@ def _kubectl_operation(
     api = api_group_map[group]
     method = getattr(api, method_name)
 
-    needs_name = operation != "create"
-    if needs_name:
+    if operation != "create":
+        # A "create" operation does not need the name. Others do.
         method = partial(method, name=name)
-    method = partial(method, namespace=namespace, body=kube_yaml)
+    if operation != "read":
+        # A "read" operation does not need the body. Others do.
+        method = partial(method, body=kube_yaml)
+    method = partial(method, namespace=namespace)
 
     return method()
 
@@ -226,6 +249,11 @@ def _kubectl_patch(kube_yaml: dict, namespace: str):
 def _kubectl_replace(kube_yaml: dict, namespace: str):
     _, name = _extract_kind_and_name(kube_yaml)
     return _kubectl_operation(kube_yaml, namespace, name, "replace")
+
+
+def get_namespaced(obj: dict | V1Deployable):
+    deployment_dict = k8s_obj_to_dict(obj)
+    return _kubectl_operation(deployment_dict, obj.metadata.namespace, obj.metadata.name, "read")
 
 
 def kubectl_apply(
@@ -538,66 +566,58 @@ def get_cleanup(
     return cleanup
 
 
-class K8sObject(Protocol):
-    metadata: V1ObjectMeta
-    kind: str
-
-
 def poll_rollout_status(
-    deployment: dict | K8sObject,
-    api_client,
+    deployment: dict | V1Deployable,
     *,
-    pod_status_condition: Optional[Tuple[str, str] | Callable[[V1Pod], bool]] = None,
+    condition: Callable[[V1Deployable], bool] | None = None,
 ) -> Tuple[int, int]:
     """
     Poll the rollout status for the given resource.
 
-    :pod_ready_condition: Logic for checking if a pod is ready.
-    If given a Callable checks `pod_ready_condition(pod : V1Pod)`.
-    If given a Tuple, checks the `pod.status.conditions` for `key == value`.
-    If None and  `kind == StatefulSet` checks `available_replicas`.
-    If None and `kind == Pod` uses `("Ready", "True")`.
-
-    For deployments/statefulsets/daemonsets: returns (available_replicas, desired_replicas)
-    For pods: returns (1, 1) if condition matches, (0, 1) otherwise.
+    :condition: Used to determine if the deployment is ready.
+    `condition(obj) -> bool`, should return `True` for ready and `False` for not ready.
+    If `None` and  `kind == StatefulSet`, checks that all pods are updated and ready.
+    If `None` and `kind == Pod`, checks that the pod has a status condition with `("Ready", "True")`.
+    etc.
     """
-    deployment = k8s_obj_to_dict(deployment)
-    namespace = deployment["metadata"]["namespace"]
-    name = deployment["metadata"]["name"]
-    kind = deployment["kind"]
+    if isinstance(deployment, dict):
+        deployment = dict_to_k8s_object(deployment, "V1" + deployment["kind"])
+    kind = deployment.kind.lower()
 
-    kind = kind.lower()
+    obj = get_namespaced(deployment)
 
     if kind == "deployment":
-        obj = client.AppsV1Api(api_client).read_namespaced_deployment(name, namespace)
-        desired = obj.spec.replicas or 0
-        available = obj.status.available_replicas or 0
-        return available, desired
+
+        def default_condition(obj: V1Deployment):
+            desired = obj.spec.replicas
+            available = obj.status.available_replicas or 0
+            return available, desired
 
     elif kind == "statefulset":
-        if pod_status_condition is None:
-            # By default, just check if pods are ready according to statefulset's available_replicas.
-            obj = client.AppsV1Api(api_client).read_namespaced_stateful_set(name, namespace)
-            desired = obj.spec.replicas or 0
-            available = getattr(obj.status, "available_replicas", None)
-            if available is None:
-                available = getattr(obj.status, "ready_replicas", 0)
-            return available, desired
-        pods = get_pods_for_statefulset(name, namespace, api_client)
-        available = [check_pod_condition(pod, pod_status_condition) for pod in pods]
-        return (sum(available), len(pods))
+
+        def default_condition(obj: V1StatefulSet):
+            ready = getattr(obj.status, "ready_replicas", 0) or 0
+            desired = obj.spec.replicas
+            logger.info(f"Statefulset `{obj.metadata.name}` ready={ready} total={desired}")
+            return (
+                obj.status.current_revision == obj.status.update_revision
+                and desired == getattr(obj.status, "available_replicas", 0)
+                and desired == getattr(obj.status, "updated_replicas", 0)
+                and desired == getattr(obj.status, "ready_replicas", 0)
+            )
 
     elif kind == "daemonset":
-        obj = client.AppsV1Api(api_client).read_namespaced_daemon_set(name, namespace)
-        desired = obj.status.desired_number_scheduled or 0
-        available = obj.status.number_available or 0
-        return available, desired
+
+        def default_condition(obj: V1DaemonSet):
+            desired = obj.spec.replicas
+            desired = obj.status.desired_number_scheduled or 0
+            available = obj.status.number_available or 0
+            return available == desired
 
     elif kind == "pod":
-        v1 = client.CoreV1Api(api_client)
-        pod = v1.read_namespaced_pod(name, namespace)
-        available = check_pod_condition(pod, pod_status_condition)
-        return int(available), 1
+
+        def default_condition(pod: V1Pod):
+            return check_pod_condition(pod)
 
     elif kind == "service":
         # Services don't have a rollout status, they are immediately available
@@ -606,15 +626,18 @@ def poll_rollout_status(
     else:
         raise ValueError(f"Unsupported kind: `{kind}`")
 
+    if condition is None:
+        return default_condition(obj)
+    return condition(obj)
+
 
 async def wait_for_rollout(
-    deployment: dict | K8sObject,
+    deployment: dict | V1Deployable,
     api_client,
     *,
     timeout: int = 300,
     polling_interval: int = 8,
-    pod_ready_condition: Optional[Tuple[str, str] | Callable[[V1Pod], bool]] = None,
-    condition: Optional[Callable[[NonNegativeInt, NonNegativeInt], bool]] = None,
+    condition: Optional[Callable[[V1Deployable], bool]] = None,
 ):
     """
     Wait for a rollout of a Kubernetes workload, or a pod ready condition.
@@ -622,14 +645,10 @@ async def wait_for_rollout(
     :timeout: Timeout in seconds.
 
     :condition: Used to determine if the rollout is done.
-    `condition(ready, total) -> bool`, should return `True` for ready and `False` for not ready.
-    If None, uses `ready == total` by default.
-
-    :pod_ready_condition: Logic for checking if a pod is ready.
-    If `Callable`, checks `pod_ready_condition(pod : V1Pod)`.
-    If `Tuple`, checks the `pod.status.conditions` for `key == value`.
-    If `None` and  `kind == StatefulSet`, checks `available_replicas`.
-    If `None` and `kind == Pod`, uses `("Ready", "True")`.
+    `condition(obj) -> bool`, should return `True` for ready and `False` for not ready.
+    If `None` and  `kind == StatefulSet`, checks that all pods are updated and ready.
+    If `None` and `kind == Pod`, checks that the pod has a status condition with `("Ready", "True")`.
+    etc.
 
     Raises TimeoutError if timeout is exceeded.
     """
@@ -638,38 +657,26 @@ async def wait_for_rollout(
     name = deployment["metadata"]["name"]
     kind = deployment["kind"]
 
-    if condition is None:
-        condition = lambda ready, total: ready == total
+    logger.info(f"Waiting for {kind} `{name}` in namespace `{namespace}` (timeout: {timeout}s)...")
 
     start_time = time.time()
-    target_desc = (
-        f"pod `{name}` Ready=`{pod_ready_condition}`"
-        if kind.lower() == "pod" and pod_ready_condition is not None
-        else f"`{kind}` `{name}`"
-    )
-    logger.info(f"Waiting for {target_desc} in namespace `{namespace}` (timeout: {timeout}s)...")
-
     while True:
         try:
-            ready, total = poll_rollout_status(
-                deployment,
-                api_client,
-                pod_status_condition=pod_ready_condition,
-            )
+            is_ready = poll_rollout_status(deployment, condition=condition)
         except ApiException as e:
             logger.warning(f"Error fetching `{kind}`: `{e}`")
             await asyncio.sleep(polling_interval)
             continue
 
-        logger.info(f"Waiting: {target_desc} ready=`{ready}` total=`{total}`...")
+        logger.info(f"Waiting for {kind} `{name}`...")
 
-        if condition(ready, total):
-            logger.info(f"{target_desc} is ready.")
-            return ready, total
+        if is_ready:
+            logger.info(f"{kind} `{name}` is ready")
+            return
 
         elapsed = time.time() - start_time
         if elapsed > timeout:
-            raise TimeoutError(f"Timeout waiting for: `{target_desc}`.")
+            raise TimeoutError(f"Timeout waiting for {kind} `{name}`.")
 
         await asyncio.sleep(polling_interval)
 
@@ -694,8 +701,8 @@ def get_pods_for_statefulset(name: str, namespace: str, api_client=None):
 
 
 def check_pod_condition(
-    pod: List[V1Pod], condition: Optional[Tuple[str, str] | Callable[[V1Pod], bool]] = None
-):
+    pod: V1Pod, condition: Optional[Tuple[str, str] | Callable[[V1Pod], bool]] = None
+) -> bool:
     if condition is None:
         condition = ("Ready", "True")
 
@@ -703,9 +710,9 @@ def check_pod_condition(
         conditions = pod.status.conditions or []
         key, value = condition
         if any(cond.type == key and cond.status == value for cond in conditions):
-            return 1
+            return True
         else:
-            return 0
+            return False
     else:
         return condition(pod)
 

--- a/src/deployments/experiments/base_experiment.py
+++ b/src/deployments/experiments/base_experiment.py
@@ -227,12 +227,7 @@ class BaseExperiment(ABC, BaseModel):
 
         if not dry_run:
             if wait_for_ready:
-                await wait_for_rollout(
-                    yaml_obj,
-                    api_client,
-                    timeout=timeout,
-                    pod_ready_condition=("Ready", "True"),
-                )
+                await wait_for_rollout(yaml_obj, api_client, timeout=timeout)
         self.log_event({"phase": "finished", **deployment_metadata})
 
         return yaml_obj

--- a/src/deployments/experiments/base_experiment.py
+++ b/src/deployments/experiments/base_experiment.py
@@ -228,12 +228,10 @@ class BaseExperiment(ABC, BaseModel):
         if not dry_run:
             if wait_for_ready:
                 await wait_for_rollout(
-                    yaml_obj["kind"],
-                    yaml_obj["metadata"]["name"],
-                    namespace,
-                    timeout,
+                    yaml_obj,
                     api_client,
-                    ("Ready", "True"),
+                    timeout=timeout,
+                    pod_ready_condition=("Ready", "True"),
                 )
         self.log_event({"phase": "finished", **deployment_metadata})
 

--- a/src/deployments/helm_deployment/nimlibp2p/experiments/regression/regression.py
+++ b/src/deployments/helm_deployment/nimlibp2p/experiments/regression/regression.py
@@ -128,7 +128,7 @@ class NimRegressionNodes(BaseExperiment, BaseModel):
         kubectl_apply(deploy, namespace=namespace)
         logger.info("Deployment applied. Waiting for rollout.")
 
-        await wait_for_rollout(deploy["kind"], deploy["metadata"]["name"], namespace, 3000)
+        await wait_for_rollout(deploy, api_client, timeout=3000)
         logger.info("Rollout successful.")
 
         logger.info(

--- a/src/deployments/helm_deployment/waku/experiments/regression/regression.py
+++ b/src/deployments/helm_deployment/waku/experiments/regression/regression.py
@@ -137,13 +137,10 @@ class WakuRegressionNodes(BaseExperiment, BaseModel):
 
         if not args.dry_run:
             await wait_for_rollout(
-                publisher["kind"],
-                publisher["metadata"]["name"],
-                publisher["metadata"]["namespace"],
-                20,
+                publisher,
                 api_client,
-                ("Ready", "True"),
-                # TODO [extend condition checks] lambda cond : cond.type == "Ready" and cond.status == "True"
+                timeout=20,
+                pod_ready_condition=("Ready", "True"),
             )
         self.log_event("publisher_deploy_finished")
 
@@ -152,13 +149,10 @@ class WakuRegressionNodes(BaseExperiment, BaseModel):
 
         if not args.dry_run:
             await wait_for_rollout(
-                publisher["kind"],
-                publisher["metadata"]["name"],
-                publisher["metadata"]["namespace"],
-                timeout,
+                publisher,
                 api_client,
-                ("Ready", "False"),
-                # TODO: consider state.reason == .completed
+                timeout=timeout,
+                pod_ready_condition=("Ready", "False"),
             )
         self.log_event("publisher_messages_finished")
         time.sleep(20)


### PR DESCRIPTION
* `pod_ready_condition` param allows custom logic in checking if a pod is ready

* `condition` param allows waiting for certain number or percentage of pods to be read for StatefulSet


This lets us wait for conditions like "75% of pods are ready", and more precisely define what it means for a pod to be ready.

Example of usage:
```
await self.deploy(api_client, stack, args, values_yaml, deployment=nodes, wait_for_ready=False)

def ready_condition(ready, total):
    return ready / total > 0.75

def pod_ready(pod: V1Pod):
    conditions = pod.status.conditions
    return all(
        any(condition.type == search_key and condition.status == search_value for condition in conditions)
        for search_key, search_value in [
            ("ContainersReady", "True"),
            ("Ready", "True"),
        ]
    )

await wait_for_rollout(nodes, api_client, timeout=3000, pod_ready_condition=pod_ready, condition=ready_condition)
```