### PR TITLE
Shadow: auto-fired post-run analysis (metrics + message reliability)

### DIFF
--- a/src/analysis/metrics/scrapper.py
+++ b/src/analysis/metrics/scrapper.py
@@ -16,10 +16,10 @@ class Scrapper(BaseModel):
     _config: ScrapeConfig
     _k8s: object
 
-    def __init__(self, kube_config: str, config: ScrapeConfig):
+    def __init__(self, kube_config: Optional[str] = None, config: ScrapeConfig = None):
         self._url = config.url
         self._config = config
-        self._k8s = kubernetes_manager.KubernetesManager(kube_config)
+        self._k8s = kubernetes_manager.KubernetesManager(kube_config) if kube_config else None
 
     def query_and_dump_metrics(self):
         # https://github.com/kubernetes-client/python/blob/master/examples/pod_portforward.py

--- a/src/analysis/metrics/shadow_metrics.py
+++ b/src/analysis/metrics/shadow_metrics.py
@@ -1,0 +1,216 @@
+# Load a Shadow run's per-peer /metrics dumps into a throwaway VictoriaMetrics so the
+# existing PromQL analysis (Scrapper) queries it like a k8s run. Shadow isn't scraped
+# live, so storeMetrics appends timestamp-less snapshots we re-time on import.
+import argparse
+import logging
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional
+
+import requests
+
+from src.analysis.metrics.libp2p.scrape import Nimlibp2pScrapeBuilder
+from src.analysis.metrics.scrapper import Scrapper
+
+logger = logging.getLogger(__name__)
+
+# A /metrics dump starts with this line; we split concatenated snapshots on it.
+_SNAPSHOT_BOUNDARY = "# HELP process_info"
+
+
+def iter_snapshots(text: str) -> List[str]:
+    """Split a concatenated metrics file into individual /metrics snapshots."""
+    chunks: List[str] = []
+    current: List[str] = []
+    for line in text.splitlines(keepends=True):
+        if line.startswith(_SNAPSHOT_BOUNDARY) and current:
+            chunks.append("".join(current))
+            current = [line]
+        else:
+            current.append(line)
+    if current:
+        chunks.append("".join(current))
+    return [c for c in chunks if _SNAPSHOT_BOUNDARY in c]
+
+
+def hosts_dir_for_run(run_dir: Path) -> Path:
+    """Path to the per-host output inside a pulled Shadow run folder."""
+    return run_dir / "shadow_logs" / "shadow_data" / "shadow.data" / "hosts"
+
+
+class EphemeralVictoriaMetrics:
+    """Throwaway dockerized VictoriaMetrics; context manager, removed on exit. `.url`
+    is the base URL to point a Scrapper / PromQL query at."""
+
+    def __init__(
+        self,
+        *,
+        image: str = "victoriametrics/victoria-metrics:v1.103.0",
+        host_port: int = 8428,
+        ready_timeout_s: int = 60,
+    ):
+        self._image = image
+        self._port = host_port
+        self._ready_timeout_s = ready_timeout_s
+        self._name = f"shadow-vm-{int(time.time())}"
+        self.url = f"http://localhost:{host_port}"
+
+    def __enter__(self) -> "EphemeralVictoriaMetrics":
+        logger.info(f"Starting ephemeral VictoriaMetrics ({self._image}) as `{self._name}`")
+        subprocess.run(
+            [
+                "docker",
+                "run",
+                "-d",
+                "--rm",
+                "--name",
+                self._name,
+                "-p",
+                f"{self._port}:8428",
+                self._image,
+            ],
+            check=True,
+            capture_output=True,
+        )
+        self._wait_ready()
+        return self
+
+    def _wait_ready(self) -> None:
+        deadline = time.time() + self._ready_timeout_s
+        while time.time() < deadline:
+            try:
+                if requests.get(f"{self.url}/health", timeout=2).ok:
+                    logger.info(f"VictoriaMetrics ready at {self.url}")
+                    return
+            except requests.RequestException:
+                pass
+            time.sleep(1)
+        raise TimeoutError(f"VictoriaMetrics not ready within {self._ready_timeout_s}s")
+
+    def __exit__(self, *exc) -> None:
+        subprocess.run(["docker", "rm", "-f", self._name], capture_output=True)
+        logger.info(f"Removed ephemeral VictoriaMetrics `{self._name}`")
+
+
+def import_shadow_metrics(
+    *,
+    hosts_dir: Path,
+    vm_url: str,
+    namespace: str,
+    interval_s: int = 15,
+    start_epoch_s: Optional[int] = None,
+    job: str = "libp2p-nodes",
+    node: str = "shadow",
+) -> dict:
+    """Import each peer's snapshots into VM, re-timed by snapshot index x interval
+    (anchored near now if `start_epoch_s` is None) and tagged with the labels a k8s
+    scrape adds (pod/instance/job/node/namespace) so the existing PromQL reads them
+    unchanged."""
+    metric_files = sorted(hosts_dir.glob("*/metrics_*.txt"))
+    if not metric_files:
+        raise FileNotFoundError(f"No metrics_*.txt under {hosts_dir}")
+
+    per_peer = []
+    max_snaps = 0
+    for mf in metric_files:
+        peer = mf.stem.replace("metrics_", "")  # metrics_pod-1 -> pod-1
+        snaps = iter_snapshots(mf.read_text())
+        if snaps:
+            per_peer.append((peer, snaps))
+            max_snaps = max(max_snaps, len(snaps))
+
+    if start_epoch_s is None:
+        start_epoch_s = int(time.time()) - max_snaps * interval_s
+
+    posted = 0
+    last_epoch_s = start_epoch_s
+    for peer, snaps in per_peer:
+        labels = [
+            f"pod={peer}",
+            f"instance={peer}",
+            f"namespace={namespace}",
+            f"job={job}",
+            f"node={node}",
+        ]
+        for k, snap in enumerate(snaps):
+            epoch_s = start_epoch_s + k * interval_s
+            last_epoch_s = max(last_epoch_s, epoch_s)
+            resp = requests.post(
+                f"{vm_url}/api/v1/import/prometheus",
+                params={"timestamp": epoch_s * 1000, "extra_label": labels},
+                data=snap.encode(),
+                timeout=15,
+            )
+            resp.raise_for_status()
+            posted += 1
+
+    requests.get(f"{vm_url}/internal/force_flush", timeout=15)  # make the import queryable now
+    summary = {
+        "peers": len(per_peer),
+        "snapshots_posted": posted,
+        "start_epoch_s": start_epoch_s,
+        "last_epoch_s": last_epoch_s,
+    }
+    logger.info(f"Imported Shadow metrics: {summary}")
+    return summary
+
+
+def scrape_run_metrics(
+    *,
+    run_dir: Path,
+    namespace: str = "zerotesting-shadow",
+    interval_s: int = 15,
+    rate_interval: str = "60s",
+    step: str = "15s",
+) -> Path:
+    """Import a Shadow run into an ephemeral VM and run the existing `Scrapper` against
+    it, dumping the same per-metric CSVs as k8s under `<run_dir>/metrics/`."""
+    hosts = hosts_dir_for_run(run_dir)
+    dump_location = run_dir / "metrics"
+    with EphemeralVictoriaMetrics() as vm:
+        info = import_shadow_metrics(
+            hosts_dir=hosts, vm_url=vm.url, namespace=namespace, interval_s=interval_s
+        )
+        start_dt = datetime.fromtimestamp(info["start_epoch_s"], tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(info["last_epoch_s"], tz=timezone.utc)
+        config = (
+            Nimlibp2pScrapeBuilder(
+                namespace=namespace,
+                dump_location=dump_location,
+                rate_interval=rate_interval,
+                step=step,
+            )
+            .with_interval(start_dt, end_dt, run_dir.name)
+            .with_libp2p_metrics()
+            .build()
+        )
+        config.url = f"{vm.url}/api/v1/"
+        Scrapper(config=config).query_and_dump_metrics()
+    logger.info(f"Dumped Shadow metrics CSVs under {dump_location}/")
+    return dump_location
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(
+        description="Load a Shadow run's metrics into an ephemeral VM and report bandwidth."
+    )
+    parser.add_argument(
+        "run_dir", type=Path, help="Pulled Shadow run folder (contains shadow_logs/)."
+    )
+    parser.add_argument("--namespace", default="zerotesting-shadow")
+    parser.add_argument("--interval-s", type=int, default=15)
+    args = parser.parse_args()
+
+    dump_location = scrape_run_metrics(
+        run_dir=args.run_dir, namespace=args.namespace, interval_s=args.interval_s
+    )
+    print(f"Metrics CSVs written under {dump_location}/")
+    for csv in sorted(p for p in dump_location.rglob("*") if p.is_file()):
+        print(f"  {csv.relative_to(dump_location)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/deployments/experiments/libp2p/shadow_gossipsub.py
+++ b/src/deployments/experiments/libp2p/shadow_gossipsub.py
@@ -159,8 +159,11 @@ class ShadowGossipsubExperiment(BaseExperiment[ExpConfig]):
         if state == "failed":
             raise RuntimeError(f"Shadow Job `{namespace}/{job_name}` failed")
 
-        self._run_analysis()
         self.log_event("internal_run_finished")
+
+    async def run(self):
+        await super().run()
+        self._run_analysis()
 
     def _run_analysis(self) -> None:
         """Post-run analysis (best-effort; never fails the run): bandwidth CSVs via the

--- a/src/deployments/experiments/libp2p/shadow_gossipsub.py
+++ b/src/deployments/experiments/libp2p/shadow_gossipsub.py
@@ -6,6 +6,9 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, NonNegativeFloat, NonNegativeInt
 
+from src.analysis.mesh_analysis.analyzers.data_puller import DataPuller
+from src.analysis.mesh_analysis.analyzers.nimlibp2p_analyzer import Nimlibp2pAnalyzer
+from src.analysis.metrics.shadow_metrics import scrape_run_metrics
 from src.deployments.experiments.base_experiment import BaseExperiment
 from src.deployments.registry import experiment
 from src.deployments.shadow.builders import (
@@ -156,4 +159,33 @@ class ShadowGossipsubExperiment(BaseExperiment[ExpConfig]):
         if state == "failed":
             raise RuntimeError(f"Shadow Job `{namespace}/{job_name}` failed")
 
+        self._run_analysis()
         self.log_event("internal_run_finished")
+
+    def _run_analysis(self) -> None:
+        """Post-run analysis (best-effort; never fails the run): bandwidth CSVs via the
+        ephemeral-VM metrics path + message reliability from the flattened logs."""
+        cfg = self.config
+        run_dir = self.output_folder
+        try:
+            scrape_run_metrics(
+                run_dir=run_dir, namespace=self.namespace, interval_s=cfg.metrics_interval_s
+            )
+        except Exception as e:
+            logger.error(f"Shadow metrics analysis failed: {e}")
+        try:
+            puller = DataPuller().with_local(run_dir / "shadow_logs" / "logs")
+            (
+                Nimlibp2pAnalyzer(dump_analysis_dir=str(run_dir / "analysis_data"))
+                .with_data_puller(puller)
+                .with_ss_check(["pod"], [cfg.num_nodes])
+                .with_reliability_check(
+                    stateful_sets=["pod"],
+                    nodes_per_ss=[cfg.num_nodes],
+                    expected_num_peers=cfg.num_nodes,
+                    expected_num_messages=cfg.num_messages,
+                )
+                .run()
+            )
+        except Exception as e:
+            logger.error(f"Shadow message analysis failed: {e}")


### PR DESCRIPTION
Makes a Shadow run analyze itself like a k8s run, mirroring the connmanager experiment (deploy + analysis + plots in one `deployment.py` invocation, defined in the experiment).

**Depends on #276**

- `analysis/metrics/shadow_metrics.py`: split each peer's `/metrics` snapshots, import into a throwaway dockerized VictoriaMetrics (synthesized timestamps + k8s-style labels), run the existing `Scrapper` -> same per-metric CSVs.
- `shadow_gossipsub._run_analysis()`: fires after the run (best-effort, never fails it) -> bandwidth CSVs (above) + message reliability via `Nimlibp2pAnalyzer` on the flattened `logs/` (`FileStack`).
- `scrapper.py`: `kube_config` made optional (unused port-forward path).

Needs Docker locally for the ephemeral VM.