### PR TITLE
BaseExperiment deploy: allow multiple deployments at once

### DIFF
--- a/src/deployments/experiments/base_experiment.py
+++ b/src/deployments/experiments/base_experiment.py
@@ -1,4 +1,5 @@
 # Python Imports
+import asyncio
 import json
 import logging
 import os
@@ -10,7 +11,7 @@ from contextlib import ExitStack
 from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Generic, Optional, TypeVar, Union
+from typing import Any, Collection, Dict, Generic, Literal, Optional, TypeVar, Union
 
 from kubernetes.client import (
     ApiClient,
@@ -42,6 +43,7 @@ from src.deployments.core.k8s_deploy import kubectl_apply
 from src.deployments.core.k8s_object import k8s_obj_to_dict
 from src.deployments.core.k8s_rollout import wait_for_rollout
 from src.deployments.registry import registry as experiment_registry
+from src.deployments.utils.flatten import flatten
 from src.deployments.utils.parser import _config_model_fields_to_args
 from src.utils.cli_utils import flag_exists
 from src.utils.yaml_utils import get_YAML
@@ -66,6 +68,10 @@ logger = logging.getLogger(__name__)
 
 
 TCfg = TypeVar("TCfg", bound=BaseModel)
+
+
+def kind_of(dep):
+    return getattr(dep, "kind", None) or getattr(dep, "__class__", type(dep)).__name__
 
 
 class BaseExperiment(ABC, BaseModel, Generic[TCfg]):
@@ -169,7 +175,36 @@ class BaseExperiment(ABC, BaseModel, Generic[TCfg]):
 
     async def deploy(
         self,
-        deployment: Optional[yaml.YAMLObject | V1Deployable],
+        deployment: V1Deployable | Collection[V1Deployable] | yaml.YAMLObject,
+        *,
+        wait_for_ready: bool = True,
+        exist_ok: bool = False,
+        timeout=3600,
+        strategy: Literal["parallel", "serial"] = "parallel",
+    ):
+        async def deploy_one(dep):
+            await self._deploy(
+                deployment=dep, wait_for_ready=wait_for_ready, exist_ok=exist_ok, timeout=timeout
+            )
+
+        async def deploy_batch(items):
+            if strategy == "parallel":
+                await asyncio.gather(*(deploy_one(dep) for dep in items))
+            else:
+                for item in items:
+                    await deploy_one(item)
+
+        items = list(flatten(deployment))
+        base_deployments = {"ServiceAccount", "Role", "ConfigMap", "Service", "RoleBinding"}
+        phase_1 = [dep for dep in items if kind_of(dep) in base_deployments]
+        phase_2 = [dep for dep in items if kind_of(dep) not in base_deployments]
+
+        await deploy_batch(phase_1)
+        await deploy_batch(phase_2)
+
+    async def _deploy(
+        self,
+        deployment: Optional[yaml.YAMLObject | V1Deployable] = None,
         *,
         wait_for_ready: bool = True,
         exist_ok: bool = False,

--- a/src/deployments/experiments/base_experiment.py
+++ b/src/deployments/experiments/base_experiment.py
@@ -11,7 +11,7 @@ from contextlib import ExitStack
 from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Collection, Dict, Generic, Literal, Optional, TypeVar, Union
+from typing import Any, Dict, Generic, Literal, Optional, TypeVar, Union
 
 from kubernetes.client import (
     ApiClient,
@@ -175,7 +175,7 @@ class BaseExperiment(ABC, BaseModel, Generic[TCfg]):
 
     async def deploy(
         self,
-        deployment: V1Deployable | Collection[V1Deployable] | yaml.YAMLObject,
+        deployment: V1Deployable | list | dict | set | yaml.YAMLObject,
         *,
         wait_for_ready: bool = True,
         exist_ok: bool = False,

--- a/src/deployments/experiments/tests/test_base_experiment.py
+++ b/src/deployments/experiments/tests/test_base_experiment.py
@@ -17,6 +17,12 @@ class DummyExperiment(BaseExperiment[DummyCfg]):
         pass
 
 
+class DeploymentObj:
+    def __init__(self, kind, name):
+        self.kind = kind
+        self.metadata = {"name": name, "namespace": "ns"}
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("strategy", ["serial", "parallel"])
 async def test_deploy_orders_base_resources_before_workloads(strategy):
@@ -28,22 +34,17 @@ async def test_deploy_orders_base_resources_before_workloads(strategy):
 
     exp._deploy = AsyncMock(return_value=None)
 
-    class Obj:
-        def __init__(self, kind, name):
-            self.kind = kind
-            self.metadata = {"name": name, "namespace": "ns"}
-
     items = [
-        Obj("Pod", "pod1"),
-        Obj("RoleBinding", "rb1"),
-        Obj("StatefulSet", "sts1"),
-        Obj("ServiceAccount", "sa1"),
-        Obj("Service", "s"),
-        Obj("DaemonSet,", "ds"),
-        Obj("Job,", "j"),
-        Obj("CronJob,", "cj"),
-        Obj("Role", "role1"),
-        Obj("ConfigMap", "cm1"),
+        DeploymentObj("Pod", "pod1"),
+        DeploymentObj("RoleBinding", "rb1"),
+        DeploymentObj("StatefulSet", "sts1"),
+        DeploymentObj("ServiceAccount", "sa1"),
+        DeploymentObj("Service", "s"),
+        DeploymentObj("DaemonSet,", "ds"),
+        DeploymentObj("Job,", "j"),
+        DeploymentObj("CronJob,", "cj"),
+        DeploymentObj("Role", "role1"),
+        DeploymentObj("ConfigMap", "cm1"),
     ]
 
     await exp.deploy(items, strategy=strategy, timeout=1)
@@ -68,3 +69,55 @@ async def test_deploy_orders_base_resources_before_workloads(strategy):
     assert foundation_positions
     assert workload_positions
     assert max(foundation_positions) < min(workload_positions)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "deployments, expected",
+    [
+        pytest.param(
+            [DeploymentObj("ServiceAccount", "sa1"), DeploymentObj("Role", "role1")],
+            ["ServiceAccount", "Role"],
+            id="list",
+        ),
+        pytest.param(
+            {"sa": DeploymentObj("ServiceAccount", "sa1"), "role": DeploymentObj("Role", "role1")},
+            ["ServiceAccount", "Role"],
+            id="dict",
+        ),
+        pytest.param(DeploymentObj("Deployment", "dep1"), ["Deployment"], id="single"),
+        pytest.param(
+            {
+                "outer": [
+                    DeploymentObj("ConfigMap", "cm1"),
+                    {"inner": DeploymentObj("Service", "svc1")},
+                ]
+            },
+            ["ConfigMap", "Service"],
+            id="nested",
+        ),
+        pytest.param(
+            {
+                "a": [
+                    DeploymentObj("ServiceAccount", "sa1"),
+                    {"b": DeploymentObj("RoleBinding", "rb1")},
+                ],
+                "c": DeploymentObj("Pod", "pod1"),
+            },
+            ["ServiceAccount", "RoleBinding", "Pod"],
+            id="nested_dict_list",
+        ),
+    ],
+)
+async def test_deploy_flattens_input_shapes(deployments, expected):
+    exp = DummyExperiment.model_construct(
+        api_client=Mock(),
+        config=DummyCfg(),
+        namespace="ns",
+    )
+    exp._deploy = AsyncMock(return_value=None)
+
+    await exp.deploy(deployments, strategy="serial", timeout=1)
+
+    kinds = [item.kwargs["deployment"].kind for item in exp._deploy.await_args_list]
+    assert kinds == expected

--- a/src/deployments/experiments/tests/test_base_experiment.py
+++ b/src/deployments/experiments/tests/test_base_experiment.py
@@ -1,0 +1,70 @@
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from pydantic import BaseModel
+
+from src.deployments.experiments.base_experiment import BaseExperiment
+
+
+class DummyCfg(BaseModel):
+    foo: str = "bar"
+
+
+class DummyExperiment(BaseExperiment[DummyCfg]):
+    config: DummyCfg
+
+    async def _run(self):
+        pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("strategy", ["serial", "parallel"])
+async def test_deploy_orders_base_resources_before_workloads(strategy):
+    exp = DummyExperiment.model_construct(
+        api_client=Mock(),
+        config=DummyCfg(),
+        namespace="ns",
+    )
+
+    exp._deploy = AsyncMock(return_value=None)
+
+    class Obj:
+        def __init__(self, kind, name):
+            self.kind = kind
+            self.metadata = {"name": name, "namespace": "ns"}
+
+    items = [
+        Obj("Pod", "pod1"),
+        Obj("RoleBinding", "rb1"),
+        Obj("StatefulSet", "sts1"),
+        Obj("ServiceAccount", "sa1"),
+        Obj("Service", "s"),
+        Obj("DaemonSet,", "ds"),
+        Obj("Job,", "j"),
+        Obj("CronJob,", "cj"),
+        Obj("Role", "role1"),
+        Obj("ConfigMap", "cm1"),
+    ]
+
+    await exp.deploy(items, strategy=strategy, timeout=1)
+
+    kinds = [c.kwargs["deployment"].kind for c in exp._deploy.await_args_list]
+
+    foundational = {"ServiceAccount", "Role", "ConfigMap", "Service", "RoleBinding"}
+    workloads = {
+        "Pod",
+        "StatefulSet",
+        "DaemonSet",
+        "Deployment",
+        "Job",
+        "CronJob",
+        "ReplicaSet",
+        "ReplicationController",
+    }
+
+    foundation_positions = [i for i, k in enumerate(kinds) if k in foundational]
+    workload_positions = [i for i, k in enumerate(kinds) if k in workloads]
+
+    assert foundation_positions
+    assert workload_positions
+    assert max(foundation_positions) < min(workload_positions)

--- a/src/deployments/experiments/tests/test_base_experiment.py
+++ b/src/deployments/experiments/tests/test_base_experiment.py
@@ -40,9 +40,9 @@ async def test_deploy_orders_base_resources_before_workloads(strategy):
         DeploymentObj("StatefulSet", "sts1"),
         DeploymentObj("ServiceAccount", "sa1"),
         DeploymentObj("Service", "s"),
-        DeploymentObj("DaemonSet,", "ds"),
-        DeploymentObj("Job,", "j"),
-        DeploymentObj("CronJob,", "cj"),
+        DeploymentObj("DaemonSet", "ds"),
+        DeploymentObj("Job", "j"),
+        DeploymentObj("CronJob", "cj"),
         DeploymentObj("Role", "role1"),
         DeploymentObj("ConfigMap", "cm1"),
     ]

--- a/src/deployments/utils/flatten.py
+++ b/src/deployments/utils/flatten.py
@@ -2,7 +2,7 @@ def flatten(obj):
     if isinstance(obj, dict):
         for value in obj.values():
             yield from flatten(value)
-    elif isinstance(obj, list):
+    elif isinstance(obj, (list, tuple, set)):
         for value in obj:
             yield from flatten(value)
     else:

--- a/src/deployments/utils/flatten.py
+++ b/src/deployments/utils/flatten.py
@@ -1,0 +1,9 @@
+def flatten(obj):
+    if isinstance(obj, dict):
+        for value in obj.values():
+            yield from flatten(value)
+    elif isinstance(obj, list):
+        for value in obj:
+            yield from flatten(value)
+    else:
+        yield obj


### PR DESCRIPTION
This lets us deploy the dependencies and pod/statefulset/etc. all at once
```
bootstrap_deployments = self.build_node_deployments("bootstrap")
await self.deploy(bootstrap_deployments, exist_ok=True)
```