### PR TITLE
BaseExperiment: Moved run params into fields

### DIFF
--- a/deployment.py
+++ b/deployment.py
@@ -2,8 +2,6 @@
 import argparse
 import asyncio
 import logging
-import random
-from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
@@ -35,27 +33,18 @@ async def run_experiment(
     except TypeError:
         # values_path is None.
         values_yaml = None
+    if values_yaml is None:
+        values_yaml = {}
 
     info = experiment_registry[name]
-    experiment = info.cls()
+    experiment = info.cls(
+        api_client=api_client,
+        config=values_yaml,
+        namespace=args.namespace,
+        output_folder=args.out_folder,
+    )
     logger.info(f"Running experiment. name `{info.name}` file: `{info.metadata['module_path']}`")
-    await experiment.run(api_client, args, values_yaml)
-
-
-def setup_output_folder(args: argparse.Namespace) -> Path:
-    base_out_dir = Path(__file__).parent / "out"
-    if args.out_folder is not None:
-        out_dir = (
-            args.out_folder if args.out_folder.is_absolute() else base_out_dir / args.out_folder
-        )
-    else:
-        # Adding a random number helps distinguish experiments.
-        random_number = random.randint(1000, 9999)
-        datetime_str = datetime.now().strftime("%Y.%m.%d_%H.%M.%f")[:-3]
-        out_dir = base_out_dir / f"{datetime_str}_{random_number}"
-
-    out_dir.mkdir(parents=True, exist_ok=False)
-    return out_dir
+    await experiment.run()
 
 
 async def main():
@@ -104,10 +93,9 @@ async def main():
             raise AttributeError(f"{info}") from e
 
     args = parser.parse_args()
-    out_folder = setup_output_folder(args)
-    args.output_folder = out_folder
     verbosity = args.verbosity or 2
-    init_logger(logging.getLogger(), verbosity, out_folder / "out.log")
+    init_logger(logging.getLogger(), verbosity)
+
     try:
         await run_experiment(
             name=args.experiment,

--- a/deployment.py
+++ b/deployment.py
@@ -42,6 +42,8 @@ async def run_experiment(
         config=values_yaml,
         namespace=args.namespace,
         output_folder=args.out_folder,
+        skip_check=args.skip_check,
+        dry_run=args.dry_run,
     )
     logger.info(f"Running experiment. name `{info.name}` file: `{info.metadata['module_path']}`")
     await experiment.run()

--- a/src/analysis/mesh_analysis/readers/tracers/waku_tracer.py
+++ b/src/analysis/mesh_analysis/readers/tracers/waku_tracer.py
@@ -64,7 +64,7 @@ class WakuTracer(MessageTracer):
                     convert=self._trace_mixnet_in_logs,
                 ),
             ],
-            query="(sent relay message OR publishWithConn)",
+            query="sent relay message",
         )
         self.patterns.append(sent_pattern_group)
         return self

--- a/src/analysis/mesh_analysis/readers/tracers/waku_tracer.py
+++ b/src/analysis/mesh_analysis/readers/tracers/waku_tracer.py
@@ -64,7 +64,7 @@ class WakuTracer(MessageTracer):
                     convert=self._trace_mixnet_in_logs,
                 ),
             ],
-            query="sent relay message",
+            query="(sent relay message OR publishWithConn)",
         )
         self.patterns.append(sent_pattern_group)
         return self

--- a/src/deployments/experiments/base_experiment.py
+++ b/src/deployments/experiments/base_experiment.py
@@ -230,7 +230,7 @@ class BaseExperiment(ABC, BaseModel, Generic[TCfg]):
 
         if not dry_run:
             if wait_for_ready:
-                await wait_for_rollout(yaml_obj, self.api_client)
+                await wait_for_rollout(yaml_obj, self.api_client, timeout=timeout)
         self.log_event({"phase": "finished", **deployment_metadata})
 
         return yaml_obj
@@ -265,15 +265,6 @@ class BaseExperiment(ABC, BaseModel, Generic[TCfg]):
         out_path = Path(self.metadata_log_path)
         with open(out_path, "a") as out_file:
             out_file.write(json.dumps(self.metadata, default=str))
-
-    def _dump_initial_metadata(self):
-        self.log_metadata(
-            {
-                "experiment_name": self.__class__.name,
-                "experiment_class": self.__class__.__name__,
-                "dump": self.serialize(),
-            }
-        )
 
     def _setup_log_paths(self):
         base_out_dir = Path(__file__).parent / "out"

--- a/src/deployments/experiments/base_experiment.py
+++ b/src/deployments/experiments/base_experiment.py
@@ -2,14 +2,14 @@
 import json
 import logging
 import os
-import shutil
+import random
 from abc import ABC, abstractmethod
-from argparse import ArgumentParser, Namespace
+from argparse import ArgumentParser
 from collections import defaultdict
 from contextlib import ExitStack
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, List, Optional, Union
+from typing import Any, Generic, List, Optional, TypeVar, Union
 
 from kubernetes.client import (
     ApiClient,
@@ -22,11 +22,11 @@ from kubernetes.client import (
     V1Service,
     V1StatefulSet,
 )
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from ruamel import yaml
-from ruamel.yaml.comments import CommentedMap
 
 # Project Imports
+from src.analysis.utils.log_utils import log_to_path
 from src.deployments.core.base_bridge import BaseBridge
 from src.deployments.core.kube_utils import (
     dict_get,
@@ -55,7 +55,10 @@ V1Deployable = Union[
 logger = logging.getLogger(__name__)
 
 
-class BaseExperiment(ABC, BaseModel):
+TCfg = TypeVar("TCfg", bound=BaseModel)
+
+
+class BaseExperiment(ABC, BaseModel, Generic[TCfg]):
     """Base experiment that add an ExitStack with `workdir` to `run` and uses an internal `_run`.
 
     How to use:
@@ -64,23 +67,36 @@ class BaseExperiment(ABC, BaseModel):
         - Implement `_run` in the child class.
     """
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    out_log_path: Path = Field(default=Path("out.log"))
     events_log_path: Path = Field(default=Path("events.log"))
     metadata_log_path: Path = Field(default=Path("metadata.json"))
 
-    deployed: dict[str, list] = defaultdict(list)
+    api_client: ApiClient = Field(exclude=True)
+    dry_run: bool = False
+    """If True, does not actually deploy kubernetes configs but runs kubectl apply --dry-run instead."""
+    skip_check: bool = False
+    """If present, does not wait until the namespace is empty before running the test."""
+    output_folder: Optional[Path] = None
+    """Base output folder for experiment."""
+    namespace: Optional[str] = None
+
+    config: TCfg
+
+    metadata: Optional[dict] = None
+
+    _deployed: dict[str, list] = defaultdict(list)
     """Dict of [namespace : yamls] for every yaml deployed with self.deploy.
 
     Used to determine whether or not to call `_wait_until_clear`."""
 
+    _workdir: Optional[Path] = None
+    """Path to deployment output folder. Based off of self.output_folder"""
+    _stack: Optional[ExitStack]
+
     @staticmethod
     def add_args(subparser: ArgumentParser):
-        subparser.add_argument(
-            "--workdir",
-            type=str,
-            required=False,
-            default=None,
-            help="Folder to use for generating the deployment files.",
-        )
         subparser.add_argument(
             "--skip-check",
             action="store_true",
@@ -102,10 +118,10 @@ class BaseExperiment(ABC, BaseModel):
             help="The namespace for deployments.",
         )
 
-    def build(self, values_yaml, workdir, service: str, *, extra_values_paths=None):
+    def build(self, values_yaml, service: str, *, extra_values_paths=None):
         yaml_obj = build_deployment(
             deployment_dir=Path(os.path.dirname(__file__)) / ".." / "helm_deployment" / service,
-            workdir=os.path.join(workdir, service),
+            workdir=os.path.join(self._workdir, service),
             cli_values=values_yaml,
             name=service,
             extra_values_names=[],
@@ -121,16 +137,11 @@ class BaseExperiment(ABC, BaseModel):
 
         return yaml_obj
 
-    # TODO: store api_client, stack, and (experiment) args in self and remove as function params.
     async def deploy(
         self,
-        api_client: ApiClient,
-        stack,
-        args: Namespace,
-        values_yaml,
         *,
+        values_yaml: Optional[object] = None,
         service: Optional[str] = None,
-        workdir: Optional[str] = None,
         deployment: Optional[yaml.YAMLObject | V1Deployable] = None,
         wait_for_ready: bool = True,
         extra_values_paths: List[str] = None,
@@ -142,25 +153,22 @@ class BaseExperiment(ABC, BaseModel):
                 return all(given(val) for val in var)
             return var is not None
 
-        if given(deployment) == (given(service) and given(workdir)):
+        if given(deployment) == (given(service)):
             raise ValueError(
-                "Invalid arguments. Pass one of the following: `deployment`, xor (`service` and `workdir`)."
+                "Invalid arguments. Pass one of the following: `deployment`, xor `service`."
             )
 
         if isinstance(deployment, V1Deployable):
-            deployment = api_client.sanitize_for_serialization(deployment)
+            deployment = self.api_client.sanitize_for_serialization(deployment)
 
         yaml_obj = (
             deployment
             if deployment is not None
-            else self.build(values_yaml, workdir, service, extra_values_paths=extra_values_paths)
+            else self.build(values_yaml, service, extra_values_paths=extra_values_paths)
         )
 
         await self.deploy_yaml(
-            api_client,
-            stack,
-            args,
-            values_yaml,
+            values_yaml=values_yaml,
             deployment_yaml=yaml_obj,
             wait_for_ready=wait_for_ready,
             extra_values_paths=extra_values_paths,
@@ -170,13 +178,9 @@ class BaseExperiment(ABC, BaseModel):
 
     async def deploy_yaml(
         self,
-        api_client: ApiClient,
-        stack,
-        args: Namespace,
-        values_yaml,
         *,
+        values_yaml: Optional[str] = None,
         service: Optional[str] = None,
-        workdir: Optional[str] = None,
         deployment_yaml: Optional[yaml.YAMLObject] = None,
         wait_for_ready: bool = True,
         extra_values_paths: List[str] = None,
@@ -186,30 +190,29 @@ class BaseExperiment(ABC, BaseModel):
         yaml_obj = (
             deployment_yaml
             if deployment_yaml is not None
-            else self.build(values_yaml, workdir, service, extra_values_paths=extra_values_paths)
+            else self.build(values_yaml, service, extra_values_paths=extra_values_paths)
         )
 
         try:
-            dry_run = args.dry_run
+            dry_run = self.dry_run
         except AttributeError:
             dry_run = False
 
         namespace = yaml_obj["metadata"]["namespace"]
 
-        if len(self.deployed[namespace]) == 0:
+        if len(self._deployed[namespace]) == 0:
             self._wait_until_clear(
-                api_client=api_client,
                 namespace=namespace,
-                skip_check=args.skip_check,
+                skip_check=self.skip_check,
             )
 
         if not dry_run:
             cleanup = get_cleanup(
-                api_client=api_client,
+                api_client=self.api_client,
                 namespace=namespace,
                 deployments=[yaml_obj],
             )
-            stack.callback(cleanup)
+            self._stack.callback(cleanup)
 
         deployment_metadata = {
             "event": "deployment",
@@ -222,12 +225,12 @@ class BaseExperiment(ABC, BaseModel):
             deployment_metadata["replicas"] = yaml_obj["spec"]["replicas"]
 
         self.log_event({"phase": "start", **deployment_metadata})
-        self.deployed[namespace].append(yaml_obj)
+        self._deployed[namespace].append(yaml_obj)
         kubectl_apply(yaml_obj, namespace=namespace, dry_run=dry_run, exist_ok=exist_ok)
 
         if not dry_run:
             if wait_for_ready:
-                await wait_for_rollout(yaml_obj, api_client, timeout=timeout)
+                await wait_for_rollout(yaml_obj, self.api_client)
         self.log_event({"phase": "finished", **deployment_metadata})
 
         return yaml_obj
@@ -242,8 +245,8 @@ class BaseExperiment(ABC, BaseModel):
                 )
             return Path(out_dir) / path
 
-    def dump_yaml(self, obj, workdir: str, name: str):
-        out_path = Path(workdir) / f"{name}.yaml"
+    def dump_yaml(self, obj, name: str):
+        out_path = Path(self._workdir) / f"{name}.yaml"
         os.makedirs(out_path.parent, exist_ok=True)
         logger.info(f"dumping deployment `{name}` to `{out_path}`")
         with open(out_path, "w") as out_file:
@@ -257,77 +260,77 @@ class BaseExperiment(ABC, BaseModel):
         self.log_event({**{"event": "metadata"}, **metadata})
 
     def _dump_metadata(self):
-        metadata = self._get_metadata()
-        self.log_metadata(metadata)
+        self.metadata = self._get_metadata()
+        self.log_metadata(self.metadata)
         out_path = Path(self.metadata_log_path)
         with open(out_path, "a") as out_file:
-            out_file.write(json.dumps(metadata, default=str))
+            out_file.write(json.dumps(self.metadata, default=str))
 
-    async def run(
-        self,
-        api_client: ApiClient,
-        args: Namespace,
-        values_yaml: Optional[yaml.YAMLObject],
-    ):
-        if values_yaml is None:
-            values_yaml = CommentedMap()
+    def _dump_initial_metadata(self):
+        self.log_metadata(
+            {
+                "experiment_name": self.__class__.name,
+                "experiment_class": self.__class__.__name__,
+                "dump": self.serialize(),
+            }
+        )
 
-        self.deployed.clear()
+    def _setup_log_paths(self):
+        base_out_dir = Path(__file__).parent / "out"
+        if self.output_folder is None:
+            # Adding a random number helps distinguish experiments.
+            random_number = random.randint(1000, 9999)
+            datetime_str = datetime.now().strftime("%Y.%m.%d_%H.%M.%f")[:-3]
+            self.output_folder = base_out_dir / f"{datetime_str}_{random_number}"
+        elif not self.output_folder.is_absolute():
+            self.output_folder = base_out_dir / self.output_folder
 
-        workdir = args.output_folder
-        if args.workdir:
-            workdir = os.path.join(workdir, args.workdir)
+        self._workdir = self.output_folder / "deployment_yamls"
+        self.out_log_path = self._get_out_path(self.out_log_path, self.output_folder)
+        self.events_log_path = self._get_out_path(self.events_log_path, self.output_folder)
+        self.metadata_log_path = self._get_out_path(self.metadata_log_path, self.output_folder)
 
-        with ExitStack() as stack:
-            stack.callback(lambda: self.log_event("cleanup_finished"))
-            os.makedirs(workdir, exist_ok=True)
-            self.events_log_path = self._get_out_path(self.events_log_path, args.output_folder)
-            self.metadata_log_path = self._get_out_path(self.metadata_log_path, args.output_folder)
-            logger.info(f"Events path: `{self.events_log_path}`")
-            logger.info(f"Metadata path: `{self.metadata_log_path}`")
-            self.log_event(
-                {
-                    "event": "metadata",
-                    "experiment_name": self.__class__.name,
-                    "experiment_class": self.__class__.__name__,
-                    "args": vars(args),
-                }
-            )
-            if args.values_path:
-                shutil.copy(args.values_path, os.path.join(workdir, "cli_values.yaml"))
-            await self._run(
-                api_client=api_client,
-                workdir=workdir,
-                args=args,
-                values_yaml=values_yaml,
-                stack=stack,
-            )
-            stack.callback(lambda: self.log_event("cleanup_start"))
+        for path in [self.output_folder, self._workdir]:
+            path.mkdir(parents=True, exist_ok=True)
+        for path in [self.out_log_path, self.events_log_path, self.metadata_log_path]:
+            path.parent.mkdir(parents=True, exist_ok=True)
+
+    async def run(self):
+        self._deployed.clear()
+        self._setup_log_paths()
+        self.log_event(
+            {
+                "event": "metadata",
+                "experiment_name": self.__class__.name,
+                "experiment_class": self.__class__.__name__,
+                "args": vars(self.config),
+            }
+        )
+
+        with log_to_path(self.out_log_path):
+            with ExitStack() as self._stack:
+                self._stack.callback(lambda: self.log_event("cleanup_finished"))
+                self.log_metadata({"params": vars(self.config)})
+                await self._run()
+                self._stack.callback(lambda: self.log_event("cleanup_start"))
+            self._stack = None
 
         self.log_event("run_finished")
         self._dump_metadata()
 
     @abstractmethod
-    async def _run(
-        self,
-        # TODO [move things into class]: move all into class so they can be accessed more easily and set before calling run?
-        api_client: ApiClient,
-        workdir: str,
-        args: Namespace,
-        values_yaml: Optional[yaml.YAMLObject],
-        stack: ExitStack,
-    ):
+    async def _run(self):
         pass
 
-    def _wait_until_clear(self, api_client: ApiClient, namespace: str, skip_check: bool):
+    def _wait_until_clear(self, namespace: str, skip_check: bool):
         # Wait for namespace to be clear unless --skip-check flag was used.
         if not skip_check:
             self.log_event("wait_for_clear_start")
-            wait_for_no_objs_in_namespace(namespace=namespace, api_client=api_client)
+            wait_for_no_objs_in_namespace(namespace=namespace, api_client=self.api_client)
             self.log_event("wait_for_clear_finished")
         else:
             namepace_is_empty = poll_namespace_has_objects(
-                namespace=namespace, api_client=api_client
+                namespace=namespace, api_client=self.api_client
             )
             if not namepace_is_empty:
                 logger.warning(f"Namespace is not empty! Namespace: `{namespace}`")

--- a/src/deployments/experiments/libp2p/kad_dht.py
+++ b/src/deployments/experiments/libp2p/kad_dht.py
@@ -1,10 +1,7 @@
 import asyncio
 import logging
-from argparse import Namespace
-from contextlib import ExitStack
-from typing import Optional
 
-from kubernetes.client import ApiClient, V1HTTPGetAction, V1Probe, V1ServicePort
+from kubernetes.client import V1HTTPGetAction, V1Probe, V1ServicePort
 from pydantic import BaseModel, ConfigDict, NonNegativeFloat, NonNegativeInt
 
 from src.deployments.core.builders import ServiceBuilder
@@ -16,8 +13,18 @@ from src.deployments.registry import experiment
 logger = logging.getLogger(__name__)
 
 
+class ExpConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    num_nodes: NonNegativeInt = 80
+    warmup_delay: NonNegativeFloat = 0
+    probe_delay: NonNegativeFloat = 60
+    image_repo: str = "radiken/dst-test-node-kad-dht"
+    image_tag: str = "melodie-fix"
+
+
 @experiment(name="kad-dht")
-class KadDHTExperiment(BaseExperiment, BaseModel):
+class KadDHTExperiment(BaseExperiment[ExpConfig]):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @classmethod
@@ -26,30 +33,12 @@ class KadDHTExperiment(BaseExperiment, BaseModel):
         BaseExperiment.add_args(subparser)
         subparser.set_defaults(namespace="nimlibp2p")
 
-    class ExpConfig(BaseModel):
-        model_config = ConfigDict(extra="ignore")
-
-        num_nodes: NonNegativeInt = 80
-        warmup_delay: NonNegativeFloat = 0
-        probe_delay: NonNegativeFloat = 60
-        image_repo: str = "radiken/dst-test-node-kad-dht"
-        image_tag: str = "melodie-fix"
-
-    async def _run(
-        self,
-        api_client: ApiClient,
-        workdir: str,
-        args: Namespace,
-        values_yaml: Optional[dict],
-        stack: ExitStack,
-    ):
+    async def _run(self):
         self.log_event("run_start")
 
-        values_yaml = values_yaml or {}
-        config = self.ExpConfig(**values_yaml)
-        self.log_metadata({"params": vars(config)})
-        namespace = args.namespace
-        image = Image(repo=config.image_repo, tag=config.image_tag)
+        self.log_metadata({"params": vars(self.config)})
+        namespace = self.namespace
+        image = Image(repo=self.config.image_repo, tag=self.config.image_tag)
 
         # 1. Build and Deploy Headless Bootstrap Service
         bootstrap_service = (
@@ -62,8 +51,8 @@ class KadDHTExperiment(BaseExperiment, BaseModel):
             .with_port(V1ServicePort(name="p2p", port=5000, target_port=5000))
             .build()
         )
-        self.dump_yaml(bootstrap_service, workdir, "bootstrap-service")
-        await self.deploy(api_client, stack, args, values_yaml, deployment=bootstrap_service)
+        self.dump_yaml(bootstrap_service, "bootstrap-service")
+        await self.deploy(deployment=bootstrap_service)
 
         # 2. Build and Deploy Bootstrap Node
         bootstrap_nodes = (
@@ -83,15 +72,13 @@ class KadDHTExperiment(BaseExperiment, BaseModel):
             )
             .build()
         )
-        self.dump_yaml(bootstrap_nodes, workdir, "bootstrap")
-        await self.deploy(
-            api_client, stack, args, values_yaml, deployment=bootstrap_nodes, wait_for_ready=True
-        )
+        self.dump_yaml(bootstrap_nodes, "bootstrap")
+        await self.deploy(deployment=bootstrap_nodes, wait_for_ready=True)
 
         # 3. Build and Deploy Regular Nodes
         nodes = (
             Libp2pStatefulSetBuilder()
-            .with_libp2p_config(name="nodes", namespace=namespace, num_nodes=config.num_nodes)
+            .with_libp2p_config(name="nodes", namespace=namespace, num_nodes=self.config.num_nodes)
             .with_image(image)
             .with_label("role", "nodes")
             .with_option("NODE_ROLE", "RoleNormal")
@@ -107,15 +94,13 @@ class KadDHTExperiment(BaseExperiment, BaseModel):
             )
             .build()
         )
-        self.dump_yaml(nodes, workdir, "nodes")
-        await self.deploy(
-            api_client, stack, args, values_yaml, deployment=nodes, wait_for_ready=True
-        )
+        self.dump_yaml(nodes, "nodes")
+        await self.deploy(deployment=nodes, wait_for_ready=True)
 
         # 4. Wait for Warmup
-        if config.warmup_delay > 0:
-            logger.info(f"Waiting {config.warmup_delay} seconds for DHT warmup...")
-            await asyncio.sleep(config.warmup_delay)
+        if self.config.warmup_delay > 0:
+            logger.info(f"Waiting {self.config.warmup_delay} seconds for DHT warmup...")
+            await asyncio.sleep(self.config.warmup_delay)
 
         # 5. Build and Deploy Probe
         probe = (
@@ -129,14 +114,14 @@ class KadDHTExperiment(BaseExperiment, BaseModel):
             .with_option("SERVICE", f"bootstrap.{namespace}.svc.cluster.local")
             .build()
         )
-        self.dump_yaml(probe, workdir, "probe")
-        await self.deploy(
-            api_client, stack, args, values_yaml, deployment=probe, wait_for_ready=True
-        )
+        self.dump_yaml(probe, "probe")
+        await self.deploy(deployment=probe, wait_for_ready=True)
 
         # 6. Wait for Probe Execution
-        if config.probe_delay > 0:
-            logger.info(f"Waiting {config.probe_delay} seconds for probe to execute lookups...")
-            await asyncio.sleep(config.probe_delay)
+        if self.config.probe_delay > 0:
+            logger.info(
+                f"Waiting {self.config.probe_delay} seconds for probe to execute lookups..."
+            )
+            await asyncio.sleep(self.config.probe_delay)
 
         self.log_event("internal_run_finished")

--- a/src/deployments/experiments/libp2p/kad_dht.py
+++ b/src/deployments/experiments/libp2p/kad_dht.py
@@ -36,7 +36,6 @@ class KadDHTExperiment(BaseExperiment[ExpConfig]):
     async def _run(self):
         self.log_event("run_start")
 
-        self.log_metadata({"params": vars(self.config)})
         namespace = self.namespace
         image = Image(repo=self.config.image_repo, tag=self.config.image_tag)
 

--- a/src/deployments/experiments/libp2p/nimlibp2p.py
+++ b/src/deployments/experiments/libp2p/nimlibp2p.py
@@ -2,11 +2,9 @@ import asyncio
 import logging
 import random
 import traceback
-from argparse import Namespace
-from contextlib import ExitStack
-from typing import Literal, Optional
+from typing import Literal
 
-from kubernetes.client import ApiClient, V1StatefulSet
+from kubernetes.client import V1StatefulSet
 from pydantic import BaseModel, ConfigDict, NonNegativeFloat, NonNegativeInt
 
 from src.deployments.core.configs.container import Image
@@ -14,6 +12,7 @@ from src.deployments.experiments.base_experiment import BaseExperiment
 from src.deployments.libp2p.bridge import Bridge
 from src.deployments.libp2p.builders.builders import Libp2pStatefulSetBuilder
 from src.deployments.libp2p.builders.builders import Option as NimLibp2p
+from src.deployments.libp2p.builders.helpers import readiness_probe_metrics
 from src.deployments.pod_api_requester.builder import PodApiRequesterBuilder
 from src.deployments.pod_api_requester.configs import Target
 from src.deployments.pod_api_requester.nimlibp2p import libp2p_dst_node_publish
@@ -52,6 +51,7 @@ def build_nodes(
         .with_option(NimLibp2p.muxer, params.muxer)
         .with_option(NimLibp2p.connect_to, params.connect_to)
         .with_option(NimLibp2p.cold_start_delay, params.node_start_delay)
+        .with_readiness_probe(readiness_probe_metrics())
         .with_image(params.image)
     )
     if params.network_delay or params.network_jitter:
@@ -80,7 +80,7 @@ async def publish(config, namespace, random_name):
 
 
 @experiment(name="nimlibp2p")
-class NimLibp2pExperiment(BaseExperiment, BaseModel):
+class NimLibp2pExperiment(BaseExperiment[ExpConfig]):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @classmethod
@@ -91,53 +91,38 @@ class NimLibp2pExperiment(BaseExperiment, BaseModel):
     def _get_metadata(self) -> dict:
         return Bridge().get_metadata(self.events_log_path)
 
-    async def _run(
-        self,
-        api_client: ApiClient,
-        workdir: str,
-        args: Namespace,
-        values_yaml: Optional[dict],
-        stack: ExitStack,
-    ):
+    async def _run(self):
         self.log_event("run_start")
-
-        config = ExpConfig(**values_yaml)
-
-        self.log_metadata({"params": vars(config)})
 
         # Publisher
         publisher = (
-            PodApiRequesterBuilder().with_namespace(args.namespace).with_mode("server").build()
+            PodApiRequesterBuilder().with_namespace(self.namespace).with_mode("server").build()
         )
-        await self.deploy(
-            api_client, stack, args, values_yaml, deployment=publisher, wait_for_ready=True
-        )
+        await self.deploy(deployment=publisher, wait_for_ready=True)
 
         # Nodes
         nodes = build_nodes(
-            args.namespace,
-            config,
+            namespace=self.namespace,
+            params=self.config,
         )
         name = nodes.metadata.name
         namespace = nodes.metadata.namespace
 
-        self.dump_yaml(nodes, workdir, name)
-        await self.deploy(api_client, stack, args, values_yaml, deployment=nodes)
-        logger.info(f"Waiting for cold_start_delay: {config.delay_cold_start}")
+        await self.deploy(deployment=nodes)
 
-        await asyncio.sleep(config.delay_cold_start)
+        await asyncio.sleep(self.config.delay_cold_start)
 
         logger.info(f"Starting publish loop for nodes in `{name}`")
 
         self.log_event("start_messages")
 
         tasks = []
-        for msg_index in range(config.num_messages):
-            index = random.randint(0, config.num_nodes - 1)
+        for msg_index in range(self.config.num_messages):
+            index = random.randint(0, self.config.num_nodes - 1)
             random_name = f"{name}-{index}"
             self.log_event({"event": "publish", "node": random_name, "index": msg_index})
-            tasks.append(asyncio.create_task(publish(config, namespace, random_name)))
-            await asyncio.sleep(config.delay_after_publish)
+            tasks.append(asyncio.create_task(publish(self.config, namespace, random_name)))
+            await asyncio.sleep(self.config.delay_after_publish)
         await asyncio.gather(*tasks)
 
         self.log_event("publisher_messages_finished")

--- a/src/deployments/experiments/waku.py
+++ b/src/deployments/experiments/waku.py
@@ -96,7 +96,6 @@ class WakuExperiment(BaseExperiment[ExpConfig]):
     async def _run(self):
         self.log_event("run_start")
 
-        self.log_metadata({"params": vars(self.config)})
 
         # Publisher
         publisher = (

--- a/src/deployments/experiments/waku.py
+++ b/src/deployments/experiments/waku.py
@@ -1,19 +1,13 @@
 import asyncio
 import logging
-import os
 import random
 import traceback
-from argparse import Namespace
-from contextlib import ExitStack
-from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict
 
 from kubernetes import client
-from kubernetes.client import ApiClient
 from pydantic import BaseModel, ConfigDict, NonNegativeFloat, NonNegativeInt
 
 from src.deployments.core.configs.statefulset import StatefulSetConfig
-from src.deployments.core.kube_utils import get_YAML
 from src.deployments.experiments.base_experiment import BaseExperiment
 from src.deployments.libp2p.builders.nodes import Nodes
 from src.deployments.pod_api_requester.builder import PodApiRequesterBuilder
@@ -73,8 +67,18 @@ def build_store_nodes(namespace: str) -> dict:
     return api_client.sanitize_for_serialization(deployment)
 
 
+class ExpConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    num_messages: NonNegativeInt = 20
+    num_nodes: NonNegativeInt = 20
+    num_bootstrap_nodes: NonNegativeInt = 5
+    delay_cold_start: NonNegativeFloat = 1
+    delay_after_publish: NonNegativeFloat = 0.5
+
+
 @experiment(name="waku")
-class WakuExperiment(BaseExperiment, BaseModel):
+class WakuExperiment(BaseExperiment[ExpConfig]):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @classmethod
@@ -89,63 +93,38 @@ class WakuExperiment(BaseExperiment, BaseModel):
         logger.info(event)
         return super().log_event(event)
 
-    class ExpConfig(BaseModel):
-        model_config = ConfigDict(extra="ignore")
-
-        num_messages: NonNegativeInt = 20
-        num_nodes: NonNegativeInt = 20
-        num_bootstrap_nodes: NonNegativeInt = 5
-        delay_cold_start: NonNegativeFloat = 1
-        delay_after_publish: NonNegativeFloat = 0.5
-
-    async def _run(
-        self,
-        api_client: ApiClient,
-        workdir: str,
-        args: Namespace,
-        values_yaml: Optional[dict],
-        stack: ExitStack,
-    ):
+    async def _run(self):
         self.log_event("run_start")
 
-        config = self.ExpConfig(**values_yaml)
-        self.log_metadata({"params": vars(config)})
+        self.log_metadata({"params": vars(self.config)})
 
         # Publisher
         publisher = (
             PodApiRequesterBuilder()
-            .with_namespace(args.namespace)
+            .with_namespace(self.namespace)
             .with_mode("server")
             # .with_debug()
             # .with_image(Image(repo="pearsonwhite/pod-api-requester", tag="9497aebc1483572b5bd4a4712bfcb76a63d04cf8"))
             .build()
         )
 
-        await self.deploy(
-            api_client, stack, args, values_yaml, deployment=publisher, wait_for_ready=True
-        )
+        await self.deploy(deployment=publisher, wait_for_ready=True)
 
         # Nodes
-        deployments = build_nodes(args.namespace, config.num_nodes, config.num_bootstrap_nodes)
-        nodes = deployments["nodes"]
-        bootstrap = deployments["bootstrap"]
+        deployments = build_nodes(
+            self.namespace, self.config.num_nodes, self.config.num_bootstrap_nodes
+        )
         for deployment in deployments.values():
-            name = deployment["metadata"]["name"]
-            out_path = Path(workdir) / name / f"{name}.yaml"
-            os.makedirs(out_path.parent, exist_ok=True)
-            logger.info(f"dumping deployment `{name}` to `{out_path}`")
-            with open(out_path, "w") as out_file:
-                yaml = get_YAML()
-                yaml.dump(deployment, out_file)
-            await self.deploy(api_client, stack, args, values_yaml, deployment=deployment)
+            await self.deploy(deployment=deployment)
 
-        await asyncio.sleep(config.delay_cold_start)
+        await asyncio.sleep(self.config.delay_cold_start)
+        nodes = deployments["nodes"]
         num_nodes = nodes["spec"]["replicas"]
         name = nodes["metadata"]["name"]
         namespace = nodes["metadata"]["namespace"]
         logger.info(f"Starting disconnect+publish loop for nodes in `{name}`")
         self.log_event("start_messages")
-        for _ in range(0, config.num_messages):
+        for _ in range(0, self.config.num_messages):
             index = random.randint(0, num_nodes - 1)
             random_name = f"{name}-{index}"
             self.log_event({"event": "publish", "node": random_name})
@@ -164,7 +143,7 @@ class WakuExperiment(BaseExperiment, BaseModel):
             except Exception as e:
                 logger.error(f"Other exception: {e} {traceback.format_exc()}")
 
-            await asyncio.sleep(config.delay_after_publish)
+            await asyncio.sleep(self.config.delay_after_publish)
 
         self.log_event("publisher_messages_finished")
 

--- a/src/deployments/experiments/waku.py
+++ b/src/deployments/experiments/waku.py
@@ -96,7 +96,6 @@ class WakuExperiment(BaseExperiment[ExpConfig]):
     async def _run(self):
         self.log_event("run_start")
 
-
         # Publisher
         publisher = (
             PodApiRequesterBuilder()

--- a/src/deployments/libp2p/builders/nodes.py
+++ b/src/deployments/libp2p/builders/nodes.py
@@ -5,7 +5,7 @@ from kubernetes.client import V1ContainerPort, V1PodDNSConfig, V1ResourceRequire
 from src.deployments.core.configs.container import ContainerConfig, Image
 from src.deployments.core.configs.pod import PodSpecConfig, PodTemplateSpecConfig
 from src.deployments.core.configs.statefulset import StatefulSetConfig, StatefulSetSpecConfig
-from src.deployments.libp2p.builders.helpers import LIBP2P_CONTAINER_NAME, readiness_probe_metrics
+from src.deployments.libp2p.builders.helpers import LIBP2P_CONTAINER_NAME
 
 
 class Nodes:
@@ -30,7 +30,6 @@ class Nodes:
         ]
 
         config.with_resources(Nodes.create_resources())
-        config.with_readiness_probe(readiness_probe_metrics())
 
         return config
 


### PR DESCRIPTION
* Move api_client, ExitStack, args (skip-check, etc.), to BaseExperiment fields

* Add namespace and config as default BaseExperiment field

* Derive workdir from output_folder

* Setup values_yaml and experiment config outside of run

* Setup output paths inside of BaseExperiment class

* Move metrics readiness probe out of default nimlibp2p node builder
