### PR TITLE
Add kaniko cluster-build tooling for native amd64 image builds

### DIFF
--- a/deployment-utilities/docker_utilities/kaniko/README.md
+++ b/deployment-utilities/docker_utilities/kaniko/README.md
@@ -28,7 +28,24 @@ Example — a nim test node from a fix branch:
 ```
 
 The script applies a kaniko Job, streams its logs, and waits for completion. Env overrides:
-`KC` (kubeconfig, defaults to `$KUBECONFIG` or `~/.kube/config`), `BUILD_NS`, `EXCLUDE_NODE`.
+`KC` (kubeconfig, defaults to `$KUBECONFIG` or `~/.kube/config`), `BUILD_NS`, `EXCLUDE_NODE`,
+`DOCKER_SECRET` (see below).
+
+### Pushing under your own Docker Hub account
+
+The push uses the `DOCKER_SECRET` k8s secret (default `dockerhub-creds`) in `$BUILD_NS`. That
+default secret belongs to **whoever set it up** — so by default you'd push into their namespace
+under their credentials. To push under your own account, create a secret with your own token and
+point `DOCKER_SECRET` at it (and use a `<destination>` in your own namespace):
+
+```bash
+kubectl -n zerotesting-build create secret docker-registry mycreds \
+  --docker-username=<you> --docker-password=<your-dockerhub-token>
+
+DOCKER_SECRET=mycreds ./build-image.sh <repo> <ref> <subpath> <dockerfile> <you>/img:tag
+```
+
+(There is no shared team registry yet; until there is, each person builds under their own account.)
 
 ### Builds from git, not your working tree
 

--- a/deployment-utilities/docker_utilities/kaniko/README.md
+++ b/deployment-utilities/docker_utilities/kaniko/README.md
@@ -1,0 +1,65 @@
+## Fast native amd64 image builds (kaniko on the lab cluster)
+
+Build any `linux/amd64` image **natively on an amd64 lab node** instead of cross-compiling
+under QEMU on the Apple-Silicon Macs. QEMU builds are slow and have stalled on machine
+sleep and Docker-Desktop cache eviction; kaniko-on-cluster is native, runs unattended, and
+uses a durable registry-backed cache. Generalised from the Shadow base-image build so it
+works for any repo/Dockerfile, not just the test nodes.
+
+### Usage
+
+```
+deployment-utilities/docker_utilities/kaniko/build-image.sh \
+  <repo> <git-ref> <context-subpath> <dockerfile> <destination> [cache-repo]
+```
+
+- `repo`            – GitHub `org/name` (e.g. `vacp2p/dst-libp2p-test-node`)
+- `git-ref`         – full ref: `refs/heads/<branch>`, `refs/tags/<tag>`, or a commit SHA
+- `context-subpath` – build-context dir within the repo
+- `dockerfile`      – Dockerfile name (relative to the subpath)
+- `destination`     – `repo/image:tag` to push
+- `cache-repo`      – optional; defaults to `<dest-without-tag>-cache`
+
+Example — a nim test node from a fix branch:
+```
+.../kaniko/build-image.sh vacp2p/dst-libp2p-test-node refs/heads/alan/regression-2678 \
+  nim-test-node/regression Dockerfile_amd64 \
+  radiken/dst-test-node-regression:v2.1.0-2678
+```
+
+The script applies a kaniko Job, streams its logs, and waits for completion. Env overrides:
+`KC` (kubeconfig, defaults to `$KUBECONFIG` or `~/.kube/config`), `BUILD_NS`, `EXCLUDE_NODE`.
+
+### Builds from git, not your working tree
+
+The context is cloned from `<git-ref>` — **uncommitted local edits are not included.** Commit
+and push first. This is also a feature: each build is a reproducible named ref, so concurrent
+runs (e.g. two people pinning different nim-libp2p commits) don't stomp each other's files the
+way local builds do.
+
+### Parallel builds
+
+Each call is an independent Job named `build-<dest-tag>`, scheduled across the workers (each
+~128 cores; a build requests 8). Distinct destination tags run in parallel; re-running the same
+tag replaces its job. Just background several invocations.
+
+### One-time setup (per cluster)
+
+```bash
+kubectl create namespace zerotesting-build
+DCJ=$(kubectl -n <ns-with-creds> get secret dockerhub-creds -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d)
+echo "$DCJ" > /tmp/dcj.json
+kubectl -n zerotesting-build create secret generic dockerhub-creds \
+  --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=/tmp/dcj.json
+rm /tmp/dcj.json
+```
+
+### Verifying the right thing got built
+
+A registry cache can serve a stale layer, so for compiled nodes confirm the binary really
+contains the intended commit before trusting a run — pull it and grep for a symbol unique to
+that commit:
+```bash
+docker create --name t <image>; docker cp t:/node/main /tmp/main; docker rm t
+strings /tmp/main | grep -c <symbol-unique-to-the-commit>
+```

--- a/deployment-utilities/docker_utilities/kaniko/build-image.sh
+++ b/deployment-utilities/docker_utilities/kaniko/build-image.sh
@@ -25,6 +25,10 @@ KC="${KC:-${KUBECONFIG:-$HOME/.kube/config}}"
 BUILD_NS="${BUILD_NS:-zerotesting-build}"
 # Avoid the master/monitoring node (it interferes with workloads).
 EXCLUDE_NODE="${EXCLUDE_NODE:-node-01.ih-eu-mda1.misc.vaclab}"
+# Docker push credentials: a dockerconfigjson secret in $BUILD_NS. Defaults to
+# `dockerhub-creds`; set this (and a matching <destination> namespace) to push under
+# your own Docker Hub account instead of whoever owns the default secret. See README.
+DOCKER_SECRET="${DOCKER_SECRET:-dockerhub-creds}"
 
 if [ "$#" -lt 5 ]; then
   sed -n '2,18p' "$0"; exit 1
@@ -39,7 +43,7 @@ BUILD_NAME="$(echo "build-${tagpart}" | cut -c1-60)"
 
 echo ">>> building $DESTINATION"
 echo "    repo=$REPO ref=$GIT_REF subpath=$SUBPATH dockerfile=$DOCKERFILE"
-echo "    job=$BUILD_NAME ns=$BUILD_NS cache=$CACHE_REPO"
+echo "    job=$BUILD_NAME ns=$BUILD_NS cache=$CACHE_REPO creds=$DOCKER_SECRET"
 
 render() {
 cat <<YAML
@@ -85,7 +89,7 @@ spec:
       volumes:
         - name: docker-config
           secret:
-            secretName: dockerhub-creds
+            secretName: ${DOCKER_SECRET}
             items:
               - { key: .dockerconfigjson, path: config.json }
 YAML

--- a/deployment-utilities/docker_utilities/kaniko/build-image.sh
+++ b/deployment-utilities/docker_utilities/kaniko/build-image.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Native amd64 image builds on the lab cluster via kaniko.
+#
+# Why: building linux/amd64 images on Apple-Silicon Macs cross-compiles under QEMU
+# emulation -- slow, and long Nim/Shadow compiles stall on machine sleep / Docker
+# cache eviction. Kaniko runs ON an amd64 lab node, so the build is native, runs
+# unattended, caches to a registry repo (durable), and several can run in parallel.
+#
+# Usage:
+#   deployment-utilities/docker_utilities/kaniko/build-image.sh \
+#     <repo> <git-ref> <context-subpath> <dockerfile> <destination> [cache-repo]
+#
+# Example (a nim test node from a branch):
+#   .../kaniko/build-image.sh vacp2p/dst-libp2p-test-node refs/heads/alan/regression-2678 \
+#     nim-test-node/regression Dockerfile_amd64 radiken/dst-test-node-regression:v2.1.0-2678
+#
+# IMPORTANT: kaniko builds from the GIT ref, NOT your local working tree -- commit and
+# push first. <git-ref> is a full ref: refs/heads/<branch>, refs/tags/<tag>, or a SHA.
+#
+# Prereqs (one-time): namespace $BUILD_NS with a `dockerhub-creds` dockerconfigjson
+# secret -- see README.md.
+set -euo pipefail
+
+KC="${KC:-${KUBECONFIG:-$HOME/.kube/config}}"
+BUILD_NS="${BUILD_NS:-zerotesting-build}"
+# Avoid the master/monitoring node (it interferes with workloads).
+EXCLUDE_NODE="${EXCLUDE_NODE:-node-01.ih-eu-mda1.misc.vaclab}"
+
+if [ "$#" -lt 5 ]; then
+  sed -n '2,18p' "$0"; exit 1
+fi
+REPO="$1"; GIT_REF="$2"; SUBPATH="$3"; DOCKERFILE="$4"; DESTINATION="$5"
+CACHE_REPO="${6:-${DESTINATION%%:*}-cache}"
+
+# k8s-safe Job name derived from the destination image:tag (distinct tags -> distinct
+# jobs run in parallel; re-running the same tag replaces its job).
+tagpart="$(echo "${DESTINATION##*/}" | tr '[:upper:]' '[:lower:]' | tr ':._/' '----' | sed 's/[^a-z0-9-]//g')"
+BUILD_NAME="$(echo "build-${tagpart}" | cut -c1-60)"
+
+echo ">>> building $DESTINATION"
+echo "    repo=$REPO ref=$GIT_REF subpath=$SUBPATH dockerfile=$DOCKERFILE"
+echo "    job=$BUILD_NAME ns=$BUILD_NS cache=$CACHE_REPO"
+
+render() {
+cat <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${BUILD_NAME}
+  namespace: ${BUILD_NS}
+  labels: { app: kaniko-build }
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels: { app: kaniko-build, build: ${BUILD_NAME} }
+    spec:
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values: [ ${EXCLUDE_NODE} ]
+      containers:
+        - name: kaniko
+          image: gcr.io/kaniko-project/executor:v1.23.2
+          args:
+            - "--context=git://github.com/${REPO}.git#${GIT_REF}"
+            - "--context-sub-path=${SUBPATH}"
+            - "--dockerfile=${DOCKERFILE}"
+            - "--destination=${DESTINATION}"
+            - "--cache=true"
+            - "--cache-repo=${CACHE_REPO}"
+            - "--snapshot-mode=redo"
+            - "--use-new-run"
+          volumeMounts:
+            - { name: docker-config, mountPath: /kaniko/.docker }
+          resources:
+            requests: { cpu: "8", memory: "8Gi" }
+            limits: { cpu: "32", memory: "16Gi" }
+      volumes:
+        - name: docker-config
+          secret:
+            secretName: dockerhub-creds
+            items:
+              - { key: .dockerconfigjson, path: config.json }
+YAML
+}
+
+render | kubectl --kubeconfig "$KC" delete -f - --ignore-not-found >/dev/null 2>&1 || true
+render | kubectl --kubeconfig "$KC" apply -f -
+
+echo ">>> waiting for build pod, then streaming logs (Ctrl-C detaches; build keeps running)"
+kubectl --kubeconfig "$KC" -n "$BUILD_NS" wait --for=condition=Ready pod -l "build=${BUILD_NAME}" --timeout=180s || true
+kubectl --kubeconfig "$KC" -n "$BUILD_NS" logs -f -l "build=${BUILD_NAME}" --tail=-1 || true
+
+echo ">>> waiting for job completion"
+if kubectl --kubeconfig "$KC" -n "$BUILD_NS" wait --for=condition=complete --timeout=1800s "job/${BUILD_NAME}"; then
+  echo "BUILD COMPLETE: $DESTINATION"
+else
+  echo "BUILD FAILED or TIMED OUT: $DESTINATION"
+  kubectl --kubeconfig "$KC" -n "$BUILD_NS" describe "job/${BUILD_NAME}" | tail -25
+  exit 1
+fi


### PR DESCRIPTION
## What
A small tool to build `linux/amd64` images natively on the lab cluster via kaniko, it builds in **~7 mins** (vs 40+ mins on my Mac).

`deployment-utilities/docker_utilities/kaniko/`:
- **`build-image.sh`** — `build-image.sh <repo> <git-ref> <subpath> <dockerfile> <dest> [cache-repo]` → renders + applies a kaniko Job (pinned off the master node), streams logs, waits for completion.
- **`README.md`** — usage + the one-time namespace/secret setup.