### PR TITLE
CI: pin uv version in setup-uv to avoid flaky latest-version lookup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.10.9"
 
       - run: uv sync --frozen
 


### PR DESCRIPTION
## Summary

The lint job intermittently fails during setup, not in any linter. `astral-sh/setup-uv@v6` is unpinned, so it resolves the latest uv release through the GitHub API on every run:

```
Getting latest version from GitHub API...
##[error]Github API request failed while getting latest release. Check the GitHub status page for outages. Try again later.
```

When that API call fails (rate limit / transient outage) the job aborts after a few seconds, before autoflake/isort/black ever run.

Fix: pin `version: "0.10.9"` (matches the version used locally) so setup-uv downloads it directly and no longer depends on the latest-release lookup.
