### PR TITLE
Fix poll_rollout_status returning a tuple for Deployments

### DIFF
--- a/src/deployments/core/kube_utils.py
+++ b/src/deployments/core/kube_utils.py
@@ -542,7 +542,7 @@ def poll_rollout_status(
         def default_condition(obj: V1Deployment):
             desired = obj.spec.replicas
             available = obj.status.available_replicas or 0
-            return available, desired
+            return available == desired
 
     elif kind == "statefulset":
 


### PR DESCRIPTION
`poll_rollout_status` returns `(available, desired)` instead of a bool. This shoud not be intended, now `wait_for_rollout` treated any deployment as ready immediately even at 0 available replicas. Fixing it to return `available == desired`.