### PR TITLE
logos core builder changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,4 +39,4 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 asyncio_mode = "auto"
-addopts = "-ra"
+addopts = "-ra --import-mode=importlib"

--- a/src/deployments/core/builders.py
+++ b/src/deployments/core/builders.py
@@ -30,7 +30,7 @@ from src.deployments.core.configs.pod import (
     build_pod_spec,
     build_pod_template_spec,
 )
-from src.deployments.core.configs.service import ServiceConfig, build_service
+from src.deployments.core.configs.service import ServiceConfig, ServiceSpecType, build_service
 from src.deployments.core.configs.statefulset import StatefulSetConfig, build_stateful_set
 
 logger = logging.getLogger(__name__)
@@ -117,6 +117,51 @@ class StatefulSetBuilder(BaseModel):
 class PodBuilder(BaseModel):
     config: PodConfig = Field(default_factory=PodConfig)
 
+    def model_post_init(self, __context) -> None:
+        self._register_dependencies()
+
+    @property
+    def name(self) -> str | None:
+        return self.config.name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self.config.name = value
+        self._reconcile("name")
+
+    @property
+    def namespace(self) -> str | None:
+        return self.config.namespace
+
+    @namespace.setter
+    def namespace(self, value: str) -> None:
+        self.config.namespace = value
+        self._reconcile("namespace")
+
+    @property
+    def app(self) -> str | None:
+        try:
+            return self.config.labels["app"]
+        except (TypeError, KeyError):
+            return None
+
+    @app.setter
+    def app(self, value: str) -> None:
+        self.config.with_app(value, overwrite=True)
+        self._reconcile("app")
+
+    def with_name(self, name: str) -> Self:
+        self.name = name
+        return self
+
+    def with_namespace(self, namespace: str) -> Self:
+        self.namespace = namespace
+        return self
+
+    def with_app(self, app: str, *, overwrite: bool = False) -> Self:
+        self.config.with_app(app, overwrite=overwrite)
+        return self
+
     def with_image_in_container(
         self, image: Image, container_name: str, *, overwrite: bool = False
     ) -> Self:
@@ -125,8 +170,25 @@ class PodBuilder(BaseModel):
         )
         return self
 
-    def with_app(self, app: str, *, overwrite: bool = False) -> Self:
-        self.config.with_app(app, overwrite=overwrite)
+    def _register_dependencies(self) -> None:
+        self._dependency_registry = {}
+        for cls in type(self).mro():
+            for name, maybe_method in cls.__dict__.items():
+                fields = getattr(maybe_method, "_depends_on_fields", None)
+                if fields:
+                    for field in fields:
+                        self._dependency_registry.setdefault(field, []).append(name)
+
+    def _reconcile(self, changed_field: Optional[str] = None) -> Self:
+        if changed_field is None:
+            return self
+
+        for method_name in self._dependency_registry.get(changed_field, []):
+            method = getattr(self, method_name)
+            required_fields = getattr(method, "_depends_on_fields", set())
+            if all(getattr(self, field, None) is not None for field in required_fields):
+                method()
+
         return self
 
     def build(self) -> V1Pod:
@@ -152,10 +214,12 @@ class ServiceBuilder(BaseModel):
         self.config.service_spec.with_selector(key, value)
         return self
 
-    def with_port(self, port: V1ServicePort) -> Self:
-        if self.config.service_spec.ports is None:
-            self.config.service_spec.ports = []
-        self.config.service_spec.ports.append(port)
+    def with_port(self, new_port: V1ServicePort) -> Self:
+        self.config.service_spec.with_port(new_port)
+        return self
+
+    def with_type(self, spec_type: ServiceSpecType) -> Self:
+        self.config.service_spec.spec_type = spec_type
         return self
 
     def with_publish_not_ready_addresses(self, value: bool = True) -> Self:

--- a/src/deployments/core/builders.py
+++ b/src/deployments/core/builders.py
@@ -158,8 +158,8 @@ class PodBuilder(BaseModel):
         self.namespace = namespace
         return self
 
-    def with_app(self, app: str, *, overwrite: bool = False) -> Self:
-        self.config.with_app(app, overwrite=overwrite)
+    def with_app(self, app: str) -> Self:
+        self.app = app
         return self
 
     def with_image_in_container(

--- a/src/deployments/core/configs/pod.py
+++ b/src/deployments/core/configs/pod.py
@@ -30,17 +30,33 @@ class PodSpecConfig(BaseModel):
     security_context: Optional[V1PodSecurityContext] = None
     automount_service_account_token: Optional[bool] = None
 
-    def with_dns_service(self, service: str, *, overwrite: bool = False):
+    def with_dns_search(self, dns_search: str, *, overwrite: bool = False):
         if self.dns_config is None:
             self.dns_config = V1PodDNSConfig(searches=[])
-        current_service = next((item for item in self.dns_config.searches if item == service), None)
+        current_service = next(
+            (item for item in self.dns_config.searches if item == dns_search), None
+        )
         if current_service:
             if not overwrite:
                 raise ValueError(
-                    f"DNS service already exists in {type(self)}. service: `{service}` config: `{self}`"
+                    f"DNS service already exists in {type(self)}. service: `{dns_search}` config: `{self}`"
                 )
             self.dns_config.searches.remove(current_service)
-        self.dns_config.searches.append(service)
+        self.dns_config.searches.append(dns_search)
+
+    def remove_dns_search(self, dns_search: str, *, missing_ok: bool = True):
+        if self.dns_config is None:
+            return
+        current_service = next(
+            (item for item in self.dns_config.searches if item == dns_search), None
+        )
+        if not current_service:
+            if missing_ok:
+                return
+            raise ValueError(
+                f"Attempted to remove nonexistent dns search. service: `{dns_search}` config: `{self}`"
+            )
+        self.dns_config.searches.remove(current_service)
 
     def with_volume(self, volume: V1Volume, *, overwrite: bool = False):
         if self.volumes is None:

--- a/src/deployments/core/configs/service.py
+++ b/src/deployments/core/configs/service.py
@@ -1,11 +1,14 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Literal, Optional, Self
 
 from kubernetes.client import V1ObjectMeta, V1Service, V1ServicePort, V1ServiceSpec
 from pydantic import BaseModel, ConfigDict, Field
 
+ServiceSpecType = Literal["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
+
 
 class ServiceSpecConfig(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
+    spec_type: Optional[ServiceSpecType] = None
     cluster_ip: Optional[str] = None
     selector: Optional[Dict[str, str]] = None
     ports: Optional[List[V1ServicePort]] = None
@@ -15,6 +18,23 @@ class ServiceSpecConfig(BaseModel):
         if self.selector is None:
             self.selector = {}
         self.selector[key] = value
+
+    def with_port(self, new_port: V1ServicePort, overwrite: bool = False):
+        if self.ports is None:
+            self.ports = []
+
+        current_port = next((item for item in self.ports if item == new_port), None)
+        if current_port:
+            if not overwrite:
+                raise ValueError(
+                    f"Port already exists in {type(self).__name__}. "
+                    f"Port: `{new_port.port}`, Protocol: `{getattr(new_port, 'protocol', 'TCP')}`, "
+                    f"Config: `{self}`"
+                )
+            self.ports.remove(current_port)
+
+        self.ports.append(new_port)
+        return self
 
 
 class ServiceConfig(BaseModel):
@@ -27,12 +47,28 @@ class ServiceConfig(BaseModel):
     service_spec: ServiceSpecConfig = Field(default_factory=ServiceSpecConfig)
 
 
+class ServiceConfigBuilder(BaseModel):
+    config: ServiceConfig = Field(default_factory=ServiceConfig)
+
+    def with_port(self, new_port: V1ServicePort) -> Self:
+        self.service_spec.with_port(new_port)
+        return self
+
+    def with_type(self, spec_type: ServiceSpecType) -> Self:
+        self.service_spec.spec_type = spec_type
+        return self
+
+    def build(self) -> V1Service:
+        return build_service(self.config)
+
+
 def build_service(config: ServiceConfig) -> V1Service:
     return V1Service(
         api_version=config.apiVersion,
         kind=config.kind,
         metadata=V1ObjectMeta(name=config.name, namespace=config.namespace, labels=config.labels),
         spec=V1ServiceSpec(
+            type=config.service_spec.spec_type,
             cluster_ip=config.service_spec.cluster_ip,
             selector=config.service_spec.selector,
             ports=config.service_spec.ports,

--- a/src/deployments/core/dependency_decorator.py
+++ b/src/deployments/core/dependency_decorator.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from functools import wraps
+from typing import Any, Callable
+
+
+def depends_on(*fields: str):
+    def decorator(fn: Callable[..., Any]):
+        setattr(fn, "_depends_on_fields", set(fields))
+
+        @wraps(fn)
+        def wrapped(*args, **kwargs):
+            return fn(*args, **kwargs)
+
+        return wrapped
+
+    return decorator
+
+
+class DependencyRegistry:
+    def __init__(self) -> None:
+        self._field_to_methods: dict[str, list[str]] = defaultdict(list)
+
+    def register(self, method_name: str, fields: set[str]) -> None:
+        for field in fields:
+            if method_name not in self._field_to_methods[field]:
+                self._field_to_methods[field].append(method_name)
+
+    def methods_for(self, field: str) -> list[str]:
+        return list(self._field_to_methods.get(field, []))

--- a/src/deployments/logos_core/builders/nodes.py
+++ b/src/deployments/logos_core/builders/nodes.py
@@ -110,7 +110,7 @@ class NodesBuilder(StatefulSetBuilder):
         self.config.stateful_set_spec.pod_template_spec_config.pod_spec_config.dns_config = None
         for dns in self._dns_configs:
             search = f"{dns}.{self._namespace}.svc.cluster.local"
-            self.config.stateful_set_spec.pod_template_spec_config.pod_spec_config.with_dns_service(
+            self.config.stateful_set_spec.pod_template_spec_config.pod_spec_config.with_dns_search(
                 search, overwrite=True
             )
 

--- a/src/deployments/logos_core/builders/request_builder.py
+++ b/src/deployments/logos_core/builders/request_builder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Self
 
@@ -17,10 +18,11 @@ from pydantic import Field, PrivateAttr
 
 from src.deployments.core.configs.helpers.identity import apply_identity
 from src.deployments.core.configs.helpers.utils import find_container_config
+from src.deployments.core.dependency_decorator import depends_on
+from src.deployments.experiments.base_experiment import V1Deployable
 from src.deployments.pod_api_requester.builder import (
     PodApiRequesterBuilder,
 )
-from src.deployments.core.dependency_decorator import depends_on
 
 
 @dataclass
@@ -204,10 +206,10 @@ class LogoscorePodApiRequester(PodApiRequesterBuilder):
 
         return self
 
-    def _get_dependencies(self):
-        base_dict = super()._get_dependencies()
-        base_dict["logoscore"] = self._logoscore_dependencies
-        return base_dict
+    def build_dependencies(self) -> Dict[str, V1Deployable]:
+        deps = super().build_dependencies()
+        deps["logoscore"] = self._logoscore_dependencies
+        return deepcopy(deps)
 
 
 def role(namespace: str, role_name: str):

--- a/src/deployments/logos_core/builders/request_builder.py
+++ b/src/deployments/logos_core/builders/request_builder.py
@@ -131,7 +131,6 @@ class LogoscorePodApiRequester(PodApiRequesterBuilder):
 
     def with_debug(self, debug: bool = True) -> Self:
         self.debug = debug
-        self._reconcile("debug")
         return self
 
     @depends_on(

--- a/src/deployments/logos_core/builders/request_builder.py
+++ b/src/deployments/logos_core/builders/request_builder.py
@@ -102,7 +102,7 @@ class LogoscorePodApiRequester(PodApiRequesterBuilder):
     def logoscore_enabled(self) -> bool:
         return self._logoscore_enabled
 
-    @debug.setter
+    @logoscore_enabled.setter
     def logoscore_enabled(self, logoscore_enabled: bool) -> None:
         self._logoscore_enabled = logoscore_enabled
         self._reconcile("logoscore_enabled")

--- a/src/deployments/logos_core/builders/request_builder.py
+++ b/src/deployments/logos_core/builders/request_builder.py
@@ -20,9 +20,7 @@ from src.deployments.core.configs.helpers.identity import apply_identity
 from src.deployments.core.configs.helpers.utils import find_container_config
 from src.deployments.core.dependency_decorator import depends_on
 from src.deployments.experiments.base_experiment import V1Deployable
-from src.deployments.pod_api_requester.builder import (
-    PodApiRequesterBuilder,
-)
+from src.deployments.pod_api_requester.builder import PodApiRequesterBuilder
 
 
 @dataclass
@@ -170,7 +168,6 @@ class LogoscorePodApiRequester(PodApiRequesterBuilder):
         if old_params and old_params.service_name and old_params.namespace:
             old_search = f"{old_params.service_name}.{old_params.namespace}.svc.cluster.local"
             pod_spec.remove_dns_search(old_search, missing_ok=True)
-
         new_search = f"{new_params.service_name}.{new_params.namespace}.svc.cluster.local"
         pod_spec.with_dns_search(new_search, overwrite=True)
 

--- a/src/deployments/logos_core/builders/request_builder.py
+++ b/src/deployments/logos_core/builders/request_builder.py
@@ -1,184 +1,213 @@
-from collections import defaultdict
-from copy import deepcopy
-from itertools import chain
-from typing import Any, Dict, Optional, Self, Set
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Self
 
 from kubernetes.client import (
     RbacV1Subject,
-    V1EnvVar,
     V1ObjectMeta,
     V1PodSecurityContext,
     V1PolicyRule,
-    V1ResourceRequirements,
     V1Role,
     V1RoleBinding,
     V1RoleRef,
-    V1Service,
     V1ServiceAccount,
-    V1ServicePort,
-    V1ServiceSpec,
 )
 from pydantic import Field, PrivateAttr
 
-from src.deployments.core.configs.container import ContainerConfig
 from src.deployments.core.configs.helpers.identity import apply_identity
-from src.deployments.core.configs.helpers.utils import find_container_config, get_config
-from src.deployments.core.configs.pod import PodSpecConfig
-from src.deployments.core.k8s_object import V1Deployable
-from src.deployments.pod_api_requester.builder import PodApiRequesterBuilder
+from src.deployments.core.configs.helpers.utils import find_container_config
+from src.deployments.pod_api_requester.builder import (
+    PodApiRequesterBuilder,
+)
+from src.deployments.core.dependency_decorator import depends_on
+
+
+@dataclass
+class LogoscoreParams:
+    namespace: Optional[str] = None
+    name: Optional[str] = None
+    app: Optional[str] = None
+    service_name: Optional[str] = None
+    debug: bool = False
+    service_account_name: Optional[str] = None
+    secret_creator_role_name: Optional[str] = None
+    secret_creator_binding_name: Optional[str] = None
+    pod_service_reader_binding_name: Optional[str] = None
+    pod_service_reader_role_name: Optional[str] = None
 
 
 class LogoscorePodApiRequester(PodApiRequesterBuilder):
     dependencies: Dict[str, Any] = Field(default_factory=dict)
-    _service_account_name: str = PrivateAttr(default="secret-creator2")
-    _secret_creator_role_name: str = PrivateAttr(default="secret-creator-role2")
-    _secret_creator_binding_name: str = PrivateAttr(default="secret-creator-binding2")
-    _pod_service_reader_binding_name_logoscore: str = PrivateAttr(
+
+    _logoscore_enabled: bool = PrivateAttr(default=False)
+    _logoscore_params: Optional[LogoscoreParams] = PrivateAttr(default=None)
+    _logoscore_dependencies: Dict[str, Any] = PrivateAttr(default_factory=dict)
+
+    _service_account_name: object = PrivateAttr(default="secret-creator2")
+    _secret_creator_role_name: object = PrivateAttr(default="secret-creator-role2")
+    _secret_creator_binding_name: object = PrivateAttr(default="secret-creator-binding2")
+    _pod_service_reader_role_name: str = "pod-service-reader"
+    _pod_service_reader_binding_name_logoscore: object = PrivateAttr(
         default="pod-service-reader-binding-logoscore2"
     )
-    _service_name: Optional[str] = PrivateAttr(default=None)
     _debug: bool = PrivateAttr(default=False)
-    _dns_searches: Set[str] = PrivateAttr(default_factory=set)
 
-    def with_namespace(self, namespace: str) -> Self:
-        return super().with_namespace(namespace)
+    @property
+    def service_account_name(self) -> Optional[str]:
+        return self._service_account_name
 
-    def with_logoscore_profile(
-        self,
-        namespace: str,
-        name: str = "logoscore2",
-        app: str = "zerotenkay-core2",
-        debug: bool = False,
-    ) -> Self:
-        self._namespace = namespace
-        self._name = name
-        self._app = app
-        self._debug = debug
-        self._reconcile()
+    @service_account_name.setter
+    def service_account_name(self, value: Optional[str]) -> None:
+        self._service_account_name = value
+        self._reconcile("service_account_name")
+
+    @property
+    def secret_creator_role_name(self) -> Optional[str]:
+        return self._secret_creator_role_name
+
+    @secret_creator_role_name.setter
+    def secret_creator_role_name(self, value: Optional[str]) -> None:
+        self._secret_creator_role_name = value
+        self._reconcile("secret_creator_role_name")
+
+    @property
+    def secret_creator_binding_name(self) -> Optional[str]:
+        return self._secret_creator_binding_name
+
+    @secret_creator_binding_name.setter
+    def secret_creator_binding_name(self, value: Optional[str]) -> None:
+        self._secret_creator_binding_name = value
+        self._reconcile("secret_creator_binding_name")
+
+    @property
+    def pod_service_reader_binding_name(self) -> Optional[str]:
+        return self._pod_service_reader_binding_name_logoscore
+
+    @pod_service_reader_binding_name.setter
+    def pod_service_reader_binding_name(self, value: Optional[str]) -> None:
+        self._pod_service_reader_binding_name_logoscore = value
+        self._reconcile("pod_service_reader_binding_name")
+
+    @property
+    def debug(self) -> bool:
+        return self._debug
+
+    @debug.setter
+    def debug(self, value: bool) -> None:
+        self._debug = value
+        self._reconcile("debug")
+
+    @property
+    def logoscore_enabled(self) -> bool:
+        return self._logoscore_enabled
+
+    @debug.setter
+    def logoscore_enabled(self, logoscore_enabled: bool) -> None:
+        self._logoscore_enabled = logoscore_enabled
+        self._reconcile("logoscore_enabled")
+
+    def with_logoscore(self) -> Self:
+        self.logoscore_enabled = True
         return self
 
     def with_service_account_name(self, service_account_name: str) -> Self:
-        self._service_account_name = service_account_name
-        self._reconcile()
+        self.service_account_name = service_account_name
         return self
 
     def with_secret_creator_role_name(self, role_name: str) -> Self:
-        self._secret_creator_role_name = role_name
+        self.secret_creator_role_name = role_name
         return self
 
     def with_secret_creator_binding_name(self, binding_name: str) -> Self:
-        self._secret_creator_binding_name = binding_name
+        self.secret_creator_binding_name = binding_name
         return self
 
     def with_pod_service_reader_binding_name(self, binding_name: str) -> Self:
-        self._pod_service_reader_binding_name_logoscore = binding_name
+        self.pod_service_reader_binding_name = binding_name
         return self
 
-    def with_service_name(self, service_name: str) -> Self:
-        self._service_name = service_name
-        self._reconcile()
+    def with_debug(self, debug: bool = True) -> Self:
+        self.debug = debug
+        self._reconcile("debug")
         return self
 
-    def with_dns_search(self, search) -> Self:
-        self._dns_searches.add(search)
-        super().with_dns_search(search)
-        self._reconcile()
-        return self
-
-    def _get_dependencies(self):
-        base_dict = super()._get_dependencies()
-        logoscore_dict = self._logoscore_dependencies()
-        deps = defaultdict(list)
-        for key, value in chain(base_dict.items(), logoscore_dict.items()):
-            deps[key].extend(value)
-        return dict(deps)
-
-    def _logoscore_dependencies(self) -> dict:
-        if not self._namespace:
-            raise ValueError("Namespace must be set before building dependencies")
-        if not self._service_account_name:
-            raise ValueError("Service account name must be set before building dependencies")
-        return {
-            "roles": [role(self._namespace, self._secret_creator_role_name)],
-            "role_bindings": role_bindings(
-                self._namespace,
-                self._service_account_name,
-                self._secret_creator_binding_name,
-                self._pod_service_reader_binding_name_logoscore,
-                self._pod_service_reader_role_name,
-                self._secret_creator_role_name,
-            ),
-            "service_accounts": [service_account(self._namespace, self._service_account_name)],
-            "services": [service(self._namespace, self._service_name, self._app)],
-        }
-
-    def build_dependencies(self) -> Dict[str, V1Deployable]:
-        self.dependencies = self._get_dependencies()
-        return deepcopy(self.dependencies)
-
-    def _reconcile(self) -> Self:
-        if not self._namespace:
-            return self
-
-        apply_identity(self.config, name=self._name, namespace=self._namespace, app=self._app)
-
-        self.config.pod_spec_config.with_service_account_name(
-            self._service_account_name, overwrite=True
+    @depends_on(
+        "logoscore_enabled",
+        "namespace",
+        "name",
+        "app",
+        "service_name",
+        "debug",
+        "service_account_name",
+        "secret_creator_role_name",
+        "secret_creator_binding_name",
+        "pod_service_reader_binding_name",
+    )
+    def _apply_logoscore(self):
+        new_params = LogoscoreParams(
+            namespace=self.namespace,
+            name=self.name,
+            app=self.app,
+            service_name=self.service_name,
+            debug=self._debug,
+            service_account_name=self._service_account_name,
+            secret_creator_role_name=self._secret_creator_role_name,
+            secret_creator_binding_name=self._secret_creator_binding_name,
+            pod_service_reader_binding_name=self._pod_service_reader_binding_name_logoscore,
+            pod_service_reader_role_name=self._pod_service_reader_role_name,
         )
-        self.config.pod_spec_config.automount_service_account_token = True
-        self.config.pod_spec_config.with_security_context(
+        self._apply_logoscore_inner(old_params=self._logoscore_params, new_params=new_params)
+        self._logoscore_params = new_params
+        return self
+
+    def _apply_logoscore_inner(
+        self, old_params: LogoscoreParams, new_params: LogoscoreParams
+    ) -> Self:
+        pod_spec = self.config.pod_spec_config
+
+        if old_params and old_params.service_name and old_params.namespace:
+            old_search = f"{old_params.service_name}.{old_params.namespace}.svc.cluster.local"
+            pod_spec.remove_dns_search(old_search, missing_ok=True)
+
+        new_search = f"{new_params.service_name}.{new_params.namespace}.svc.cluster.local"
+        pod_spec.with_dns_search(new_search, overwrite=True)
+
+        apply_identity(
+            self.config, name=new_params.name, namespace=new_params.namespace, app=new_params.app
+        )
+
+        pod_spec.with_service_account_name(new_params.service_account_name, overwrite=True)
+        pod_spec.automount_service_account_token = True
+        pod_spec.with_security_context(
             V1PodSecurityContext(run_as_user=0, fs_group=0), overwrite=True
         )
 
-        self.config.pod_spec_config.dns_config.searches.clear()
-        if self._service_name:
-            super().with_dns_search(
-                f"{self._service_name}.{self._namespace}.svc.cluster.local", overwrite=True
-            )
-        for search in self._dns_searches:
-            super().with_dns_search(search, overwrite=True)
-
+        self._ensure_container()
         container_config = find_container_config(
             self.config.pod_spec_config,
             self._container_name,
             default=None,
         )
-        if not container_config:
-            pod_config = get_config(self.config, PodSpecConfig)
-            pod_config.add_container(
-                ContainerConfig(
-                    name=self._container_name,
-                    image_pull_policy="IfNotPresent",
-                )
-            )
-            container_config = find_container_config(
-                self.config.pod_spec_config,
-                self._container_name,
-            )
 
-        if not container_config.resources:
-            container_config.with_resources(
-                V1ResourceRequirements(
-                    requests={"memory": "1Gi", "cpu": "500m"},
-                    limits={"memory": "4Gi", "cpu": "2000m"},
-                )
-            )
-
-        if self._debug:
-            container_config.with_env_var(
-                V1EnvVar(name="LOGGING_LEVEL", value="DEBUG"),
-                overwrite=True,
-            )
+        self._logoscore_dependencies["service_account"] = V1ServiceAccount(
+            api_version="v1",
+            kind="ServiceAccount",
+            metadata=V1ObjectMeta(
+                name=new_params.service_account_name, namespace=new_params.namespace
+            ),
+        )
+        self._logoscore_dependencies["roles"] = [
+            role(new_params.namespace, new_params.secret_creator_role_name)
+        ]
+        self._logoscore_dependencies["role_bindings"] = role_bindings(new_params)
 
         return self
 
-
-def service_account(namespace: str, service_account_name: str):
-    return V1ServiceAccount(
-        api_version="v1",
-        kind="ServiceAccount",
-        metadata=V1ObjectMeta(name=service_account_name, namespace=namespace),
-    )
+    def _get_dependencies(self):
+        base_dict = super()._get_dependencies()
+        base_dict["logoscore"] = self._logoscore_dependencies
+        return base_dict
 
 
 def role(namespace: str, role_name: str):
@@ -199,31 +228,24 @@ def role(namespace: str, role_name: str):
     )
 
 
-def role_bindings(
-    namespace: str,
-    service_account_name: str,
-    secret_creator_binding_name: str,
-    pod_service_reader_binding_name: str,
-    pod_service_reader_role_name: str,
-    secret_creator_role_name: str,
-):
+def role_bindings(params: LogoscoreParams):
     secret_role_binding = V1RoleBinding(
         api_version="rbac.authorization.k8s.io/v1",
         kind="RoleBinding",
         metadata=V1ObjectMeta(
-            name=secret_creator_binding_name,
-            namespace=namespace,
+            name=params.secret_creator_binding_name,
+            namespace=params.namespace,
         ),
         subjects=[
             RbacV1Subject(
                 kind="ServiceAccount",
-                name=service_account_name,
-                namespace=namespace,
+                name=params.service_account_name,
+                namespace=params.namespace,
             )
         ],
         role_ref=V1RoleRef(
             kind="Role",
-            name=secret_creator_role_name,
+            name=params.secret_creator_role_name,
             api_group="rbac.authorization.k8s.io",
         ),
     )
@@ -231,39 +253,20 @@ def role_bindings(
         api_version="rbac.authorization.k8s.io/v1",
         kind="RoleBinding",
         metadata=V1ObjectMeta(
-            name=pod_service_reader_binding_name,
-            namespace=namespace,
+            name=params.pod_service_reader_binding_name,
+            namespace=params.namespace,
         ),
         subjects=[
             RbacV1Subject(
                 kind="ServiceAccount",
-                name=service_account_name,
-                namespace=namespace,
+                name=params.service_account_name,
+                namespace=params.namespace,
             )
         ],
         role_ref=V1RoleRef(
             kind="Role",
-            name=pod_service_reader_role_name,
+            name=params.pod_service_reader_role_name,
             api_group="rbac.authorization.k8s.io",
         ),
     )
     return [secret_role_binding, role_binding]
-
-
-def service(namespace: str, service_name: str, app: str) -> V1Service:
-    return V1Service(
-        api_version="v1",
-        kind="Service",
-        metadata=V1ObjectMeta(name=service_name, namespace=namespace),
-        spec=V1ServiceSpec(
-            type="NodePort",
-            selector={"app": app},
-            ports=[
-                V1ServicePort(
-                    protocol="TCP",
-                    port=8000,
-                    target_port=8645,
-                )
-            ],
-        ),
-    )

--- a/src/deployments/logos_core/builders/tests/test_request_builder.py
+++ b/src/deployments/logos_core/builders/tests/test_request_builder.py
@@ -1,0 +1,23 @@
+import inspect
+from unittest.mock import Mock
+
+from src.deployments.logos_core.builders.request_builder import LogoscorePodApiRequester
+
+
+def _dummy_value_for_property(name: str):
+    if name == "debug":
+        return True
+    return object()
+
+
+def test_setters_call_reconcile():
+    obj = LogoscorePodApiRequester()
+    obj._reconcile = Mock(wraps=obj._reconcile)
+
+    for name, member in inspect.getmembers(type(obj), lambda x: isinstance(x, property)):
+        if member.fset is None:
+            # Read-only properties cannot be assigned to, so skip them.
+            continue
+
+        setattr(obj, name, _dummy_value_for_property(name))
+        obj._reconcile.assert_called_with(name)

--- a/src/deployments/logos_core/experiment.py
+++ b/src/deployments/logos_core/experiment.py
@@ -275,6 +275,20 @@ class LogosDeliveryExperiment(BaseExperiment[ExpConfig]):
         metadata["stack"]["container_name"] = self._container_name
         return metadata
 
+    async def deploy_all(self, deployment, exist_ok: bool = False):
+        if isinstance(deployment, dict):
+            for _, dep in deployment.items():
+                await self.deploy_all(dep)
+        elif isinstance(deployment, list):
+            for dep in deployment:
+                await self.deploy_all(dep)
+        else:
+            try:
+                await self.deploy(deployment=deployment, wait_for_ready=True)
+            except Exception as e:
+                # Ignore duplicate dependencies between bootstrap and relay
+                raise_unless_already_exists(e)
+
     async def _run(self):
         self.log_event("run_start")
         bootstrap_service = "core-bootstrap"
@@ -285,26 +299,17 @@ class LogosDeliveryExperiment(BaseExperiment[ExpConfig]):
         publisher_builder = (
             LogoscorePodApiRequester()
             .with_namespace(self.namespace)
+            .with_name(name="logoscore-requester")
+            .with_app(_LOGOSCORE_PUBLISHER["app"])
             .with_image(Image(repo="pearsonwhite/dst-lc-api", tag="wip-amd"))
             .with_mode("server")
             .with_service_account_name(service_account_name)
             .with_service_name(_LOGOSCORE_PUBLISHER["service_name"])
-            .with_logoscore_profile(
-                self.namespace, name="logoscore-requester", app=_LOGOSCORE_PUBLISHER["app"]
-            )
             .with_dns_search(f"{bootstrap_service}.{self.namespace}.svc.cluster.local")
             .with_dns_search(f"{relay_service}.{self.namespace}.svc.cluster.local")
+            .with_logoscore()
         )
-
-        dependencies = publisher_builder.build_dependencies()
-        for _name, dep_list in dependencies.items():
-            for dep in dep_list:
-                logger.info(f"Deploying dependency: {_name}")
-                logger.info(f"{dep.metadata.namespace}")
-                logger.info(f"{dep.metadata.name}")
-                logger.info(f"{type(dep.metadata)}")
-                await self.deploy(deployment=dep, wait_for_ready=True)
-
+        await self.deploy_all(publisher_builder.build_dependencies(), exist_ok=False)
         await self.deploy(deployment=publisher_builder.build(), wait_for_ready=True)
 
         bootstrap_nodes_builder = (
@@ -316,14 +321,7 @@ class LogosDeliveryExperiment(BaseExperiment[ExpConfig]):
             .with_dns_service([relay_service, bootstrap_service])
             .with_service_account_name(service_account_name)
         )
-        nodes_deps = bootstrap_nodes_builder.build_dependencies()
-        for _kind, deps in nodes_deps.items():
-            for dep in deps:
-                try:
-                    await self.deploy(deployment=dep, wait_for_ready=True)
-                except Exception as e:
-                    # Ignore duplicate dependencies between bootstrap and relay
-                    raise_unless_already_exists(e)
+        await self.deploy_all(bootstrap_nodes_builder.build_dependencies(), exist_ok=True)
         bootstrap_nodes = bootstrap_nodes_builder.build()
         await self.deploy(deployment=bootstrap_nodes, wait_for_ready=True)
         self._container_name = bootstrap_nodes.spec.template.spec.containers[0].name
@@ -358,14 +356,7 @@ class LogosDeliveryExperiment(BaseExperiment[ExpConfig]):
             .with_dns_service([relay_service, bootstrap_service])
             .with_service_account_name(service_account_name)
         )
-        nodes_deps = relay_nodes_builder.build_dependencies()
-        for _kind, deps in nodes_deps.items():
-            for dep in deps:
-                try:
-                    await self.deploy(deployment=dep, wait_for_ready=True)
-                except Exception as e:
-                    # Ignore duplicate dependencies between bootstrap and relay
-                    raise_unless_already_exists(e)
+        await self.deploy_all(relay_nodes_builder.build_dependencies(), exist_ok=True)
 
         self.log_event("init_relay_nodes")
         relay_nodes = relay_nodes_builder.build()

--- a/src/deployments/logos_core/experiment.py
+++ b/src/deployments/logos_core/experiment.py
@@ -3,8 +3,9 @@
 import asyncio
 import json
 import logging
+import random
 import traceback
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from kubernetes.dynamic.exceptions import ApiException
 from pydantic import BaseModel, ConfigDict, NonNegativeFloat, NonNegativeInt, PrivateAttr
@@ -31,12 +32,177 @@ class ExpConfig(BaseModel):
     num_messages: NonNegativeInt = 2
     delay_cold_start: NonNegativeFloat = 2
     delay_after_publish: NonNegativeFloat = 1
+    num_bootstrap_nodes: NonNegativeInt = 2
 
 
 _LOGOSCORE_PUBLISHER = {
     "service_name": "core-external",
     "app": "zerotenkay-core2",
 }
+
+
+def raise_unless_already_exists(e):
+    if not hasattr(e, "api_exceptions"):
+        raise e
+    all_already_exist = True
+    for api_exception in e.api_exceptions:
+        if isinstance(api_exception, ApiException):
+            if not (api_exception.status == 409 and api_exception.reason == "AlreadyExists"):
+                all_already_exist = False
+                break
+        else:
+            all_already_exist = False
+            return
+
+    if not all_already_exist:
+        raise e
+
+
+@experiment(name="core")
+class LogosDeliveryExperiment(BaseExperiment[ExpConfig]):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    bootstrap_service: str = "core-bootstrap"
+    relay_service: str = "core-relay"
+    service_account_name: str = "secret-creator2"
+    pod_container_name: str = "logoscore-0"  # All on shard 0. Eg. logoscore-0-0 logoscore-0-1
+
+    _container_name: Optional[str] = PrivateAttr(default=None)
+
+    @classmethod
+    def add_parser(cls, subparsers) -> None:
+        subparser = subparsers.add_parser(cls.name, help="nimlibp2p2 experiment")
+        BaseExperiment.add_args(subparser)
+
+    def _get_metadata(self) -> dict:
+        metadata = Bridge().get_metadata(self.events_log_path)
+        metadata["stack"]["container_name"] = self._container_name
+        return metadata
+
+    def build_publisher(self):
+        builder = (
+            LogoscorePodApiRequester()
+            .with_namespace(self.namespace)
+            .with_name("logoscore-requester")
+            .with_image(Image(repo="pearsonwhite/dst-lc-api", tag="wip-amd"))
+            .with_mode("server")
+            .with_service_account_name(self.service_account_name)
+            .with_service_name(_LOGOSCORE_PUBLISHER["service_name"])
+            .with_app(_LOGOSCORE_PUBLISHER["app"])
+            .with_logoscore()
+            .with_dns_search(f"{self.bootstrap_service}.{self.namespace}.svc.cluster.local")
+            .with_dns_search(f"{self.relay_service}.{self.namespace}.svc.cluster.local")
+        )
+        return {"pod": builder.build(), **builder.build_dependencies()}
+
+    def build_node_deployments(self, type: Literal["relay", "bootstrap"]):
+        if type == "relay":
+            name = "relay-nodes-0"
+            service = self.relay_service
+            replicas = self.config.num_relay_nodes
+        else:
+            name = "bootstrap-nodes-0"
+            service = self.bootstrap_service
+            replicas = self.config.num_bootstrap_nodes
+        builder = (
+            NodesBuilder()
+            .with_container_name(self.pod_container_name)
+            .with_config(namespace=self.namespace, name=name)
+            .with_service_name(service)
+            .with_replicas(replicas)
+            .with_dns_service([self.relay_service, self.bootstrap_service])
+            .with_service_account_name(self.service_account_name)
+        )
+        return {"stateful_set": builder.build(), **builder.build_dependencies()}
+
+    async def deploy_all(self, deployment, exist_ok: bool = False):
+        if isinstance(deployment, dict):
+            for _, dep in deployment.items():
+                await self.deploy_all(dep)
+        elif isinstance(deployment, list):
+            for dep in deployment:
+                await self.deploy_all(dep)
+        else:
+            try:
+                await self.deploy(deployment=deployment, wait_for_ready=True)
+            except Exception as e:
+                # Ignore duplicate dependencies between bootstrap and relay
+                raise_unless_already_exists(e)
+
+    async def _run(self):
+        self.log_event("run_start")
+
+        publisher_deployments = self.build_publisher()
+        publisher_pod = publisher_deployments["pod"]
+        del publisher_deployments["pod"]
+        publisher_deps = publisher_deployments
+        await self.deploy_all(publisher_deps, exist_ok=False)
+        await self.deploy(deployment=publisher_pod, wait_for_ready=True, exist_ok=True)
+
+        bootstrap_deployments = self.build_node_deployments("bootstrap")
+        bootstrap_ss = bootstrap_deployments["stateful_set"]
+        del bootstrap_deployments["stateful_set"]
+        await self.deploy_all(bootstrap_deployments, exist_ok=False)
+        await self.deploy(deployment=bootstrap_ss, exist_ok=True)
+
+        logger.info(f"Waiting for cold_start_delay: {self.config.delay_cold_start}")
+        await asyncio.sleep(self.config.delay_cold_start)
+
+        bootstrap_name = bootstrap_ss.metadata.name
+        self.log_event("init_bootstrap_nodes")
+        for index in range(self.config.num_bootstrap_nodes):
+            indexed_name = f"{bootstrap_name}-{index}"
+            try:
+                await init_token(self.namespace, indexed_name, self.bootstrap_service)
+            except Exception as e:
+                logger.error(f"e: {e}")
+            await init_node(self.namespace, indexed_name, self.bootstrap_service)
+
+        # Get bootstrap addresses
+        addresses = []
+        for index in range(self.config.num_bootstrap_nodes):
+            indexed_name = f"{bootstrap_name}-{index}"
+            address = await get_address(self.namespace, indexed_name, self.bootstrap_service)
+            addresses.append(address)
+        logger.info(f"Addresses {addresses}")
+
+        relay_deployments = self.build_node_deployments("relay")
+        relay_ss = relay_deployments["stateful_set"]
+        del relay_deployments["stateful_set"]
+        await self.deploy_all(relay_deployments, exist_ok=False)
+        await self.deploy(deployment=relay_ss, wait_for_ready=True)
+
+        self.log_event("init_relay_nodes")
+        relay_name = relay_ss.metadata.name
+        for index in range(self.config.num_relay_nodes):
+            indexed_name = f"{relay_name}-{index}"
+            try:
+                await init_token(self.namespace, indexed_name, self.relay_service)
+            except Exception as e:
+                logger.error(f"e: {e}")
+            await init_node(self.namespace, indexed_name, self.relay_service, addresses)
+
+        for name, service in zip(
+            [bootstrap_name, relay_name], [self.bootstrap_service, self.relay_service]
+        ):
+            for index in range(self.config.num_relay_nodes):
+                indexed_name = f"{name}-{index}"
+                await start_node(self.namespace, indexed_name, service)
+
+        topic = "/my-app/1/dst/proto"
+        for index in range(self.config.num_relay_nodes):
+            indexed_name = f"{relay_name}-{index}"
+            await subscribe(self.namespace, indexed_name, self.relay_service, topic)
+
+        message = "aGVsbG8="  # Test message
+        for _message_index in range(self.config.num_messages):
+            index = random.randrange(0, self.config.num_relay_nodes)
+            indexed_name = f"{relay_name}-{index}"
+            await send(self.namespace, indexed_name, self.relay_service, topic, message)
+
+        await asyncio.sleep(20)
+        self.log_event("publisher_wait_finished")
+        self.log_event("internal_run_finished")
 
 
 async def send(namespace, name_with_index, service_name, topic, message):
@@ -240,153 +406,3 @@ async def init_token(namespace, name_with_index, service_name):
         logger.error(f"PodApiError: {e} {traceback.format_exc()}")
     except Exception as e:
         logger.error(f"Other exception: {e} {traceback.format_exc()}")
-
-
-def raise_unless_already_exists(e):
-    if not hasattr(e, "api_exceptions"):
-        raise e
-    all_already_exist = True
-    for api_exception in e.api_exceptions:
-        if isinstance(api_exception, ApiException):
-            if not (api_exception.status == 409 and api_exception.reason == "AlreadyExists"):
-                all_already_exist = False
-                break
-        else:
-            all_already_exist = False
-            return
-
-    if not all_already_exist:
-        raise e
-
-
-@experiment(name="core")
-class LogosDeliveryExperiment(BaseExperiment[ExpConfig]):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    _container_name: Optional[str] = PrivateAttr(default=None)
-
-    @classmethod
-    def add_parser(cls, subparsers) -> None:
-        subparser = subparsers.add_parser(cls.name, help="nimlibp2p2 experiment")
-        BaseExperiment.add_args(subparser)
-
-    def _get_metadata(self) -> dict:
-        metadata = Bridge().get_metadata(self.events_log_path)
-        metadata["stack"]["container_name"] = self._container_name
-        return metadata
-
-    async def deploy_all(self, deployment, exist_ok: bool = False):
-        if isinstance(deployment, dict):
-            for _, dep in deployment.items():
-                await self.deploy_all(dep)
-        elif isinstance(deployment, list):
-            for dep in deployment:
-                await self.deploy_all(dep)
-        else:
-            try:
-                await self.deploy(deployment=deployment, wait_for_ready=True)
-            except Exception as e:
-                # Ignore duplicate dependencies between bootstrap and relay
-                raise_unless_already_exists(e)
-
-    async def _run(self):
-        self.log_event("run_start")
-        bootstrap_service = "core-bootstrap"
-        relay_service = "core-relay"
-        service_account_name = "secret-creator2"
-        pod_container_name = "logoscore-0"  # All on shard 0. Eg. logoscore-0-0 logoscore-0-1
-
-        publisher_builder = (
-            LogoscorePodApiRequester()
-            .with_namespace(self.namespace)
-            .with_name(name="logoscore-requester")
-            .with_app(_LOGOSCORE_PUBLISHER["app"])
-            .with_image(Image(repo="pearsonwhite/dst-lc-api", tag="wip-amd"))
-            .with_mode("server")
-            .with_service_account_name(service_account_name)
-            .with_service_name(_LOGOSCORE_PUBLISHER["service_name"])
-            .with_dns_search(f"{bootstrap_service}.{self.namespace}.svc.cluster.local")
-            .with_dns_search(f"{relay_service}.{self.namespace}.svc.cluster.local")
-            .with_logoscore()
-        )
-        await self.deploy_all(publisher_builder.build_dependencies(), exist_ok=False)
-        await self.deploy(deployment=publisher_builder.build(), wait_for_ready=True)
-
-        bootstrap_nodes_builder = (
-            NodesBuilder()
-            .with_container_name(pod_container_name)
-            .with_config(namespace=self.namespace, name="bootstrap-nodes-0")
-            .with_service_name(bootstrap_service)
-            .with_replicas(self.config.num_relay_nodes)
-            .with_dns_service([relay_service, bootstrap_service])
-            .with_service_account_name(service_account_name)
-        )
-        await self.deploy_all(bootstrap_nodes_builder.build_dependencies(), exist_ok=True)
-        bootstrap_nodes = bootstrap_nodes_builder.build()
-        await self.deploy(deployment=bootstrap_nodes, wait_for_ready=True)
-        self._container_name = bootstrap_nodes.spec.template.spec.containers[0].name
-
-        logger.info(f"Waiting for cold_start_delay: {self.config.delay_cold_start}")
-        await asyncio.sleep(self.config.delay_cold_start)
-
-        bootstrap_name = bootstrap_nodes.metadata.name
-        self.log_event("init_bootstrap_nodes")
-        for index in range(self.config.num_relay_nodes):
-            indexed_name = f"{bootstrap_name}-{index}"
-            try:
-                await init_token(self.namespace, indexed_name, bootstrap_service)
-            except Exception as e:
-                logger.error(f"e: {e}")
-            await init_node(self.namespace, indexed_name, bootstrap_service)
-
-        # Get bootstrap ENRs
-        addresses = []
-        for index in range(self.config.num_relay_nodes):
-            indexed_name = f"{bootstrap_name}-{index}"
-            address = await get_address(self.namespace, indexed_name, bootstrap_service)
-            addresses.append(address)
-        logger.info(f"Addresses {addresses}")
-
-        relay_nodes_builder = (
-            NodesBuilder()
-            .with_container_name(pod_container_name)
-            .with_config(namespace=self.namespace, name="relay-nodes-0")
-            .with_service_name(relay_service)
-            .with_replicas(self.config.num_relay_nodes)
-            .with_dns_service([relay_service, bootstrap_service])
-            .with_service_account_name(service_account_name)
-        )
-        await self.deploy_all(relay_nodes_builder.build_dependencies(), exist_ok=True)
-
-        self.log_event("init_relay_nodes")
-        relay_nodes = relay_nodes_builder.build()
-        relay_name = relay_nodes.metadata.name
-        await self.deploy(deployment=relay_nodes, wait_for_ready=True)
-        for index in range(self.config.num_relay_nodes):
-            indexed_name = f"{relay_name}-{index}"
-            try:
-                await init_token(self.namespace, indexed_name, relay_service)
-            except Exception as e:
-                logger.error(f"e: {e}")
-            await init_node(self.namespace, indexed_name, relay_service, addresses)
-
-        for name, service in zip([bootstrap_name, relay_name], [bootstrap_service, relay_service]):
-            for index in range(self.config.num_relay_nodes):
-                indexed_name = f"{name}-{index}"
-                await start_node(self.namespace, indexed_name, service)
-
-        topic = "/my-app/1/dst/proto"
-        for index in range(self.config.num_relay_nodes):
-            indexed_name = f"{relay_name}-{index}"
-            await subscribe(self.namespace, indexed_name, relay_service, topic)
-
-        message = "aGVsbG8="  # Test message
-        for _message_index in range(self.config.num_messages):
-            # index = random.randrange(0, self.config.num_nodes)
-            index = _message_index
-            indexed_name = f"{relay_name}-{index}"
-            await send(self.namespace, indexed_name, relay_service, topic, message)
-
-        await asyncio.sleep(20)
-        self.log_event("publisher_wait_finished")
-        self.log_event("internal_run_finished")

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/api-requester-config.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/api-requester-config.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    targets:
+      - name: firstClients
+        service: zerotesting-lightpush-client
+        name_template: "^client-0-(1[0-2]|[0-9])$"
+        stateful_set: "client-0"
+
+      - name: jswakuClients
+        service: zerotesting-lightpush-client
+        stateful_set: "client-0"
+        port: 8080
+
+      - name: nwakuClients
+        service: zerotesting-lightpush-client
+        stateful_set: "client-0"
+        port: 8645
+
+    endpoints:
+      - name: set-debug
+        headers: {"accept": "text/plain"}
+        params: {"logLevel": "DEBUG"}
+        url: "http://{node}/admin/v1/log-level/DEBUG"
+        type: "POST"
+        paged: False
+
+      - name: lightpush-publish-static-sharding
+        url: "http://{node}:{port}/lightpush/v3/message"
+        headers: {"Content-Type": "application/json"}
+        params: {"pubsubTopic": "/waku/2/rs/2/0",   "message": {"contentTopic": "/test/1/cross-network/proto", "payload": "W1EsIDIsIDNd"}}
+        type: "POST"
+        paged: False
+
+      - name: lightpush-publish-auto-sharding
+        url: "http://{node}:{port}/lightpush/v3/message"
+        headers: {"Content-Type": "application/json"}
+        params: { "pubsubTopic":"",   "message": {"contentTopic": "/test/1/cross-network/proto", "payload" : "W1EsIDIsIDNd"}}
+        type: "POST"
+        paged: False
+
+      - name: waku-relay-publish
+        url: "http://{node}:{port}/relay/v1/messages/%2Fwaku%2F2%2Frs%2F2%2F0"
+        headers: {"Content-Type": "application/json"}
+        params: {"payload": "38KKa5Ilr4Igjw", "contentTopic": "/my-app/1/dst/proto", "version": 1}
+        type: "POST"
+        paged: False
+
+      - name: libp2p-dst-node-publish
+        url: "http://{node}:{port}/publish"
+        headers: {"Content-Type": "application/json"}
+        params: {"topic": "test", "msgSize": 1000, "version": 1}
+        type: "POST"
+        paged: False
+
+    requests:
+      - name: publish-request
+        endpoint: lightpush-publish-static-sharding
+        retries: 0
+        retry_delay: 0.3
+
+    actions:
+      - name: publish-to-clients-random
+        requests: ["publish-request"]
+        targets: ["nwakuClients"]
+        pod_start_index: 0
+        pod_count: 91
+        order: ascending
+        loop_order: foreach_request_target_each_pod
+kind: ConfigMap
+metadata:
+  name: api-requester-config
+  namespace: zerotesting-pwhite

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/api-requester-config.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/api-requester-config.yaml
@@ -70,4 +70,4 @@ data:
 kind: ConfigMap
 metadata:
   name: api-requester-config
-  namespace: zerotesting-pwhite
+  namespace: ns

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/bootstrap-nodes-0.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/bootstrap-nodes-0.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: bootstrap-nodes-0
-  namespace: zerotesting-pwhite
+  namespace: ns
 spec:
   replicas: 5
   selector:
@@ -14,7 +14,7 @@ spec:
       labels:
         app: zerotenkay-core
       name: bootstrap-nodes-0
-      namespace: zerotesting-pwhite
+      namespace: ns
     spec:
       containers:
         - env:
@@ -42,6 +42,6 @@ spec:
               cpu: 500m
       dnsConfig:
         searches:
-          - core-relay.zerotesting-pwhite.svc.cluster.local
-          - core-bootstrap.zerotesting-pwhite.svc.cluster.local
+          - core-relay.ns.svc.cluster.local
+          - core-bootstrap.ns.svc.cluster.local
       serviceAccountName: secret-creator2

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/bootstrap-nodes-0.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/bootstrap-nodes-0.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: bootstrap-nodes-0
+  namespace: zerotesting-pwhite
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app: zerotenkay-core
+  serviceName: core-bootstrap
+  template:
+    metadata:
+      labels:
+        app: zerotenkay-core
+      name: bootstrap-nodes-0
+      namespace: zerotesting-pwhite
+    spec:
+      containers:
+        - env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+          image: pearsonwhite/dst-lc-node:wip3-amd
+          imagePullPolicy: IfNotPresent
+          name: logoscore-0
+          ports:
+            - containerPort: 8645
+            - containerPort: 8008
+            - containerPort: 8080
+          resources:
+            limits:
+              memory: 4Gi
+              cpu: 2000m
+            requests:
+              memory: 1Gi
+              cpu: 500m
+      dnsConfig:
+        searches:
+          - core-relay.zerotesting-pwhite.svc.cluster.local
+          - core-bootstrap.zerotesting-pwhite.svc.cluster.local
+      serviceAccountName: secret-creator2

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/core-bootstrap.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/core-bootstrap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: core-bootstrap
-  namespace: zerotesting-pwhite
+  namespace: ns
 spec:
   clusterIP: None
   ports:

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/core-bootstrap.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/core-bootstrap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: core-bootstrap
+  namespace: zerotesting-pwhite
+spec:
+  clusterIP: None
+  ports:
+    - name: main
+      port: 8645
+      targetPort: 8645
+  selector:
+    app: zerotenkay-core

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/core-external.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/core-external.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: core-external
+  namespace: zerotesting-pwhite
+spec:
+  ports:
+    - port: 8000
+      protocol: TCP
+      targetPort: 8645
+  selector:
+    app: zerotenkay-core2
+  type: NodePort

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/core-external.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/core-external.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: core-external
-  namespace: zerotesting-pwhite
+  namespace: ns
 spec:
   ports:
     - port: 8000

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/core-relay.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/core-relay.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: core-relay
-  namespace: zerotesting-pwhite
+  namespace: ns
 spec:
   clusterIP: None
   ports:

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/core-relay.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/core-relay.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: core-relay
+  namespace: zerotesting-pwhite
+spec:
+  clusterIP: None
+  ports:
+    - name: main
+      port: 8645
+      targetPort: 8645
+  selector:
+    app: zerotenkay-core

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/logoscore-requester.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/logoscore-requester.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: zerotenkay-core2
+  name: logoscore-requester
+  namespace: zerotesting-pwhite
+spec:
+  automountServiceAccountToken: true
+  containers:
+    - command:
+        - sh
+        - -c
+        - |
+          python /app/api_requester.py --mode=server --config=/mount/config.yaml
+      image: pearsonwhite/dst-lc-api:wip-amd
+      imagePullPolicy: Always
+      name: pod-api-requester-container
+      ports:
+        - containerPort: 8645
+        - containerPort: 8008
+        - containerPort: 8080
+      resources:
+        limits:
+          memory: 4Gi
+          cpu: 2000m
+        requests:
+          memory: 1Gi
+          cpu: 500m
+      volumeMounts:
+        - mountPath: /mount
+          name: api-requester-config-volume
+  dnsConfig:
+    searches:
+      - core-external.zerotesting-pwhite.svc.cluster.local
+      - core-bootstrap.zerotesting-pwhite.svc.cluster.local
+      - core-relay.zerotesting-pwhite.svc.cluster.local
+  securityContext:
+    fsGroup: 0
+    runAsUser: 0
+  serviceAccountName: secret-creator2
+  volumes:
+    - configMap:
+        name: api-requester-config
+      name: api-requester-config-volume

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/logoscore-requester.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/logoscore-requester.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: zerotenkay-core2
   name: logoscore-requester
-  namespace: zerotesting-pwhite
+  namespace: ns
 spec:
   automountServiceAccountToken: true
   containers:
@@ -32,9 +32,9 @@ spec:
           name: api-requester-config-volume
   dnsConfig:
     searches:
-      - core-external.zerotesting-pwhite.svc.cluster.local
-      - core-bootstrap.zerotesting-pwhite.svc.cluster.local
-      - core-relay.zerotesting-pwhite.svc.cluster.local
+      - core-external.ns.svc.cluster.local
+      - core-bootstrap.ns.svc.cluster.local
+      - core-relay.ns.svc.cluster.local
   securityContext:
     fsGroup: 0
     runAsUser: 0

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/pod-service-reader-binding-logoscore2.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/pod-service-reader-binding-logoscore2.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-service-reader-binding-logoscore2
+  namespace: zerotesting-pwhite
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-service-reader
+subjects:
+  - kind: ServiceAccount
+    name: secret-creator2
+    namespace: zerotesting-pwhite

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/pod-service-reader-binding-logoscore2.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/pod-service-reader-binding-logoscore2.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: pod-service-reader-binding-logoscore2
-  namespace: zerotesting-pwhite
+  namespace: ns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -10,4 +10,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: secret-creator2
-    namespace: zerotesting-pwhite
+    namespace: ns

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/pod-service-reader-binding.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/pod-service-reader-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-service-reader-binding
+  namespace: zerotesting-pwhite
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-service-reader
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: zerotesting-pwhite

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/pod-service-reader-binding.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/pod-service-reader-binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: pod-service-reader-binding
-  namespace: zerotesting-pwhite
+  namespace: ns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -10,4 +10,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: default
-    namespace: zerotesting-pwhite
+    namespace: ns

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/pod-service-reader.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/pod-service-reader.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-service-reader
+  namespace: zerotesting-pwhite
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/pod-service-reader.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/pod-service-reader.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: pod-service-reader
-  namespace: zerotesting-pwhite
+  namespace: ns
 rules:
   - apiGroups:
       - ''

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/relay-nodes-0.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/relay-nodes-0.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: relay-nodes-0
-  namespace: zerotesting-pwhite
+  namespace: ns
 spec:
   replicas: 100
   selector:
@@ -14,7 +14,7 @@ spec:
       labels:
         app: zerotenkay-core
       name: relay-nodes-0
-      namespace: zerotesting-pwhite
+      namespace: ns
     spec:
       containers:
         - env:
@@ -42,6 +42,6 @@ spec:
               cpu: 500m
       dnsConfig:
         searches:
-          - core-relay.zerotesting-pwhite.svc.cluster.local
-          - core-bootstrap.zerotesting-pwhite.svc.cluster.local
+          - core-relay.ns.svc.cluster.local
+          - core-bootstrap.ns.svc.cluster.local
       serviceAccountName: secret-creator2

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/relay-nodes-0.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/relay-nodes-0.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: relay-nodes-0
+  namespace: zerotesting-pwhite
+spec:
+  replicas: 100
+  selector:
+    matchLabels:
+      app: zerotenkay-core
+  serviceName: core-relay
+  template:
+    metadata:
+      labels:
+        app: zerotenkay-core
+      name: relay-nodes-0
+      namespace: zerotesting-pwhite
+    spec:
+      containers:
+        - env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+          image: pearsonwhite/dst-lc-node:wip3-amd
+          imagePullPolicy: IfNotPresent
+          name: logoscore-0
+          ports:
+            - containerPort: 8645
+            - containerPort: 8008
+            - containerPort: 8080
+          resources:
+            limits:
+              memory: 4Gi
+              cpu: 2000m
+            requests:
+              memory: 1Gi
+              cpu: 500m
+      dnsConfig:
+        searches:
+          - core-relay.zerotesting-pwhite.svc.cluster.local
+          - core-bootstrap.zerotesting-pwhite.svc.cluster.local
+      serviceAccountName: secret-creator2

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/secret-creator-binding2.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/secret-creator-binding2.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: secret-creator-binding2
+  namespace: zerotesting-pwhite
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: secret-creator-role2
+subjects:
+  - kind: ServiceAccount
+    name: secret-creator2
+    namespace: zerotesting-pwhite

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/secret-creator-binding2.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/secret-creator-binding2.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: secret-creator-binding2
-  namespace: zerotesting-pwhite
+  namespace: ns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -10,4 +10,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: secret-creator2
-    namespace: zerotesting-pwhite
+    namespace: ns

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/secret-creator-role2.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/secret-creator-role2.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-creator-role2
+  namespace: zerotesting-pwhite
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - create
+      - get
+      - update

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/secret-creator-role2.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/secret-creator-role2.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: secret-creator-role2
-  namespace: zerotesting-pwhite
+  namespace: ns
 rules:
   - apiGroups:
       - ''

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/secret-creator2.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/secret-creator2.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: secret-creator2
-  namespace: zerotesting-pwhite
+  namespace: ns

--- a/src/deployments/logos_core/tests/data/cases/case_1/expected/secret-creator2.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/expected/secret-creator2.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: secret-creator2
+  namespace: zerotesting-pwhite

--- a/src/deployments/logos_core/tests/data/cases/case_1/input.yaml
+++ b/src/deployments/logos_core/tests/data/cases/case_1/input.yaml
@@ -1,0 +1,5 @@
+num_relay_nodes: 100
+num_messages: 20
+delay_cold_start: 60
+delay_after_publish: 0.25
+num_bootstrap_nodes: 5

--- a/src/deployments/logos_core/tests/data/cases/default/expected/api-requester-config.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/api-requester-config.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    targets:
+      - name: firstClients
+        service: zerotesting-lightpush-client
+        name_template: "^client-0-(1[0-2]|[0-9])$"
+        stateful_set: "client-0"
+
+      - name: jswakuClients
+        service: zerotesting-lightpush-client
+        stateful_set: "client-0"
+        port: 8080
+
+      - name: nwakuClients
+        service: zerotesting-lightpush-client
+        stateful_set: "client-0"
+        port: 8645
+
+    endpoints:
+      - name: set-debug
+        headers: {"accept": "text/plain"}
+        params: {"logLevel": "DEBUG"}
+        url: "http://{node}/admin/v1/log-level/DEBUG"
+        type: "POST"
+        paged: False
+
+      - name: lightpush-publish-static-sharding
+        url: "http://{node}:{port}/lightpush/v3/message"
+        headers: {"Content-Type": "application/json"}
+        params: {"pubsubTopic": "/waku/2/rs/2/0",   "message": {"contentTopic": "/test/1/cross-network/proto", "payload": "W1EsIDIsIDNd"}}
+        type: "POST"
+        paged: False
+
+      - name: lightpush-publish-auto-sharding
+        url: "http://{node}:{port}/lightpush/v3/message"
+        headers: {"Content-Type": "application/json"}
+        params: { "pubsubTopic":"",   "message": {"contentTopic": "/test/1/cross-network/proto", "payload" : "W1EsIDIsIDNd"}}
+        type: "POST"
+        paged: False
+
+      - name: waku-relay-publish
+        url: "http://{node}:{port}/relay/v1/messages/%2Fwaku%2F2%2Frs%2F2%2F0"
+        headers: {"Content-Type": "application/json"}
+        params: {"payload": "38KKa5Ilr4Igjw", "contentTopic": "/my-app/1/dst/proto", "version": 1}
+        type: "POST"
+        paged: False
+
+      - name: libp2p-dst-node-publish
+        url: "http://{node}:{port}/publish"
+        headers: {"Content-Type": "application/json"}
+        params: {"topic": "test", "msgSize": 1000, "version": 1}
+        type: "POST"
+        paged: False
+
+    requests:
+      - name: publish-request
+        endpoint: lightpush-publish-static-sharding
+        retries: 0
+        retry_delay: 0.3
+
+    actions:
+      - name: publish-to-clients-random
+        requests: ["publish-request"]
+        targets: ["nwakuClients"]
+        pod_start_index: 0
+        pod_count: 91
+        order: ascending
+        loop_order: foreach_request_target_each_pod
+kind: ConfigMap
+metadata:
+  name: api-requester-config
+  namespace: zerotesting-pwhite

--- a/src/deployments/logos_core/tests/data/cases/default/expected/api-requester-config.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/api-requester-config.yaml
@@ -70,4 +70,4 @@ data:
 kind: ConfigMap
 metadata:
   name: api-requester-config
-  namespace: zerotesting-pwhite
+  namespace: ns

--- a/src/deployments/logos_core/tests/data/cases/default/expected/bootstrap-nodes-0.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/bootstrap-nodes-0.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: bootstrap-nodes-0
-  namespace: zerotesting-pwhite
+  namespace: ns
 spec:
   replicas: 2
   selector:
@@ -14,7 +14,7 @@ spec:
       labels:
         app: zerotenkay-core
       name: bootstrap-nodes-0
-      namespace: zerotesting-pwhite
+      namespace: ns
     spec:
       containers:
         - env:
@@ -42,6 +42,6 @@ spec:
               cpu: 500m
       dnsConfig:
         searches:
-          - core-relay.zerotesting-pwhite.svc.cluster.local
-          - core-bootstrap.zerotesting-pwhite.svc.cluster.local
+          - core-relay.ns.svc.cluster.local
+          - core-bootstrap.ns.svc.cluster.local
       serviceAccountName: secret-creator2

--- a/src/deployments/logos_core/tests/data/cases/default/expected/bootstrap-nodes-0.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/bootstrap-nodes-0.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: bootstrap-nodes-0
+  namespace: zerotesting-pwhite
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: zerotenkay-core
+  serviceName: core-bootstrap
+  template:
+    metadata:
+      labels:
+        app: zerotenkay-core
+      name: bootstrap-nodes-0
+      namespace: zerotesting-pwhite
+    spec:
+      containers:
+        - env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+          image: pearsonwhite/dst-lc-node:wip3-amd
+          imagePullPolicy: IfNotPresent
+          name: logoscore-0
+          ports:
+            - containerPort: 8645
+            - containerPort: 8008
+            - containerPort: 8080
+          resources:
+            limits:
+              memory: 4Gi
+              cpu: 2000m
+            requests:
+              memory: 1Gi
+              cpu: 500m
+      dnsConfig:
+        searches:
+          - core-relay.zerotesting-pwhite.svc.cluster.local
+          - core-bootstrap.zerotesting-pwhite.svc.cluster.local
+      serviceAccountName: secret-creator2

--- a/src/deployments/logos_core/tests/data/cases/default/expected/core-bootstrap.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/core-bootstrap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: core-bootstrap
-  namespace: zerotesting-pwhite
+  namespace: ns
 spec:
   clusterIP: None
   ports:

--- a/src/deployments/logos_core/tests/data/cases/default/expected/core-bootstrap.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/core-bootstrap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: core-bootstrap
+  namespace: zerotesting-pwhite
+spec:
+  clusterIP: None
+  ports:
+    - name: main
+      port: 8645
+      targetPort: 8645
+  selector:
+    app: zerotenkay-core

--- a/src/deployments/logos_core/tests/data/cases/default/expected/core-external.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/core-external.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: core-external
+  namespace: zerotesting-pwhite
+spec:
+  ports:
+    - port: 8000
+      protocol: TCP
+      targetPort: 8645
+  selector:
+    app: zerotenkay-core2
+  type: NodePort

--- a/src/deployments/logos_core/tests/data/cases/default/expected/core-external.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/core-external.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: core-external
-  namespace: zerotesting-pwhite
+  namespace: ns
 spec:
   ports:
     - port: 8000

--- a/src/deployments/logos_core/tests/data/cases/default/expected/core-relay.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/core-relay.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: core-relay
-  namespace: zerotesting-pwhite
+  namespace: ns
 spec:
   clusterIP: None
   ports:

--- a/src/deployments/logos_core/tests/data/cases/default/expected/core-relay.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/core-relay.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: core-relay
+  namespace: zerotesting-pwhite
+spec:
+  clusterIP: None
+  ports:
+    - name: main
+      port: 8645
+      targetPort: 8645
+  selector:
+    app: zerotenkay-core

--- a/src/deployments/logos_core/tests/data/cases/default/expected/logoscore-requester.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/logoscore-requester.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: zerotenkay-core2
+  name: logoscore-requester
+  namespace: zerotesting-pwhite
+spec:
+  automountServiceAccountToken: true
+  containers:
+    - command:
+        - sh
+        - -c
+        - |
+          python /app/api_requester.py --mode=server --config=/mount/config.yaml
+      image: pearsonwhite/dst-lc-api:wip-amd
+      imagePullPolicy: Always
+      name: pod-api-requester-container
+      ports:
+        - containerPort: 8645
+        - containerPort: 8008
+        - containerPort: 8080
+      resources:
+        limits:
+          memory: 4Gi
+          cpu: 2000m
+        requests:
+          memory: 1Gi
+          cpu: 500m
+      volumeMounts:
+        - mountPath: /mount
+          name: api-requester-config-volume
+  dnsConfig:
+    searches:
+      - core-external.zerotesting-pwhite.svc.cluster.local
+      - core-bootstrap.zerotesting-pwhite.svc.cluster.local
+      - core-relay.zerotesting-pwhite.svc.cluster.local
+  securityContext:
+    fsGroup: 0
+    runAsUser: 0
+  serviceAccountName: secret-creator2
+  volumes:
+    - configMap:
+        name: api-requester-config
+      name: api-requester-config-volume

--- a/src/deployments/logos_core/tests/data/cases/default/expected/logoscore-requester.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/logoscore-requester.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: zerotenkay-core2
   name: logoscore-requester
-  namespace: zerotesting-pwhite
+  namespace: ns
 spec:
   automountServiceAccountToken: true
   containers:
@@ -32,9 +32,9 @@ spec:
           name: api-requester-config-volume
   dnsConfig:
     searches:
-      - core-external.zerotesting-pwhite.svc.cluster.local
-      - core-bootstrap.zerotesting-pwhite.svc.cluster.local
-      - core-relay.zerotesting-pwhite.svc.cluster.local
+      - core-external.ns.svc.cluster.local
+      - core-bootstrap.ns.svc.cluster.local
+      - core-relay.ns.svc.cluster.local
   securityContext:
     fsGroup: 0
     runAsUser: 0

--- a/src/deployments/logos_core/tests/data/cases/default/expected/pod-service-reader-binding-logoscore2.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/pod-service-reader-binding-logoscore2.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-service-reader-binding-logoscore2
+  namespace: zerotesting-pwhite
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-service-reader
+subjects:
+  - kind: ServiceAccount
+    name: secret-creator2
+    namespace: zerotesting-pwhite

--- a/src/deployments/logos_core/tests/data/cases/default/expected/pod-service-reader-binding-logoscore2.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/pod-service-reader-binding-logoscore2.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: pod-service-reader-binding-logoscore2
-  namespace: zerotesting-pwhite
+  namespace: ns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -10,4 +10,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: secret-creator2
-    namespace: zerotesting-pwhite
+    namespace: ns

--- a/src/deployments/logos_core/tests/data/cases/default/expected/pod-service-reader-binding.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/pod-service-reader-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-service-reader-binding
+  namespace: zerotesting-pwhite
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-service-reader
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: zerotesting-pwhite

--- a/src/deployments/logos_core/tests/data/cases/default/expected/pod-service-reader-binding.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/pod-service-reader-binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: pod-service-reader-binding
-  namespace: zerotesting-pwhite
+  namespace: ns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -10,4 +10,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: default
-    namespace: zerotesting-pwhite
+    namespace: ns

--- a/src/deployments/logos_core/tests/data/cases/default/expected/pod-service-reader.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/pod-service-reader.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-service-reader
+  namespace: zerotesting-pwhite
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch

--- a/src/deployments/logos_core/tests/data/cases/default/expected/pod-service-reader.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/pod-service-reader.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: pod-service-reader
-  namespace: zerotesting-pwhite
+  namespace: ns
 rules:
   - apiGroups:
       - ''

--- a/src/deployments/logos_core/tests/data/cases/default/expected/relay-nodes-0.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/relay-nodes-0.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: relay-nodes-0
-  namespace: zerotesting-pwhite
+  namespace: ns
 spec:
   replicas: 2
   selector:
@@ -14,7 +14,7 @@ spec:
       labels:
         app: zerotenkay-core
       name: relay-nodes-0
-      namespace: zerotesting-pwhite
+      namespace: ns
     spec:
       containers:
         - env:
@@ -42,6 +42,6 @@ spec:
               cpu: 500m
       dnsConfig:
         searches:
-          - core-relay.zerotesting-pwhite.svc.cluster.local
-          - core-bootstrap.zerotesting-pwhite.svc.cluster.local
+          - core-relay.ns.svc.cluster.local
+          - core-bootstrap.ns.svc.cluster.local
       serviceAccountName: secret-creator2

--- a/src/deployments/logos_core/tests/data/cases/default/expected/relay-nodes-0.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/relay-nodes-0.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: relay-nodes-0
+  namespace: zerotesting-pwhite
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: zerotenkay-core
+  serviceName: core-relay
+  template:
+    metadata:
+      labels:
+        app: zerotenkay-core
+      name: relay-nodes-0
+      namespace: zerotesting-pwhite
+    spec:
+      containers:
+        - env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+          image: pearsonwhite/dst-lc-node:wip3-amd
+          imagePullPolicy: IfNotPresent
+          name: logoscore-0
+          ports:
+            - containerPort: 8645
+            - containerPort: 8008
+            - containerPort: 8080
+          resources:
+            limits:
+              memory: 4Gi
+              cpu: 2000m
+            requests:
+              memory: 1Gi
+              cpu: 500m
+      dnsConfig:
+        searches:
+          - core-relay.zerotesting-pwhite.svc.cluster.local
+          - core-bootstrap.zerotesting-pwhite.svc.cluster.local
+      serviceAccountName: secret-creator2

--- a/src/deployments/logos_core/tests/data/cases/default/expected/secret-creator-binding2.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/secret-creator-binding2.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: secret-creator-binding2
+  namespace: zerotesting-pwhite
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: secret-creator-role2
+subjects:
+  - kind: ServiceAccount
+    name: secret-creator2
+    namespace: zerotesting-pwhite

--- a/src/deployments/logos_core/tests/data/cases/default/expected/secret-creator-binding2.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/secret-creator-binding2.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: secret-creator-binding2
-  namespace: zerotesting-pwhite
+  namespace: ns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -10,4 +10,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: secret-creator2
-    namespace: zerotesting-pwhite
+    namespace: ns

--- a/src/deployments/logos_core/tests/data/cases/default/expected/secret-creator-role2.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/secret-creator-role2.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-creator-role2
+  namespace: zerotesting-pwhite
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - create
+      - get
+      - update

--- a/src/deployments/logos_core/tests/data/cases/default/expected/secret-creator-role2.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/secret-creator-role2.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: secret-creator-role2
-  namespace: zerotesting-pwhite
+  namespace: ns
 rules:
   - apiGroups:
       - ''

--- a/src/deployments/logos_core/tests/data/cases/default/expected/secret-creator2.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/secret-creator2.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: secret-creator2
-  namespace: zerotesting-pwhite
+  namespace: ns

--- a/src/deployments/logos_core/tests/data/cases/default/expected/secret-creator2.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/expected/secret-creator2.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: secret-creator2
+  namespace: zerotesting-pwhite

--- a/src/deployments/logos_core/tests/data/cases/default/input.yaml
+++ b/src/deployments/logos_core/tests/data/cases/default/input.yaml
@@ -1,0 +1,5 @@
+num_relay_nodes: 2
+num_messages: 2
+delay_cold_start: 2
+delay_after_publish: 1
+num_bootstrap_nodes: 2

--- a/src/deployments/logos_core/tests/requester_data/base_case/api-requester-config.yaml
+++ b/src/deployments/logos_core/tests/requester_data/base_case/api-requester-config.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    targets:
+      - name: firstClients
+        service: zerotesting-lightpush-client
+        name_template: "^client-0-(1[0-2]|[0-9])$"
+        stateful_set: "client-0"
+
+      - name: jswakuClients
+        service: zerotesting-lightpush-client
+        stateful_set: "client-0"
+        port: 8080
+
+      - name: nwakuClients
+        service: zerotesting-lightpush-client
+        stateful_set: "client-0"
+        port: 8645
+
+    endpoints:
+      - name: set-debug
+        headers: {"accept": "text/plain"}
+        params: {"logLevel": "DEBUG"}
+        url: "http://{node}/admin/v1/log-level/DEBUG"
+        type: "POST"
+        paged: False
+
+      - name: lightpush-publish-static-sharding
+        url: "http://{node}:{port}/lightpush/v3/message"
+        headers: {"Content-Type": "application/json"}
+        params: {"pubsubTopic": "/waku/2/rs/2/0",   "message": {"contentTopic": "/test/1/cross-network/proto", "payload": "W1EsIDIsIDNd"}}
+        type: "POST"
+        paged: False
+
+      - name: lightpush-publish-auto-sharding
+        url: "http://{node}:{port}/lightpush/v3/message"
+        headers: {"Content-Type": "application/json"}
+        params: { "pubsubTopic":"",   "message": {"contentTopic": "/test/1/cross-network/proto", "payload" : "W1EsIDIsIDNd"}}
+        type: "POST"
+        paged: False
+
+      - name: waku-relay-publish
+        url: "http://{node}:{port}/relay/v1/messages/%2Fwaku%2F2%2Frs%2F2%2F0"
+        headers: {"Content-Type": "application/json"}
+        params: {"payload": "38KKa5Ilr4Igjw", "contentTopic": "/my-app/1/dst/proto", "version": 1}
+        type: "POST"
+        paged: False
+
+      - name: libp2p-dst-node-publish
+        url: "http://{node}:{port}/publish"
+        headers: {"Content-Type": "application/json"}
+        params: {"topic": "test", "msgSize": 1000, "version": 1}
+        type: "POST"
+        paged: False
+
+    requests:
+      - name: publish-request
+        endpoint: lightpush-publish-static-sharding
+        retries: 0
+        retry_delay: 0.3
+
+    actions:
+      - name: publish-to-clients-random
+        requests: ["publish-request"]
+        targets: ["nwakuClients"]
+        pod_start_index: 0
+        pod_count: 91
+        order: ascending
+        loop_order: foreach_request_target_each_pod
+kind: ConfigMap
+metadata:
+  name: api-requester-config
+  namespace: ns

--- a/src/deployments/logos_core/tests/requester_data/base_case/logoscore-requester.yaml
+++ b/src/deployments/logos_core/tests/requester_data/base_case/logoscore-requester.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: app
+  name: logoscore-requester
+  namespace: ns
+spec:
+  automountServiceAccountToken: true
+  containers:
+    - command:
+        - sh
+        - -c
+        - |
+          python /app/api_requester.py --mode=server --config=/mount/config.yaml
+      image: repo:tag
+      imagePullPolicy: Always
+      name: pod-api-requester-container
+      ports:
+        - containerPort: 8645
+        - containerPort: 8008
+        - containerPort: 8080
+      resources:
+        limits:
+          memory: 4Gi
+          cpu: 2000m
+        requests:
+          memory: 1Gi
+          cpu: 500m
+      volumeMounts:
+        - mountPath: /mount
+          name: api-requester-config-volume
+  dnsConfig:
+    searches:
+      - service-name.ns.svc.cluster.local
+  securityContext:
+    fsGroup: 0
+    runAsUser: 0
+  serviceAccountName: service-account-name
+  volumes:
+    - configMap:
+        name: api-requester-config
+      name: api-requester-config-volume

--- a/src/deployments/logos_core/tests/requester_data/base_case/pod-service-reader-binding-logoscore2.yaml
+++ b/src/deployments/logos_core/tests/requester_data/base_case/pod-service-reader-binding-logoscore2.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-service-reader-binding-logoscore2
+  namespace: ns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-service-reader
+subjects:
+  - kind: ServiceAccount
+    name: service-account-name
+    namespace: ns

--- a/src/deployments/logos_core/tests/requester_data/base_case/pod-service-reader-binding.yaml
+++ b/src/deployments/logos_core/tests/requester_data/base_case/pod-service-reader-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-service-reader-binding
+  namespace: ns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-service-reader
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: ns

--- a/src/deployments/logos_core/tests/requester_data/base_case/pod-service-reader.yaml
+++ b/src/deployments/logos_core/tests/requester_data/base_case/pod-service-reader.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-service-reader
+  namespace: ns
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch

--- a/src/deployments/logos_core/tests/requester_data/base_case/secret-creator-binding2.yaml
+++ b/src/deployments/logos_core/tests/requester_data/base_case/secret-creator-binding2.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: secret-creator-binding2
+  namespace: ns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: secret-creator-role2
+subjects:
+  - kind: ServiceAccount
+    name: service-account-name
+    namespace: ns

--- a/src/deployments/logos_core/tests/requester_data/base_case/secret-creator-role2.yaml
+++ b/src/deployments/logos_core/tests/requester_data/base_case/secret-creator-role2.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-creator-role2
+  namespace: ns
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - create
+      - get
+      - update

--- a/src/deployments/logos_core/tests/requester_data/base_case/service-account-name.yaml
+++ b/src/deployments/logos_core/tests/requester_data/base_case/service-account-name.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: service-account-name
+  namespace: ns

--- a/src/deployments/logos_core/tests/requester_data/base_case/service-name.yaml
+++ b/src/deployments/logos_core/tests/requester_data/base_case/service-name.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-name
+  namespace: ns
+spec:
+  ports:
+    - port: 8000
+      protocol: TCP
+      targetPort: 8645
+  selector:
+    app: app
+  type: NodePort

--- a/src/deployments/logos_core/tests/test_experiment.py
+++ b/src/deployments/logos_core/tests/test_experiment.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, List, Tuple
 from unittest.mock import Mock
 
 import pytest
@@ -19,16 +19,16 @@ def load_yaml(path: Path) -> Any:
         return yaml.safe_load(f)
 
 
-def load_expected_case(case_dir: Path) -> dict[str, Any]:
+def load_expected_case(case_dir: Path) -> List[Tuple[str, Any]]:
     expected_dir = case_dir / "expected"
     result: dict[str, Any] = {}
     for path in sorted(expected_dir.glob("*.yaml")):
         dict_obj = load_yaml(path)
         result[path.name] = dict_obj
-    return sorted(result)
+    return sorted(result.items())
 
 
-def collect_actual_resources(experiment: LogosDeliveryExperiment) -> dict[str, Any]:
+def collect_actual_resources(experiment: LogosDeliveryExperiment) -> List[Tuple[str, Any]]:
     deployments = flatten(
         [
             experiment.build_publisher(),
@@ -40,7 +40,7 @@ def collect_actual_resources(experiment: LogosDeliveryExperiment) -> dict[str, A
     for dep in deployments:
         name = dep.metadata.name
         result[f"{name}.yaml"] = k8s_obj_to_dict(dep)
-    return sorted(result)
+    return sorted(result.items())
 
 
 @pytest.mark.parametrize("case_name", ["default", "case_1"])

--- a/src/deployments/logos_core/tests/test_experiment.py
+++ b/src/deployments/logos_core/tests/test_experiment.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+import yaml
+
+from src.deployments.core.k8s_object import k8s_obj_to_dict
+from src.deployments.logos_core.experiment import ExpConfig, LogosDeliveryExperiment
+from src.deployments.utils.flatten import flatten
+
+TEST_DATA_DIR = Path(__file__).parent / "data"
+
+
+def load_yaml(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def load_expected_case(case_dir: Path) -> dict[str, Any]:
+    expected_dir = case_dir / "expected"
+    result: dict[str, Any] = {}
+    for path in sorted(expected_dir.glob("*.yaml")):
+        dict_obj = load_yaml(path)
+        result[path.name] = dict_obj
+    return sorted(result)
+
+
+def collect_actual_resources(experiment: LogosDeliveryExperiment) -> dict[str, Any]:
+    deployments = flatten(
+        [
+            experiment.build_publisher(),
+            experiment.build_node_deployments("bootstrap"),
+            experiment.build_node_deployments("relay"),
+        ]
+    )
+    result: dict[str, Any] = {}
+    for dep in deployments:
+        name = dep.metadata.name
+        result[f"{name}.yaml"] = k8s_obj_to_dict(dep)
+    return sorted(result)
+
+
+@pytest.mark.parametrize("case_name", ["default", "case_1"])
+def test_experiment_cases(case_name: str):
+    case_dir = TEST_DATA_DIR / "cases" / case_name
+    input_data = load_yaml(case_dir / "input.yaml")
+    exp_config = ExpConfig(**input_data)
+
+    experiment = LogosDeliveryExperiment.model_construct(
+        config=exp_config,
+        api_client=Mock(),
+        namespace="ns",
+    )
+
+    actual = collect_actual_resources(experiment)
+    expected = load_expected_case(case_dir)
+
+    assert expected == actual

--- a/src/deployments/logos_core/tests/test_request_builder.py
+++ b/src/deployments/logos_core/tests/test_request_builder.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import random
+from pathlib import Path
+from typing import Any, Callable, List, Tuple
+
+import pytest
+import yaml
+from kubernetes.client import V1Pod
+
+from src.deployments.core.configs.container import Image
+from src.deployments.core.k8s_object import k8s_obj_to_dict
+from src.deployments.logos_core.builders.request_builder import LogoscorePodApiRequester
+from src.deployments.utils.flatten import flatten
+
+TEST_DATA_DIR = Path(__file__).parent / "requester_data"
+
+
+def load_yaml(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def load_expected_case(case_dir: Path) -> List[Tuple[str, Any]]:
+    print(f"asdfasdfasdf: {case_dir}")
+    result: dict[str, Any] = {}
+    for path in sorted(case_dir.glob("*.yaml")):
+        dict_obj = load_yaml(path)
+        result[path.name] = dict_obj
+    return sorted(result.items())
+
+
+def get_deployments(builder: LogoscorePodApiRequester) -> List[Tuple[str, Any]]:
+    """Executes funcs, builds, and returns sorted list of (filename, dict)."""
+    deployments = flatten({"pod": builder.build(), **builder.build_dependencies()})
+    result: dict[str, Any] = {}
+    for dep in deployments:
+        name = dep.metadata.name
+        print(f"asdf {name} {type(dep)}")
+        result[f"{name}.yaml"] = k8s_obj_to_dict(dep)
+    return sorted(result.items())
+
+
+def check_deployments_outputs(case_name: str, builder: LogoscorePodApiRequester):
+    """
+    Core logic: Reads expected YAML for case/scenario, executes func_list,
+    and asserts they match.
+    """
+    expected_yaml_data = load_expected_case(TEST_DATA_DIR / case_name)
+    actual_yaml_data = get_deployments(builder)
+    assert expected_yaml_data == actual_yaml_data
+
+
+def get_scenarios(funcs: List[Callable]) -> List[pytest.ParamSpec]:
+    scenarios = []
+    scenarios.append(pytest.param(funcs, id="base_order"))
+    scenarios.append(pytest.param(list(reversed(funcs)), id="reversed_order"))
+    for seed in [7, 41, 227]:
+        shuffled_case = funcs.copy()
+        random.seed(seed)
+        random.shuffle(shuffled_case)
+        scenarios.append(pytest.param(shuffled_case, id=f"shuffled_seed_{seed}"))
+    return scenarios
+
+
+@pytest.mark.parametrize(
+    "func_list",
+    get_scenarios(
+        [
+            lambda builder: builder.with_namespace("ns"),
+            lambda builder: builder.with_name("logoscore-requester"),
+            lambda builder: builder.with_image(Image(repo="repo", tag="tag")),
+            lambda builder: builder.with_mode("server"),
+            lambda builder: builder.with_service_account_name("service-account-name"),
+            lambda builder: builder.with_service_name("service-name"),
+            lambda builder: builder.with_app("app"),
+            lambda builder: builder.with_logoscore(),
+        ]
+    ),
+)
+def test_order_independences(func_list):
+    builder = LogoscorePodApiRequester()
+    for fun in func_list:
+        fun(builder)
+
+    check_deployments_outputs("base_case", builder)
+
+
+def check_dns_config(deployment: V1Pod, expected_dns_config: List[str]):
+    deployment.spec.dns_config == expected_dns_config
+
+
+class TestDnsConfig:
+    """Test that custom dns_config searches are retained,
+    while the feature manages its own dns_config.
+
+    The order should be most recently called last.
+    """
+
+    search_1 = "bootstrap-service.ns.svc.cluster.local"
+    search_2 = "relay_service.ns.svc.cluster.local"
+    feature_search = "service-name.ns.svc.cluster.local"
+
+    def test_feature_first(self, base_builder):
+        pod = (
+            base_builder.with_logoscore()
+            .with_dns_search(self.search_1)
+            .with_dns_search(self.search_2)
+        ).build()
+        check_dns_config(pod, [self.feature_search, self.search_1, self.search_2])
+
+    def test_feature_last(self, base_builder):
+        pod = (
+            base_builder.with_dns_search(self.search_1)
+            .with_dns_search(self.search_2)
+            .with_logoscore()
+        ).build()
+        check_dns_config(pod, [self.search_1, self.search_2, self.feature_search])
+
+    def test_feature_both(self, base_builder):
+        pod = (
+            base_builder.with_logoscore()
+            .with_dns_search(self.search_1)
+            .with_dns_search(self.search_2, overwrite=True)
+            .with_logoscore()
+        ).build()
+        check_dns_config(pod, [self.search_1, self.search_2, self.feature_search])
+
+    def test_feature_multiple(self, base_builder):
+        pod = (
+            base_builder.with_dns_search(self.search_1, overwrite=True)
+            .with_dns_search(self.search_1, overwrite=True)
+            .with_logoscore()
+            .with_dns_search(self.search_2, overwrite=True)
+            .with_logoscore()
+            .with_dns_search(self.search_1, overwrite=True)
+        ).build()
+        check_dns_config(pod, [self.search_2, self.feature_search, self.search_1])
+
+
+class TestErrors:
+    """Test required fields are set before building the deployment."""
+
+    def test_no_namespace(self):
+        with pytest.raises(ValueError):
+            _pod = (
+                LogoscorePodApiRequester()
+                .with_name("logoscore-requester")
+                .with_logoscore()
+                .with_mode("server")
+                .build()
+            )
+
+    def test_no_mode(self):
+        _pod = (
+            LogoscorePodApiRequester()
+            .with_logoscore()
+            .with_namespace("ns")
+            .with_name("logoscore-requester")
+            .with_mode("server")
+            .build()
+        )
+
+
+@pytest.fixture()
+def base_builder() -> LogoscorePodApiRequester:
+    return (
+        LogoscorePodApiRequester()
+        .with_namespace("ns")
+        .with_name("logoscore-requester")
+        .with_image(Image(repo="repo", tag="tag"))
+        .with_mode("server")
+        .with_service_account_name("service-account-name")
+        .with_service_name("service-name")
+        .with_app("app")
+    )
+
+
+class TestServiceAccountName:
+    def test_after_feature(self, base_builder):
+        """Test that we have a default service account name."""
+        pod = (
+            base_builder.with_app("app")
+            .with_logoscore()
+            .with_service_account_name("custom-service-account")
+            .build()
+        )
+        pod.spec.service_account_name == "custom-service-account"
+
+    def test_after_feature(self, base_builder):
+        """Test that we can override default service account name."""
+        pod = (
+            base_builder.with_app("app")
+            .with_logoscore()
+            .with_service_account_name("custom-service-account")
+            .build()
+        )
+        pod.spec.service_account_name == "custom-service-account"
+
+    def test_before_feature(self, base_builder):
+        """Test that we can override default service account name."""
+        pod = (
+            base_builder.with_app("app")
+            .with_service_account_name("custom-service-account")
+            .with_logoscore()
+            .build()
+        )
+        pod.spec.service_account_name == "custom-service-account"
+
+    def test_multiple_calls(self, base_builder):
+        """Test that we can override default service account name."""
+        pod = (
+            base_builder.with_app("app")
+            .with_logoscore()
+            .with_service_account_name("custom-service-account")
+            .with_service_account_name("custom-service-account2")
+            .build()
+        )
+        pod.spec.service_account_name == "custom-service-account2"

--- a/src/deployments/logos_core/tests/test_request_builder.py
+++ b/src/deployments/logos_core/tests/test_request_builder.py
@@ -6,7 +6,6 @@ from typing import Any, Callable, List, Tuple
 
 import pytest
 import yaml
-from kubernetes.client import V1Pod
 
 from src.deployments.core.configs.container import Image
 from src.deployments.core.k8s_object import k8s_obj_to_dict
@@ -86,10 +85,6 @@ def test_order_independences(func_list):
     check_deployments_outputs("base_case", builder)
 
 
-def check_dns_config(deployment: V1Pod, expected_dns_config: List[str]):
-    deployment.spec.dns_config == expected_dns_config
-
-
 class TestDnsConfig:
     """Test that custom dns_config searches are retained,
     while the feature manages its own dns_config.
@@ -107,7 +102,7 @@ class TestDnsConfig:
             .with_dns_search(self.search_1)
             .with_dns_search(self.search_2)
         ).build()
-        check_dns_config(pod, [self.feature_search, self.search_1, self.search_2])
+        pod.spec.dns_config == [self.feature_search, self.search_1, self.search_2]
 
     def test_feature_last(self, base_builder):
         pod = (
@@ -115,7 +110,7 @@ class TestDnsConfig:
             .with_dns_search(self.search_2)
             .with_logoscore()
         ).build()
-        check_dns_config(pod, [self.search_1, self.search_2, self.feature_search])
+        pod.spec.dns_config == [self.search_1, self.search_2, self.feature_search]
 
     def test_feature_both(self, base_builder):
         pod = (
@@ -124,7 +119,7 @@ class TestDnsConfig:
             .with_dns_search(self.search_2, overwrite=True)
             .with_logoscore()
         ).build()
-        check_dns_config(pod, [self.search_1, self.search_2, self.feature_search])
+        pod.spec.dns_config == [self.search_1, self.search_2, self.feature_search]
 
     def test_feature_multiple(self, base_builder):
         pod = (
@@ -135,7 +130,7 @@ class TestDnsConfig:
             .with_logoscore()
             .with_dns_search(self.search_1, overwrite=True)
         ).build()
-        check_dns_config(pod, [self.search_2, self.feature_search, self.search_1])
+        pod.spec.dns_config == [self.search_2, self.feature_search, self.search_1]
 
 
 class TestErrors:
@@ -177,15 +172,10 @@ def base_builder() -> LogoscorePodApiRequester:
 
 
 class TestServiceAccountName:
-    def test_after_feature(self, base_builder):
+    def test_default(self, base_builder):
         """Test that we have a default service account name."""
-        pod = (
-            base_builder.with_app("app")
-            .with_logoscore()
-            .with_service_account_name("custom-service-account")
-            .build()
-        )
-        pod.spec.service_account_name == "custom-service-account"
+        pod = base_builder.with_app("app").with_logoscore().build()
+        pod.spec.service_account_name == "secret-creator2"
 
     def test_after_feature(self, base_builder):
         """Test that we can override default service account name."""

--- a/src/deployments/logos_core/tests/test_request_builder.py
+++ b/src/deployments/logos_core/tests/test_request_builder.py
@@ -102,7 +102,7 @@ class TestDnsConfig:
             .with_dns_search(self.search_1)
             .with_dns_search(self.search_2)
         ).build()
-        pod.spec.dns_config == [self.feature_search, self.search_1, self.search_2]
+        assert pod.spec.dns_config == [self.feature_search, self.search_1, self.search_2]
 
     def test_feature_last(self, base_builder):
         pod = (
@@ -110,7 +110,7 @@ class TestDnsConfig:
             .with_dns_search(self.search_2)
             .with_logoscore()
         ).build()
-        pod.spec.dns_config == [self.search_1, self.search_2, self.feature_search]
+        assert pod.spec.dns_config == [self.search_1, self.search_2, self.feature_search]
 
     def test_feature_both(self, base_builder):
         pod = (
@@ -119,7 +119,7 @@ class TestDnsConfig:
             .with_dns_search(self.search_2, overwrite=True)
             .with_logoscore()
         ).build()
-        pod.spec.dns_config == [self.search_1, self.search_2, self.feature_search]
+        assert pod.spec.dns_config == [self.search_1, self.search_2, self.feature_search]
 
     def test_feature_multiple(self, base_builder):
         pod = (
@@ -130,7 +130,7 @@ class TestDnsConfig:
             .with_logoscore()
             .with_dns_search(self.search_1, overwrite=True)
         ).build()
-        pod.spec.dns_config == [self.search_2, self.feature_search, self.search_1]
+        assert pod.spec.dns_config == [self.search_2, self.feature_search, self.search_1]
 
 
 class TestErrors:
@@ -175,7 +175,7 @@ class TestServiceAccountName:
     def test_default(self, base_builder):
         """Test that we have a default service account name."""
         pod = base_builder.with_app("app").with_logoscore().build()
-        pod.spec.service_account_name == "secret-creator2"
+        assert pod.spec.service_account_name == "secret-creator2"
 
     def test_after_feature(self, base_builder):
         """Test that we can override default service account name."""
@@ -185,7 +185,7 @@ class TestServiceAccountName:
             .with_service_account_name("custom-service-account")
             .build()
         )
-        pod.spec.service_account_name == "custom-service-account"
+        assert pod.spec.service_account_name == "custom-service-account"
 
     def test_before_feature(self, base_builder):
         """Test that we can override default service account name."""
@@ -195,7 +195,7 @@ class TestServiceAccountName:
             .with_logoscore()
             .build()
         )
-        pod.spec.service_account_name == "custom-service-account"
+        assert pod.spec.service_account_name == "custom-service-account"
 
     def test_multiple_calls(self, base_builder):
         """Test that we can override default service account name."""
@@ -206,4 +206,4 @@ class TestServiceAccountName:
             .with_service_account_name("custom-service-account2")
             .build()
         )
-        pod.spec.service_account_name == "custom-service-account2"
+        assert pod.spec.service_account_name == "custom-service-account2"

--- a/src/deployments/pod_api_requester/builder.py
+++ b/src/deployments/pod_api_requester/builder.py
@@ -1,12 +1,15 @@
-# Python Imports
+import logging
+from copy import deepcopy
+from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Literal, Optional, Self
+from typing import Dict, List, Literal, Optional, Self
 
 import yaml
 from kubernetes.client import (
     V1ConfigMap,
     V1ConfigMapVolumeSource,
     V1ContainerPort,
+    V1EnvVar,
     V1ObjectMeta,
     V1Pod,
     V1PodDNSConfig,
@@ -15,45 +18,184 @@ from kubernetes.client import (
     V1Role,
     V1RoleBinding,
     V1RoleRef,
-    V1Service,
     V1ServicePort,
-    V1ServiceSpec,
     V1Volume,
     V1VolumeMount,
 )
 from pydantic import PrivateAttr
 
-# Project Imports
-from src.deployments.core.builders import PodBuilder
-from src.deployments.core.configs.command import Command, CommandConfig, CommandNotFoundError
+from src.deployments.core.base_bridge import V1Deployable
+from src.deployments.core.builders import PodBuilder, ServiceBuilder
+from src.deployments.core.configs.command import Command, CommandConfig
 from src.deployments.core.configs.container import ContainerConfig, Image
 from src.deployments.core.configs.helpers.identity import apply_identity
 from src.deployments.core.configs.helpers.utils import find_container_config, get_config
-from src.deployments.core.configs.pod import PodConfig, PodSpecConfig
+from src.deployments.core.configs.pod import PodSpecConfig
 from src.deployments.core.k8s_object import dict_to_k8s_object
+from src.deployments.core.dependency_decorator import depends_on
 
-ScriptMode = Literal["server", "batch"]
+ScriptMode = Literal["server", "batch", "debug"]
+
+DEFAULT_REQUESTER_NAME = "publisher"
+DEFAULT_REQUESTER_APP = "zerotenkay-publisher"
+DEFAULT_REQUESTER_CONFIG_MAP_NAME = "api-requester-config"
+DEFAULT_REQUESTER_VOLUME_NAME = "api-requester-config-volume"
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RequesterBaseParams:
+    name: Optional[str] = None
+    namespace: Optional[str] = None
+    app: Optional[str] = None
+    mode: Optional[ScriptMode] = None
+    container_name: Optional[str] = None
+    image: Optional[Image] = None
+    service_name: Optional[str] = None
+    requester_base_enabled: Optional[bool] = None
+    requester_selector_app: Optional[str] = None
+    pod_service_reader_role_name: Optional[str] = None
+    pod_service_reader_binding_name: Optional[str] = None
 
 
 class PodApiRequesterBuilder(PodBuilder):
     _mode: Optional[ScriptMode] = None
-    """Sent to the --mode arg of the api-requester script.
-    This must be set through `with_mode` prior to building."""
 
+    _base_requester_params: Optional[RequesterBaseParams] = None
+
+    # TODO: move to base class
     _restart_policy: Optional[Literal["Always", "OnFailure", "Never"]] = None
-    """Restart policy for the pod (for batch mode)."""
 
     _container_name: str = PrivateAttr(default="pod-api-requester-container")
-    _namespace: Optional[str] = PrivateAttr(default=None)
-    _name: Optional[str] = PrivateAttr(default=None)
-    _app: Optional[str] = PrivateAttr(default=None)
-    _pod_service_reader_role_name: str = PrivateAttr(default="pod-service-reader")
-    _pod_service_reader_binding_name: str = PrivateAttr(default="pod-service-reader-binding")
     _image: Image = PrivateAttr(
         default_factory=lambda: Image(
             repo="pearsonwhite/pod-api-requester", tag="10b85bb60895fe63aa8d3f09b24b714f2abce300"
         )
     )
+    _service_name: str = PrivateAttr(default="zerotesting-publisher")
+
+    _requester_base_enabled: bool = PrivateAttr(default=False)
+    _requester_selector_app: Optional[str] = PrivateAttr(default="zerotenkay-publisher")
+    _pod_service_reader_role_name: Optional[str] = PrivateAttr(default="pod-service-reader")
+    _pod_service_reader_binding_name: Optional[str] = PrivateAttr(
+        default="pod-service-reader-binding"
+    )
+
+    def model_post_init(self, __context) -> None:
+        super().model_post_init(__context)
+
+        # Enabled by default. Base feature.
+        self._enable_requester_base()
+
+    @property
+    def service_name(self) -> Optional[str]:
+        return self._service_name
+
+    @service_name.setter
+    def service_name(self, value: Optional[str]) -> None:
+        self._service_name = value
+        self._reconcile("service_name")
+
+    def _enable_requester_base(self) -> None:
+        self._set_requester_defaults()
+        self._requester_base_enabled = True
+        self._reconcile("_requester_base_enabled")
+
+    def _set_requester_defaults(self) -> None:
+        if self.name is None:
+            self.name = DEFAULT_REQUESTER_NAME
+        if self.app is None:
+            self.app = DEFAULT_REQUESTER_APP
+
+    @depends_on(
+        "_requester_base_enabled",
+        "namespace",
+        "name",
+        "app",
+        "_container_name",
+        "_requester_selector_app",
+        "_pod_service_reader_role_name",
+        "_pod_service_reader_binding_name",
+        "_image",
+        "_mode",
+    )
+    def _apply_requester_base(self):
+        if not self._requester_base_enabled:
+            return self
+
+        new_params = _build_requester_base_params(self)
+        self._apply_requester_base_inner(
+            old_params=self._base_requester_params, new_params=new_params
+        )
+        self._base_requester_params = new_params
+        return self
+
+    def _apply_requester_base_inner(
+        self, old_params: RequesterBaseParams, new_params: RequesterBaseParams
+    ):
+        config = self.config
+
+        apply_identity(
+            config, name=new_params.name, namespace=new_params.namespace, app=new_params.app
+        )
+        pod_spec_config = config.pod_spec_config
+        pod_spec_config.dns_config = V1PodDNSConfig(
+            searches=[f"{new_params.service_name}.{new_params.namespace}.svc.cluster.local"]
+        )
+        pod_spec_config.with_volume(
+            V1Volume(
+                name=DEFAULT_REQUESTER_VOLUME_NAME,
+                config_map=V1ConfigMapVolumeSource(name=DEFAULT_REQUESTER_CONFIG_MAP_NAME),
+            ),
+            overwrite=True,
+        )
+
+        self._ensure_container()
+        container = find_container_config(config, new_params.container_name)
+        container.name = new_params.container_name
+        if not container.resources:
+            container.with_resources(
+                V1ResourceRequirements(
+                    requests={"memory": "1Gi", "cpu": "500m"},
+                    limits={"memory": "4Gi", "cpu": "2000m"},
+                )
+            )
+        container.with_image(image=new_params.image, overwrite=True)
+        container.image_pull_policy = "Always"
+        container.ports = [
+            V1ContainerPort(8645),
+            V1ContainerPort(8008),
+            V1ContainerPort(8080),
+        ]
+        container.with_volume_mount(
+            V1VolumeMount(name=DEFAULT_REQUESTER_VOLUME_NAME, mount_path="/mount"), overwrite=True
+        )
+        if new_params.mode == "debug":
+            container.with_env_var(
+                V1EnvVar(name="LOGGING_LEVEL", value="DEBUG"),
+                overwrite=True,
+            )
+
+        def command_from_mode(mode):
+            if mode == "debug":
+                return Command("sleep", args=["infinity"])
+            else:
+                return Command(
+                    command="python",
+                    args=[
+                        "/app/api_requester.py",
+                        ("--mode", mode),
+                        ("--config", "/mount/config.yaml"),
+                    ],
+                )
+
+        command_config = container.command_config
+        if old_params and old_params.mode:
+            old_command = command_from_mode(old_params.mode)
+            command_config.commands.remove(old_command)
+        new_command = command_from_mode(new_params.mode)
+        command_config.commands.append(new_command)
 
     def _ensure_container(self):
         container_config = find_container_config(self.config, self._container_name, default=None)
@@ -64,22 +206,43 @@ class PodApiRequesterBuilder(PodBuilder):
             )
 
     def with_container_name(self, container_name: str) -> Self:
-        self._ensure_container()
-        container_config = find_container_config(self.config, self._container_name)
         self._container_name = container_name
-        container_config.name = self._container_name
+        self._reconcile("_container_name")
         return self
 
     def with_image(self, image: Image) -> Self:
-        self._ensure_container()
         self._image = image
-        apply_pod_config(
-            namespace=self._namespace,
-            container_name=self._container_name,
-            image=self._image,
-            config=self.config,
+        self._reconcile("_image")
+        return self
+
+    def with_service_name(self, service_name: str) -> Self:
+        self.service_name = service_name
+        return self
+
+    def with_requester_selector_app(self, app: str) -> Self:
+        self.requester_selector_app = app
+        return self
+
+    def with_mode(self, mode: ScriptMode) -> Self:
+        self._mode = mode
+        self._reconcile("_mode")
+        return self
+
+    def with_command(self, command: str, args: List[str]) -> Self:
+        container_config = find_container_config(self.config.pod_spec_config, self._container_name)
+        container_config.command_config = CommandConfig(
+            commands=[Command(command=command, args=args)]
         )
         return self
+
+    def with_dns_search(self, search, *, overwrite: bool = False) -> Self:
+        self.config.pod_spec_config.with_dns_search(search, overwrite=overwrite)
+        self._reconcile("dns_search")
+        return self
+
+    def with_debug(self) -> Self:
+        self._mode = "debug"
+        return self.with_command("sleep", args=["infinity"])
 
     def build_role(self) -> V1Role:
         return V1Role(
@@ -87,7 +250,7 @@ class PodApiRequesterBuilder(PodBuilder):
             kind="Role",
             metadata=V1ObjectMeta(
                 name=self._pod_service_reader_role_name,
-                namespace=self.config.namespace,
+                namespace=self.namespace,
             ),
             rules=[
                 V1PolicyRule(
@@ -104,7 +267,7 @@ class PodApiRequesterBuilder(PodBuilder):
             kind="RoleBinding",
             metadata=V1ObjectMeta(
                 name=self._pod_service_reader_binding_name,
-                namespace=self.config.namespace,
+                namespace=self.namespace,
             ),
             role_ref=V1RoleRef(
                 kind="Role",
@@ -115,7 +278,7 @@ class PodApiRequesterBuilder(PodBuilder):
                 {
                     "kind": "ServiceAccount",
                     "name": "default",
-                    "namespace": self.config.namespace,
+                    "namespace": self.namespace,
                 },
             ],
         )
@@ -124,29 +287,11 @@ class PodApiRequesterBuilder(PodBuilder):
         with open(Path(__file__).parent / "config.yaml", "r") as config_file:
             config_dict = yaml.safe_load(config_file.read())
         config_map: V1ConfigMap = dict_to_k8s_object(config_dict, "V1ConfigMap")
-        config_map.metadata.namespace = self.config.namespace
+        config_map.metadata.namespace = self.namespace
         return config_map
 
-    def build_service(self) -> V1Service:
-        return V1Service(
-            api_version="v1",
-            kind="Service",
-            metadata=V1ObjectMeta(name="zerotesting-publisher", namespace=self.config.namespace),
-            spec=V1ServiceSpec(
-                type="NodePort",
-                selector={"app": "zerotenkay-publisher"},
-                ports=[
-                    V1ServicePort(
-                        protocol="TCP",
-                        port=8000,
-                        target_port=8645,
-                    )
-                ],
-            ),
-        )
-
     def build(self) -> V1Pod:
-        if not self.config.name:
+        if not self.name:
             raise ValueError(f"Must configure node first. Config: `{self.config}`")
         if not self._mode:
             raise ValueError(
@@ -155,159 +300,55 @@ class PodApiRequesterBuilder(PodBuilder):
 
         pod = super().build()
 
-        # Apply restart policy if set, or auto-set for batch mode
         if self._restart_policy:
             pod.spec.restart_policy = self._restart_policy
         elif self._mode == "batch":
-            # Batch mode should not restart on completion
             pod.spec.restart_policy = "Never"
 
         return pod
 
-    def with_image_override(self, image: Image) -> Self:
-        """Allow overriding the default publisher image."""
-        container = find_container_config(self.config.pod_spec_config, NAME)
-        container.with_image(image, overwrite=True)
-        return self
-
-    def with_restart_policy(self, policy: Literal["Always", "OnFailure", "Never"]) -> Self:
-        """Set pod restart policy (for batch mode, use 'Never')."""
-        self._restart_policy = policy
-        return self
-
-    def with_name(self, name: str) -> Self:
-        """Set pod name."""
-        self.config.name = name
-        return self
-
-    def with_config_map(self, configmap_name: str) -> Self:
-        """Set the ConfigMap name for the api-requester config."""
-        for volume in self.config.pod_spec_config.volumes:
-            if volume.name == "api-requester-config-volume":
-                volume.config_map = V1ConfigMapVolumeSource(name=configmap_name)
-                break
-        return self
-
-    def with_namespace(self, namespace: str) -> Self:
-        self._namespace = namespace
-        apply_identity(self.config, name=self._name, namespace=self._namespace, app=self._app)
-        self._ensure_container()
-        apply_pod_config(
-            namespace=namespace,
-            container_name=self._container_name,
-            image=self._image,
-            config=self.config,
-        )
-        return self
-
-    def with_mode(self, mode: ScriptMode) -> Self:
-        self._ensure_container()
-        container = find_container_config(self.config.pod_spec_config, self._container_name)
-        apply_command_config(container.command_config, mode=mode)
-        self._mode = mode
-        return self
-
-    def with_command(self, command: str, args: List[str]) -> Self:
-        container_config = find_container_config(self.config.pod_spec_config, self._container_name)
-        container_config.command_config = CommandConfig(
-            commands=[Command(command=command, args=args)]
-        )
-        return self
-
-    def with_dns_search(self, search, *, overwrite: bool = False) -> Self:
-        self.config.pod_spec_config.with_dns_service(search, overwrite=overwrite)
-        return self
-
-    def with_debug(self) -> Self:
-        self._mode = "debug"
-        return self.with_command("sleep", args=["infinity"])
+    def build_dependencies(self) -> Dict[str, V1Deployable]:
+        self.dependencies = self._get_dependencies()
+        return deepcopy(self.dependencies)
 
     def _get_dependencies(self):
-        if not self.config.namespace:
+        if not self.namespace:
             raise ValueError("Namespace must be set before building dependencies")
+
+        service = (
+            ServiceBuilder()
+            .with_namespace(self.namespace)
+            .with_name(self._service_name)
+            .with_selector("app", self.app)
+            .with_type("NodePort")
+            .with_port(
+                V1ServicePort(
+                    protocol="TCP",
+                    port=8000,
+                    target_port=8645,
+                )
+            )
+            .build()
+        )
         return {
-            "services": [self.build_service()],
+            "services": [service],
             "roles": [self.build_role()],
             "role_bindings": [self.build_rolebinding()],
             "config_maps": [self.build_config_map()],
         }
 
 
-def apply_command_config(config: CommandConfig, mode: ScriptMode = "server"):
-    try:
-        command = config.find_command("python")
-    except CommandNotFoundError as e:
-        config.commands.append(Command(command="python", args=["/app/api_requester.py"]))
-        command = config.find_command("python")
-
-    command.add_args(
-        [
-            ("--mode", mode),
-            ("--config", "/mount/config.yaml"),
-        ],
-        on_duplicate="replace",
-    )
-
-
-def apply_container_config(
-    container: ContainerConfig,
-    container_name: str,
-    image: Image,
-    mode: Optional[ScriptMode] = None,
-) -> ContainerConfig:
-    container.name = container_name
-    container.with_image(image=image, overwrite=True)
-
-    container.image_pull_policy = "Always"
-    container.ports = [
-        V1ContainerPort(8645),
-        V1ContainerPort(8008),
-        V1ContainerPort(8080),
-    ]
-    container.with_volume_mount(
-        V1VolumeMount(name="api-requester-config-volume", mount_path="/mount"), overwrite=True
-    )
-    if mode is not None:
-        apply_command_config(container.command_config, mode)
-
-    return container
-
-
-def apply_pod_spec_config(
-    namespace: str, container_name: str, image: Image, config: PodSpecConfig
-) -> PodSpecConfig:
-    container = find_container_config(config, container_name)
-    apply_container_config(container, container_name, image)
-    config.dns_config = V1PodDNSConfig(
-        searches=[f"zerotesting-publisher.{namespace}.svc.cluster.local"]
-    )
-    config.with_volume(
-        V1Volume(
-            name="api-requester-config-volume",
-            config_map=V1ConfigMapVolumeSource(name="api-requester-config"),
-        ),
-        overwrite=True,
-    )
-    return config
-
-
-def apply_pod_config(
-    namespace: str, container_name: str, image: Image, config: PodConfig
-) -> PodConfig:
-    config.name = "publisher"
-    config.namespace = namespace
-    apply_pod_spec_config(
-        namespace=namespace,
-        container_name=container_name,
-        image=image,
-        config=config.pod_spec_config,
-    )
-    config.with_app("zerotenkay-publisher", overwrite=True)
-    return config
-
-
-def create_resources() -> V1ResourceRequirements:
-    return V1ResourceRequirements(
-        requests={"memory": "64Mi", "cpu": "150m"},
-        limits={"memory": "600Mi", "cpu": "400m"},
+def _build_requester_base_params(builder: PodApiRequesterBuilder) -> RequesterBaseParams:
+    return RequesterBaseParams(
+        name=builder.name,
+        namespace=builder.namespace,
+        app=builder.app,
+        mode=builder._mode,
+        container_name=builder._container_name,
+        requester_base_enabled=builder._requester_base_enabled,
+        requester_selector_app=builder._requester_selector_app,
+        image=builder._image,
+        pod_service_reader_binding_name=builder._pod_service_reader_binding_name,
+        pod_service_reader_role_name=builder._pod_service_reader_role_name,
+        service_name=builder.service_name,
     )

--- a/src/deployments/pod_api_requester/builder.py
+++ b/src/deployments/pod_api_requester/builder.py
@@ -11,7 +11,6 @@ from kubernetes.client import (
     V1EnvVar,
     V1ObjectMeta,
     V1Pod,
-    V1PodDNSConfig,
     V1PolicyRule,
     V1ResourceRequirements,
     V1Role,
@@ -142,9 +141,14 @@ class PodApiRequesterBuilder(PodBuilder):
             config, name=new_params.name, namespace=new_params.namespace, app=new_params.app
         )
         pod_spec_config = config.pod_spec_config
-        pod_spec_config.dns_config = V1PodDNSConfig(
-            searches=[f"{new_params.service_name}.{new_params.namespace}.svc.cluster.local"]
+
+        if old_params and old_params.service_name and old_params.namespace:
+            old_search = f"{old_params.service_name}.{old_params.namespace}.svc.cluster.local"
+            pod_spec_config.remove_dns_search(old_search, missing_ok=True)
+        pod_spec_config.with_dns_search(
+            f"{new_params.service_name}.{new_params.namespace}.svc.cluster.local", overwrite=True
         )
+
         pod_spec_config.with_volume(
             V1Volume(
                 name=DEFAULT_REQUESTER_VOLUME_NAME,
@@ -247,7 +251,7 @@ class PodApiRequesterBuilder(PodBuilder):
         return self.with_command("sleep", args=["infinity"])
 
     def build(self) -> V1Pod:
-        if not self.name:
+        if not self.namespace:
             raise ValueError(f"Must configure node first. Config: `{self.config}`")
         if not self._mode:
             raise ValueError(

--- a/src/deployments/pod_api_requester/builder.py
+++ b/src/deployments/pod_api_requester/builder.py
@@ -1,5 +1,4 @@
 import logging
-from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Literal, Optional, Self
@@ -63,6 +62,7 @@ class PodApiRequesterBuilder(PodBuilder):
     _mode: Optional[ScriptMode] = None
 
     _base_requester_params: Optional[RequesterBaseParams] = None
+    _base_requester_dependencies: Dict[str, object] = PrivateAttr(default_factory=dict)
 
     # TODO: move to base class
     _restart_policy: Optional[Literal["Always", "OnFailure", "Never"]] = None
@@ -129,6 +129,7 @@ class PodApiRequesterBuilder(PodBuilder):
         self._apply_requester_base_inner(
             old_params=self._base_requester_params, new_params=new_params
         )
+        self._base_requester_dependencies = _build_requester_base_dependencies(new_params)
         self._base_requester_params = new_params
         return self
 
@@ -245,52 +246,6 @@ class PodApiRequesterBuilder(PodBuilder):
         self._mode = "debug"
         return self.with_command("sleep", args=["infinity"])
 
-    def build_role(self) -> V1Role:
-        return V1Role(
-            api_version="rbac.authorization.k8s.io/v1",
-            kind="Role",
-            metadata=V1ObjectMeta(
-                name=self._pod_service_reader_role_name,
-                namespace=self.namespace,
-            ),
-            rules=[
-                V1PolicyRule(
-                    api_groups=[""],
-                    resources=["pods", "services"],
-                    verbs=["get", "list", "watch"],
-                )
-            ],
-        )
-
-    def build_rolebinding(self) -> V1RoleBinding:
-        return V1RoleBinding(
-            api_version="rbac.authorization.k8s.io/v1",
-            kind="RoleBinding",
-            metadata=V1ObjectMeta(
-                name=self._pod_service_reader_binding_name,
-                namespace=self.namespace,
-            ),
-            role_ref=V1RoleRef(
-                kind="Role",
-                name=self._pod_service_reader_role_name,
-                api_group="rbac.authorization.k8s.io",
-            ),
-            subjects=[
-                {
-                    "kind": "ServiceAccount",
-                    "name": "default",
-                    "namespace": self.namespace,
-                },
-            ],
-        )
-
-    def build_config_map(self) -> V1ConfigMap:
-        with open(Path(__file__).parent / "config.yaml", "r") as config_file:
-            config_dict = yaml.safe_load(config_file.read())
-        config_map: V1ConfigMap = dict_to_k8s_object(config_dict, "V1ConfigMap")
-        config_map.metadata.namespace = self.namespace
-        return config_map
-
     def build(self) -> V1Pod:
         if not self.name:
             raise ValueError(f"Must configure node first. Config: `{self.config}`")
@@ -309,34 +264,31 @@ class PodApiRequesterBuilder(PodBuilder):
         return pod
 
     def build_dependencies(self) -> Dict[str, V1Deployable]:
-        self.dependencies = self._get_dependencies()
-        return deepcopy(self.dependencies)
+        return {"requester_base": self._base_requester_dependencies}
 
-    def _get_dependencies(self):
-        if not self.namespace:
-            raise ValueError("Namespace must be set before building dependencies")
 
-        service = (
-            ServiceBuilder()
-            .with_namespace(self.namespace)
-            .with_name(self._service_name)
-            .with_selector("app", self.app)
-            .with_type("NodePort")
-            .with_port(
-                V1ServicePort(
-                    protocol="TCP",
-                    port=8000,
-                    target_port=8645,
-                )
+def _build_requester_base_dependencies(new_params: RequesterBaseParams):
+    service = (
+        ServiceBuilder()
+        .with_namespace(new_params.namespace)
+        .with_name(new_params.service_name)
+        .with_selector("app", new_params.app)
+        .with_type("NodePort")
+        .with_port(
+            V1ServicePort(
+                protocol="TCP",
+                port=8000,
+                target_port=8645,
             )
-            .build()
         )
-        return {
-            "services": [service],
-            "roles": [self.build_role()],
-            "role_bindings": [self.build_rolebinding()],
-            "config_maps": [self.build_config_map()],
-        }
+        .build()
+    )
+    return {
+        "services": [service],
+        "roles": [build_role(new_params)],
+        "role_bindings": [build_rolebinding(new_params)],
+        "config_maps": [build_config_map(new_params.namespace)],
+    }
 
 
 def _build_requester_base_params(builder: PodApiRequesterBuilder) -> RequesterBaseParams:
@@ -353,3 +305,52 @@ def _build_requester_base_params(builder: PodApiRequesterBuilder) -> RequesterBa
         pod_service_reader_role_name=builder._pod_service_reader_role_name,
         service_name=builder.service_name,
     )
+
+
+def build_role(new_params: RequesterBaseParams) -> V1Role:
+    return V1Role(
+        api_version="rbac.authorization.k8s.io/v1",
+        kind="Role",
+        metadata=V1ObjectMeta(
+            name=new_params.pod_service_reader_role_name,
+            namespace=new_params.namespace,
+        ),
+        rules=[
+            V1PolicyRule(
+                api_groups=[""],
+                resources=["pods", "services"],
+                verbs=["get", "list", "watch"],
+            )
+        ],
+    )
+
+
+def build_rolebinding(new_params: RequesterBaseParams) -> V1RoleBinding:
+    return V1RoleBinding(
+        api_version="rbac.authorization.k8s.io/v1",
+        kind="RoleBinding",
+        metadata=V1ObjectMeta(
+            name=new_params.pod_service_reader_binding_name,
+            namespace=new_params.namespace,
+        ),
+        role_ref=V1RoleRef(
+            kind="Role",
+            name=new_params.pod_service_reader_role_name,
+            api_group="rbac.authorization.k8s.io",
+        ),
+        subjects=[
+            {
+                "kind": "ServiceAccount",
+                "name": "default",
+                "namespace": new_params.namespace,
+            },
+        ],
+    )
+
+
+def build_config_map(namespace: str) -> V1ConfigMap:
+    with open(Path(__file__).parent / "config.yaml", "r") as config_file:
+        config_dict = yaml.safe_load(config_file.read())
+    config_map: V1ConfigMap = dict_to_k8s_object(config_dict, "V1ConfigMap")
+    config_map.metadata.namespace = namespace
+    return config_map

--- a/src/deployments/pod_api_requester/builder.py
+++ b/src/deployments/pod_api_requester/builder.py
@@ -31,8 +31,8 @@ from src.deployments.core.configs.container import ContainerConfig, Image
 from src.deployments.core.configs.helpers.identity import apply_identity
 from src.deployments.core.configs.helpers.utils import find_container_config, get_config
 from src.deployments.core.configs.pod import PodSpecConfig
-from src.deployments.core.k8s_object import dict_to_k8s_object
 from src.deployments.core.dependency_decorator import depends_on
+from src.deployments.core.k8s_object import dict_to_k8s_object
 
 ScriptMode = Literal["server", "batch", "debug"]
 
@@ -119,6 +119,7 @@ class PodApiRequesterBuilder(PodBuilder):
         "_pod_service_reader_binding_name",
         "_image",
         "_mode",
+        "service_name",
     )
     def _apply_requester_base(self):
         if not self._requester_base_enabled:


### PR DESCRIPTION
Requirements:
1. Allow any order of `.with_` in the caller
2. Allow changing specific fields (such as `.with_service_name`), not just features
3. Incrementally build the config, avoiding giant if/else build() function
4. Allow user to call `.with_` multiple times with the same or different parameters. build() should use the last-called `.with_` values.

The design:
1. Each feature lists its dependencies. See [_apply_logoscore](https://github.com/vacp2p/10ksim/commit/5bf979fb075ded842c9cbde3d3fe2bded3dda1bf#diff-32e95345a8a2b626bdab46ec25c8ce50bd0df8ae535ed542d8ccbf7f42bace02R4-R147)
2. Each feature is applied any time a dependency is changed, but only if all dependencies are set. See [def _reconcile](https://github.com/vacp2p/10ksim/commit/5bf979fb075ded842c9cbde3d3fe2bded3dda1bf#diff-74213642a5f947f6046d61a90ee2424bb113d9b1b10071fbc19a678f0ae0220aR182) in `src/deployments/core/builders.py`
3. When a feature is applied, it is responsible for cleaning up anything it had generated before (eg. dns_config), without removing other changes (eg. explicitly added dns search, or dns search added by another feature). In order to do this, the feature keeps a copy of the previously used parameters. For settings that are overwritten (scalers), they are simply modified. For other settings (lists, etc.), the old value must be found and removed before the new value is added.
4. Each change to a field calls `_reconcile` (in the setters). It's possible we could automatically do this using a decorator for the class.
5. Instead of duplicating certain fields, like `_app`/`app`, I changed the fields into properties and put them into the base class. This is unrelated to the design change.
It's possible we could get the Requirements listed with a better design, but we can't avoid adding significant complexity.