### PR TITLE
Emit wait_for_clear_finished even when --skip-check is used

### DIFF
--- a/src/deployments/experiments/base_experiment.py
+++ b/src/deployments/experiments/base_experiment.py
@@ -318,13 +318,13 @@ class BaseExperiment(ABC, BaseModel, Generic[TCfg]):
         if not skip_check:
             self.log_event("wait_for_clear_start")
             wait_for_no_objs_in_namespace(namespace=namespace, api_client=self.api_client)
-            self.log_event("wait_for_clear_finished")
         else:
             namepace_is_empty = poll_namespace_has_objects(
                 namespace=namespace, api_client=self.api_client
             )
             if not namepace_is_empty:
                 logger.warning(f"Namespace is not empty! Namespace: `{namespace}`")
+        self.log_event("wait_for_clear_finished")
 
     def _preprocess_event(self, event: Any) -> Any:
         if isinstance(event, str):


### PR DESCRIPTION
## Summary

Running an experiment with `--skip-check` crashes in `_get_metadata` with `KeyError: 'start'` *after* the run (and cleanup) have already finished. The metadata bridge builds the `complete` interval's start from the `wait_for_clear_finished` event, but `_wait_until_clear` only logged that event in the non-skip branch — so with `--skip-check` the event is never recorded and `events["complete"]["start"]` blows up.

Fix: emit `wait_for_clear_finished` in both branches so metadata generation works regardless of the flag. This affects any nimlibp2p `--skip-check` run.