### PR TITLE
Use pod-api-requester as the publisher for Shadow

### DIFF
--- a/src/deployments/experiments/libp2p/shadow_gossipsub.py
+++ b/src/deployments/experiments/libp2p/shadow_gossipsub.py
@@ -1,7 +1,6 @@
 # Shadow GossipSub experiment: N nim libp2p peers + 1 publisher inside Shadow on a
 # single k8s pod. See the "Using Shadow at DST" runbook in Notion.
 import logging
-from pathlib import Path
 from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, NonNegativeFloat, NonNegativeInt
@@ -12,17 +11,15 @@ from src.analysis.metrics.shadow_metrics import scrape_run_metrics
 from src.deployments.experiments.base_experiment import BaseExperiment
 from src.deployments.registry import experiment
 from src.deployments.shadow.builders import (
-    TRAFFIC_SYNC_REPO_PATH,
     build_configmap,
     build_pvc,
     build_shadow_job,
+    render_publisher_config,
     render_shadow_yaml,
 )
 from src.deployments.shadow.runtime import pull_shadow_logs, wait_for_job_complete
 
 logger = logging.getLogger(__name__)
-
-_REPO_ROOT = Path(__file__).resolve().parents[4]
 
 
 class ExpConfig(BaseModel):
@@ -76,26 +73,24 @@ class ShadowGossipsubExperiment(BaseExperiment[ExpConfig]):
 
         shadow_yaml = render_shadow_yaml(
             num_nodes=cfg.num_nodes,
-            num_messages=cfg.num_messages,
-            msg_size_bytes=cfg.message_size_bytes,
-            delay_seconds=cfg.delay_seconds,
             sim_stop_time_s=cfg.sim_stop_time_s,
             publisher_start_s=cfg.publisher_start_s,
             connect_to=cfg.connect_to,
             metrics_interval_s=cfg.metrics_interval_s,
         )
-        traffic_sync_path = _REPO_ROOT / TRAFFIC_SYNC_REPO_PATH
-        if not traffic_sync_path.exists():
-            raise FileNotFoundError(
-                f"traffic_sync.py not found at expected path: {traffic_sync_path}"
-            )
+        publisher_config = render_publisher_config(
+            num_nodes=cfg.num_nodes,
+            num_messages=cfg.num_messages,
+            msg_size_bytes=cfg.message_size_bytes,
+            delay_seconds=cfg.delay_seconds,
+        )
 
         pvc = build_pvc(namespace=namespace, name=pvc_name, storage=cfg.pvc_storage)
         configmap = build_configmap(
             namespace=namespace,
             name=cm_name,
             shadow_yaml=shadow_yaml,
-            traffic_sync_path=traffic_sync_path,
+            publisher_config=publisher_config,
         )
         job = build_shadow_job(
             namespace=namespace,

--- a/src/deployments/shadow/builders.py
+++ b/src/deployments/shadow/builders.py
@@ -1,6 +1,5 @@
 # Builders for Shadow simulator runs: config values -> kubernetes-client objects
 # and yaml dicts. Pure data, no I/O. See the "Using Shadow at DST" runbook.
-from pathlib import Path
 from typing import Optional
 
 from kubernetes.client import (
@@ -26,9 +25,10 @@ from kubernetes.client import (
 )
 from ruamel.yaml import YAML
 
-TRAFFIC_SYNC_REPO_PATH = (
-    "deployment-utilities/docker_utilities/nimlibp2p/publisher_headless/traffic_sync.py"
-)
+# The pod-api-requester app is baked into the Shadow base image; the publisher host
+# runs it in batch mode and reads its traffic config from the mounted ConfigMap.
+_REQUESTER_APP_PATH = "/app/api_requester.py"
+_PUBLISHER_CONFIG = "publisher.yaml"  # ConfigMap key == filename mounted under /sim/config
 
 # Mount targets inside the Shadow runner container.
 _BIN_MOUNT = "/sim/bin"
@@ -45,17 +45,18 @@ _SHADOW_SECURITY = V1SecurityContext(
 def render_shadow_yaml(
     *,
     num_nodes: int,
-    num_messages: int,
-    msg_size_bytes: int,
-    delay_seconds: float,
     sim_stop_time_s: int,
     publisher_start_s: int,
     connect_to: int = 2,
     muxer: str = "yamux",
     metrics_interval_s: int = 15,
+    requester_app_path: str = _REQUESTER_APP_PATH,
 ) -> dict:
     """Build the shadow.yaml dict: N peer hosts running `./main` + a publisher host
-    running `traffic_sync.py` against the peers' `/publish` endpoints (port 8645)."""
+    running the pod-api-requester in batch mode against the peers' `/publish`
+    endpoints. The traffic shape (message count, size, pacing) lives in the
+    requester's own config (see `render_publisher_config`), mounted at
+    `{_CONFIG_MOUNT}/{_PUBLISHER_CONFIG}`."""
     if connect_to >= num_nodes:
         raise ValueError(f"connect_to ({connect_to}) must be smaller than num_nodes ({num_nodes}).")
 
@@ -85,13 +86,9 @@ def render_shadow_yaml(
             {
                 "path": "/usr/bin/python3",
                 "args": (
-                    f"{_CONFIG_MOUNT}/traffic_sync.py"
-                    f" --peer-selection id"
-                    f" -n {num_nodes}"
-                    f" -m {num_messages}"
-                    f" -s {msg_size_bytes}"
-                    f" -d {delay_seconds}"
-                    f" -p 8645"
+                    f"{requester_app_path}"
+                    f" --mode batch"
+                    f" --config {_CONFIG_MOUNT}/{_PUBLISHER_CONFIG}"
                 ),
                 "start_time": f"{publisher_start_s}s",
             }
@@ -106,6 +103,65 @@ def render_shadow_yaml(
             "graph": {"type": "1_gbit_switch"},
         },
         "hosts": hosts,
+    }
+
+
+def render_publisher_config(
+    *,
+    num_nodes: int,
+    num_messages: int,
+    msg_size_bytes: int,
+    delay_seconds: float,
+    port: int = 8645,
+    topic: str = "test",
+) -> dict:
+    """Build the pod-api-requester batch config reproducing the legacy traffic_sync.py
+    injector: publish `num_messages` messages round-robin across pod-0..pod-(N-1),
+    `delay_seconds` apart, to each peer's `/publish` endpoint. Targets are an explicit
+    `hosts` list (pod-0..pod-(N-1)) resolved by Shadow DNS, so no Kubernetes API is
+    contacted.
+
+    `pod_count = num_messages` walks the sorted host list with wraparound, matching
+    traffic_sync's `pod-(i % num_nodes)` selection (and its `version: 1` / `msgSize`
+    JSON body)."""
+    return {
+        "targets": [
+            {
+                "name": "peers",
+                "hosts": [f"pod-{i}" for i in range(num_nodes)],
+                "port": port,
+            }
+        ],
+        "endpoints": [
+            {
+                "name": "libp2p-publish",
+                "url": "http://{node}:{port}/publish",
+                "headers": {"Content-Type": "application/json"},
+                "params": {"topic": topic, "msgSize": msg_size_bytes, "version": 1},
+                "type": "POST",
+                "paged": False,
+            }
+        ],
+        "requests": [
+            {
+                "name": "publish",
+                "endpoint": "libp2p-publish",
+                "retries": 0,
+                "retry_delay": 0,
+            }
+        ],
+        "actions": [
+            {
+                "name": "inject-traffic",
+                "requests": ["publish"],
+                "targets": ["peers"],
+                "order": "ascending",
+                "pod_start_index": 0,
+                "pod_count": num_messages,
+                "delay": delay_seconds,
+                "loop_order": "foreach_request_target_each_pod",
+            }
+        ],
     }
 
 
@@ -125,16 +181,17 @@ def build_configmap(
     namespace: str,
     name: str,
     shadow_yaml: dict,
-    traffic_sync_path: Path,
+    publisher_config: dict,
 ) -> V1ConfigMap:
-    """ConfigMap with shadow.yaml + traffic_sync.py, mounted at /sim/config/."""
+    """ConfigMap with shadow.yaml + the pod-api-requester batch config, mounted at
+    /sim/config/. The requester app itself is baked into the Shadow base image."""
     return V1ConfigMap(
         api_version="v1",
         kind="ConfigMap",
         metadata=V1ObjectMeta(name=name, namespace=namespace),
         data={
             "shadow.yaml": _dump_yaml(shadow_yaml),
-            "traffic_sync.py": traffic_sync_path.read_text(),
+            _PUBLISHER_CONFIG: _dump_yaml(publisher_config),
         },
     )
 

--- a/src/deployments/shadow/tests/test_builders.py
+++ b/src/deployments/shadow/tests/test_builders.py
@@ -1,0 +1,195 @@
+import io
+
+import pytest
+from ruamel.yaml import YAML
+
+from src.deployments.shadow.builders import (
+    build_configmap,
+    build_pvc,
+    build_shadow_job,
+    render_publisher_config,
+    render_shadow_yaml,
+)
+
+
+def _load_yaml(text: str):
+    return YAML(typ="safe").load(io.StringIO(text))
+
+
+# --------------------------------------------------------------------------- #
+# render_publisher_config  (pod-api-requester batch config, reproduces traffic_sync)
+# --------------------------------------------------------------------------- #
+class TestRenderPublisherConfig:
+    def test_hosts_expand_over_num_nodes(self):
+        cfg = render_publisher_config(
+            num_nodes=10, num_messages=5, msg_size_bytes=1000, delay_seconds=2.0
+        )
+        target = cfg["targets"][0]
+        assert target["hosts"] == [f"pod-{i}" for i in range(10)]
+        assert target["port"] == 8645
+        # the host_template/host_count knobs were dropped in favour of an explicit list
+        assert "host_template" not in target
+        assert "host_count" not in target
+
+    def test_action_reproduces_traffic_sync(self):
+        cfg = render_publisher_config(
+            num_nodes=10, num_messages=5, msg_size_bytes=1000, delay_seconds=2.0
+        )
+        action = cfg["actions"][0]
+        assert action["pod_count"] == 5  # = num_messages
+        assert action["delay"] == 2.0  # = delay_seconds
+        assert action["order"] == "ascending"
+        assert action["pod_start_index"] == 0
+        assert action["loop_order"] == "foreach_request_target_each_pod"
+
+    def test_publish_endpoint_payload(self):
+        cfg = render_publisher_config(
+            num_nodes=3, num_messages=2, msg_size_bytes=512, delay_seconds=1.0
+        )
+        endpoint = cfg["endpoints"][0]
+        assert endpoint["url"] == "http://{node}:{port}/publish"
+        assert endpoint["type"] == "POST"
+        assert endpoint["paged"] is False
+        assert endpoint["params"] == {"topic": "test", "msgSize": 512, "version": 1}
+
+    def test_custom_port_and_topic(self):
+        cfg = render_publisher_config(
+            num_nodes=2, num_messages=1, msg_size_bytes=10, delay_seconds=0, port=9000, topic="foo"
+        )
+        assert cfg["targets"][0]["port"] == 9000
+        assert cfg["endpoints"][0]["params"]["topic"] == "foo"
+
+    def test_request_and_action_cross_references_resolve(self):
+        cfg = render_publisher_config(
+            num_nodes=2, num_messages=1, msg_size_bytes=10, delay_seconds=0
+        )
+        # the action references the request by name, the request references the endpoint
+        assert cfg["requests"][0]["endpoint"] == cfg["endpoints"][0]["name"]
+        assert cfg["actions"][0]["requests"] == [cfg["requests"][0]["name"]]
+        assert cfg["actions"][0]["targets"] == [cfg["targets"][0]["name"]]
+
+
+# --------------------------------------------------------------------------- #
+# render_shadow_yaml  (peer hosts + publisher host)
+# --------------------------------------------------------------------------- #
+class TestRenderShadowYaml:
+    def test_peer_hosts_plus_publisher(self):
+        sy = render_shadow_yaml(num_nodes=4, sim_stop_time_s=180, publisher_start_s=90)
+        hosts = sy["hosts"]
+        assert sorted(h for h in hosts if h.startswith("pod-")) == [f"pod-{i}" for i in range(4)]
+        assert "publisher" in hosts
+        assert len(hosts) == 5  # 4 peers + 1 publisher
+
+    def test_publisher_runs_requester_in_batch_mode(self):
+        sy = render_shadow_yaml(num_nodes=4, sim_stop_time_s=180, publisher_start_s=90)
+        proc = sy["hosts"]["publisher"]["processes"][0]
+        assert proc["path"] == "/usr/bin/python3"
+        assert (
+            proc["args"] == "/app/api_requester.py --mode batch --config /sim/config/publisher.yaml"
+        )
+        assert proc["start_time"] == "90s"
+        assert "traffic_sync" not in proc["args"]  # the swap removed the legacy injector
+
+    def test_requester_app_path_override(self):
+        sy = render_shadow_yaml(
+            num_nodes=4, sim_stop_time_s=180, publisher_start_s=90, requester_app_path="/opt/req.py"
+        )
+        assert sy["hosts"]["publisher"]["processes"][0]["args"].startswith(
+            "/opt/req.py --mode batch"
+        )
+
+    def test_peer_process_is_daemon_with_env(self):
+        sy = render_shadow_yaml(
+            num_nodes=3,
+            sim_stop_time_s=120,
+            publisher_start_s=60,
+            connect_to=2,
+            metrics_interval_s=15,
+        )
+        peer = sy["hosts"]["pod-0"]["processes"][0]
+        assert peer["path"] == "./main"
+        assert peer["start_time"] == "5s"
+        assert peer["expected_final_state"] == "running"
+        env = peer["environment"]
+        assert env["PEERS"] == "3"
+        assert env["CONNECTTO"] == "2"
+        assert env["SHADOWENV"] == "true"
+        assert env["METRICS_INTERVAL_S"] == "15"
+
+    def test_general_and_network_section(self):
+        sy = render_shadow_yaml(num_nodes=3, sim_stop_time_s=180, publisher_start_s=90)
+        assert sy["general"]["stop_time"] == "180s"
+        assert sy["general"]["progress"] is True
+        assert sy["network"]["graph"]["type"] == "1_gbit_switch"
+
+    def test_connect_to_must_be_less_than_num_nodes(self):
+        with pytest.raises(ValueError):
+            render_shadow_yaml(num_nodes=2, sim_stop_time_s=10, publisher_start_s=5, connect_to=2)
+
+
+# --------------------------------------------------------------------------- #
+# build_configmap  (ships shadow.yaml + publisher.yaml)
+# --------------------------------------------------------------------------- #
+class TestBuildConfigmap:
+    def test_keys_metadata_and_yaml_roundtrip(self):
+        sy = render_shadow_yaml(num_nodes=3, sim_stop_time_s=180, publisher_start_s=90)
+        pub = render_publisher_config(
+            num_nodes=3, num_messages=2, msg_size_bytes=1000, delay_seconds=2.0
+        )
+        cm = build_configmap(
+            namespace="zerotesting-shadow", name="shadow-x", shadow_yaml=sy, publisher_config=pub
+        )
+
+        assert set(cm.data.keys()) == {"shadow.yaml", "publisher.yaml"}
+        assert cm.metadata.name == "shadow-x"
+        assert cm.metadata.namespace == "zerotesting-shadow"
+        # the data values are valid YAML that round-trips back to the inputs
+        assert _load_yaml(cm.data["publisher.yaml"])["targets"][0]["hosts"] == [
+            f"pod-{i}" for i in range(3)
+        ]
+        assert "publisher" in _load_yaml(cm.data["shadow.yaml"])["hosts"]
+        assert "traffic_sync.py" not in cm.data  # legacy injector no longer shipped
+
+
+# --------------------------------------------------------------------------- #
+# build_shadow_job / build_pvc  (k8s objects)
+# --------------------------------------------------------------------------- #
+class TestBuildShadowJob:
+    def test_containers_images_and_ptrace(self):
+        job = build_shadow_job(
+            namespace="ns",
+            name="job-x",
+            configmap_name="cm",
+            pvc_name="pvc",
+            test_node_image="repo/test-node:tag",
+            shadow_base_image="repo/base:tag",
+        )
+        spec = job.spec.template.spec
+        assert [c.name for c in spec.init_containers] == ["fetch-test-node"]
+        assert spec.init_containers[0].image == "repo/test-node:tag"
+        assert spec.containers[0].name == "shadow"
+        assert spec.containers[0].image == "repo/base:tag"
+        # Shadow's syscall interposer needs SYS_PTRACE
+        assert "SYS_PTRACE" in spec.containers[0].security_context.capabilities.add
+        assert job.spec.backoff_limit == 0
+
+    def test_node_pin_sets_node_selector(self):
+        job = build_shadow_job(
+            namespace="ns",
+            name="job-x",
+            configmap_name="cm",
+            pvc_name="pvc",
+            test_node_image="tn",
+            shadow_base_image="base",
+            node_pin="node-05",
+        )
+        assert job.spec.template.spec.node_selector == {"kubernetes.io/hostname": "node-05"}
+
+
+class TestBuildPvc:
+    def test_rwo_storage_and_class(self):
+        pvc = build_pvc(namespace="ns", name="data", storage="7Gi", storage_class="longhorn")
+        assert pvc.metadata.name == "data"
+        assert pvc.spec.access_modes == ["ReadWriteOnce"]
+        assert pvc.spec.storage_class_name == "longhorn"
+        assert pvc.spec.resources.requests["storage"] == "7Gi"


### PR DESCRIPTION
Replace the traffic_sync.py publisher host with the pod-api-requester run in batch mode.

Related to: https://github.com/vacp2p/10ksim/issues/220