### PR TITLE
Window event

### DIFF
--- a/src/deployments/core/event_window_bridge.py
+++ b/src/deployments/core/event_window_bridge.py
@@ -1,0 +1,60 @@
+# Python Imports
+from datetime import timedelta
+from pathlib import Path
+from typing import Dict, Literal, Union
+
+from pydantic import BaseModel, Field
+
+# Project Imports
+from src.deployments.core.base_bridge import BaseBridge, EventMapping
+
+EventBound = Literal["start", "end"]
+
+
+class EventWindowEndpoint(BaseModel):
+    key: dict
+    time_shift: timedelta = Field(default_factory=lambda: timedelta(0))
+
+
+def event_window(
+    event: Union[str, dict], time_shift: timedelta = timedelta(0)
+) -> EventWindowEndpoint:
+    key = {"event": event} if isinstance(event, str) else event
+    return EventWindowEndpoint(key=key, time_shift=time_shift)
+
+
+class EventWindowBridge(BaseBridge):
+    interval: str = "complete"
+    container_name: str
+    event_windows: Dict[str, Dict[EventBound, EventWindowEndpoint]] = Field(default_factory=dict)
+
+    def get_metadata(self, events_log_path: Path) -> dict:
+        metadata = super().get_metadata(events_log_path)
+        events = self._get_metadata_events(events_log_path)
+
+        try:
+            selected_interval = events[self.interval]
+            metadata["stack"]["start_time"] = selected_interval["start"]
+            metadata["stack"]["end_time"] = selected_interval["end"]
+        except KeyError as e:
+            raise ValueError(
+                f"Missing `{self.interval}` analysis window in events metadata. "
+                f"interval: `{self.interval}` events: `{events}`"
+            ) from e
+
+        metadata["results"] = events
+        metadata["stack"]["container_name"] = self.container_name
+
+        return metadata
+
+    def _get_metadata_events(self, events_log_path: Path) -> dict:
+        events_list = [
+            EventMapping(
+                key=endpoint.key,
+                target=Path(window_name, bound),
+                time_shift=endpoint.time_shift,
+            )
+            for window_name, bounds in self.event_windows.items()
+            for bound, endpoint in bounds.items()
+        ]
+        return self._get_metadata_from_events_list(events_log_path, events_list)

--- a/src/deployments/core/event_window_bridge.py
+++ b/src/deployments/core/event_window_bridge.py
@@ -1,32 +1,37 @@
 # Python Imports
+from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
-from typing import Dict, Literal, Union
-
-from pydantic import BaseModel, Field
+from typing import List, Union
 
 # Project Imports
 from src.deployments.core.base_bridge import BaseBridge, EventMapping
 
-EventBound = Literal["start", "end"]
 
-
-class EventWindowEndpoint(BaseModel):
+@dataclass(frozen=True)
+class EventBound:
     key: dict
-    time_shift: timedelta = Field(default_factory=lambda: timedelta(0))
+    time_shift: timedelta = timedelta(0)
+
+    def __init__(self, event: Union[str, dict], time_shift: timedelta = timedelta(0)):
+        key = {"event": event} if isinstance(event, str) else event
+        object.__setattr__(self, "key", key)
+        object.__setattr__(self, "time_shift", time_shift)
 
 
-def event_window(
-    event: Union[str, dict], time_shift: timedelta = timedelta(0)
-) -> EventWindowEndpoint:
-    key = {"event": event} if isinstance(event, str) else event
-    return EventWindowEndpoint(key=key, time_shift=time_shift)
+@dataclass(frozen=True)
+class EventWindow:
+    key: str
+    start: EventBound
+    end: EventBound
 
 
 class EventWindowBridge(BaseBridge):
     interval: str = "complete"
     container_name: str
-    event_windows: Dict[str, Dict[EventBound, EventWindowEndpoint]] = Field(default_factory=dict)
+
+    def event_windows(self) -> List[EventWindow]:
+        return []
 
     def get_metadata(self, events_log_path: Path) -> dict:
         metadata = super().get_metadata(events_log_path)
@@ -50,11 +55,11 @@ class EventWindowBridge(BaseBridge):
     def _get_metadata_events(self, events_log_path: Path) -> dict:
         events_list = [
             EventMapping(
-                key=endpoint.key,
-                target=Path(window_name, bound),
-                time_shift=endpoint.time_shift,
+                key=bound.key,
+                target=Path(window.key, bound_name),
+                time_shift=bound.time_shift,
             )
-            for window_name, bounds in self.event_windows.items()
-            for bound, endpoint in bounds.items()
+            for window in self.event_windows()
+            for bound_name, bound in (("start", window.start), ("end", window.end))
         ]
         return self._get_metadata_from_events_list(events_log_path, events_list)

--- a/src/deployments/core/tests/test_event_window_bridge.py
+++ b/src/deployments/core/tests/test_event_window_bridge.py
@@ -1,16 +1,11 @@
 # Python Import
 import json
 from datetime import timedelta
-from typing import Dict
 
 import pytest
 
 # Project Import
-from src.deployments.core.event_window_bridge import (
-    EventWindowBridge,
-    EventWindowEndpoint,
-    event_window,
-)
+import src.deployments.core.event_window_bridge as event_window_bridge
 from src.deployments.libp2p.bridge import Bridge as Libp2pBridge
 from src.deployments.libp2p.builders.helpers import LIBP2P_CONTAINER_NAME
 from src.deployments.waku.bridge import Bridge as WakuBridge
@@ -23,38 +18,40 @@ def write_events_log(tmp_path, events):
     return log_path
 
 
-class ExampleWindowBridge(EventWindowBridge):
+class ExampleWindowBridge(event_window_bridge.EventWindowBridge):
     interval: str = "stable"
     container_name: str = "example-container"
-    event_windows: Dict[str, Dict[str, EventWindowEndpoint]] = {
-        "complete": {
-            "start": event_window("experiment_started"),
-            "end": event_window("experiment_finished", timedelta(seconds=30)),
-        },
-        "stable": {
-            "start": event_window(
-                {"event": "messages_started", "role": "publisher"}, timedelta(minutes=3)
+
+    def event_windows(self):
+        return [
+            event_window_bridge.EventWindow(
+                key="complete",
+                start=event_window_bridge.EventBound("experiment_started"),
+                end=event_window_bridge.EventBound("experiment_finished", timedelta(seconds=30)),
             ),
-            "end": event_window("messages_finished", timedelta(seconds=-30)),
-        },
-    }
+            event_window_bridge.EventWindow(
+                key="stable",
+                start=event_window_bridge.EventBound(
+                    {"event": "messages_started", "role": "publisher"}, timedelta(minutes=3)
+                ),
+                end=event_window_bridge.EventBound("messages_finished", timedelta(seconds=-30)),
+            ),
+        ]
 
 
-def test_event_window_builds_endpoint_from_string_event():
-    endpoint = event_window("experiment_started", timedelta(seconds=5))
+def test_event_bound_builds_key_from_string_event():
+    bound = event_window_bridge.EventBound("experiment_started", timedelta(seconds=5))
 
-    assert endpoint == EventWindowEndpoint(
-        key={"event": "experiment_started"}, time_shift=timedelta(seconds=5)
-    )
+    assert bound == event_window_bridge.EventBound("experiment_started", timedelta(seconds=5))
+    assert bound.key == {"event": "experiment_started"}
+    assert bound.time_shift == timedelta(seconds=5)
 
 
-def test_event_window_builds_endpoint_from_dict_event():
-    endpoint = event_window({"event": "messages_started", "role": "publisher"})
+def test_event_bound_uses_dict_event_as_key():
+    bound = event_window_bridge.EventBound({"event": "messages_started", "role": "publisher"})
 
-    assert endpoint == EventWindowEndpoint(
-        key={"event": "messages_started", "role": "publisher"},
-        time_shift=timedelta(0),
-    )
+    assert bound.key == {"event": "messages_started", "role": "publisher"}
+    assert bound.time_shift == timedelta(0)
 
 
 def test_event_window_bridge_extracts_results_and_selected_interval(tmp_path):
@@ -98,6 +95,7 @@ def test_event_window_bridge_extracts_results_and_selected_interval(tmp_path):
     assert metadata["stack"]["container_name"] == "example-container"
     assert metadata["stack"]["stateful_sets"] == ["publisher"]
     assert metadata["experiment"]["name"] == "window-demo"
+    assert "event_windows" not in metadata["experiment"]["bridge_class"]
 
 
 def test_event_window_bridge_raises_when_selected_interval_is_missing(tmp_path):
@@ -138,22 +136,17 @@ def test_protocol_bridges_define_complete_and_stable_event_windows(bridge_cls, c
 
     assert bridge.interval == "complete"
     assert bridge.container_name == container_name
-    assert bridge.event_windows == {
-        "complete": {
-            "start": EventWindowEndpoint(
-                key={"event": "wait_for_clear_finished"}, time_shift=timedelta(0)
+    assert bridge.event_windows() == [
+        event_window_bridge.EventWindow(
+            key="complete",
+            start=event_window_bridge.EventBound("wait_for_clear_finished"),
+            end=event_window_bridge.EventBound("internal_run_finished", timedelta(seconds=30)),
+        ),
+        event_window_bridge.EventWindow(
+            key="stable",
+            start=event_window_bridge.EventBound("start_messages", timedelta(minutes=3)),
+            end=event_window_bridge.EventBound(
+                "publisher_messages_finished", timedelta(seconds=-30)
             ),
-            "end": EventWindowEndpoint(
-                key={"event": "internal_run_finished"}, time_shift=timedelta(seconds=30)
-            ),
-        },
-        "stable": {
-            "start": EventWindowEndpoint(
-                key={"event": "start_messages"}, time_shift=timedelta(minutes=3)
-            ),
-            "end": EventWindowEndpoint(
-                key={"event": "publisher_messages_finished"},
-                time_shift=timedelta(seconds=-30),
-            ),
-        },
-    }
+        ),
+    ]

--- a/src/deployments/core/tests/test_event_window_bridge.py
+++ b/src/deployments/core/tests/test_event_window_bridge.py
@@ -1,0 +1,159 @@
+# Python Import
+import json
+from datetime import timedelta
+from typing import Dict
+
+import pytest
+
+# Project Import
+from src.deployments.core.event_window_bridge import (
+    EventWindowBridge,
+    EventWindowEndpoint,
+    event_window,
+)
+from src.deployments.libp2p.bridge import Bridge as Libp2pBridge
+from src.deployments.libp2p.builders.helpers import LIBP2P_CONTAINER_NAME
+from src.deployments.waku.bridge import Bridge as WakuBridge
+from src.deployments.waku.builders.helpers import WAKU_CONTAINER_NAME
+
+
+def write_events_log(tmp_path, events):
+    log_path = tmp_path / "events.log"
+    log_path.write_text("\n".join(json.dumps(event) for event in events) + "\n")
+    return log_path
+
+
+class ExampleWindowBridge(EventWindowBridge):
+    interval: str = "stable"
+    container_name: str = "example-container"
+    event_windows: Dict[str, Dict[str, EventWindowEndpoint]] = {
+        "complete": {
+            "start": event_window("experiment_started"),
+            "end": event_window("experiment_finished", timedelta(seconds=30)),
+        },
+        "stable": {
+            "start": event_window(
+                {"event": "messages_started", "role": "publisher"}, timedelta(minutes=3)
+            ),
+            "end": event_window("messages_finished", timedelta(seconds=-30)),
+        },
+    }
+
+
+def test_event_window_builds_endpoint_from_string_event():
+    endpoint = event_window("experiment_started", timedelta(seconds=5))
+
+    assert endpoint == EventWindowEndpoint(
+        key={"event": "experiment_started"}, time_shift=timedelta(seconds=5)
+    )
+
+
+def test_event_window_builds_endpoint_from_dict_event():
+    endpoint = event_window({"event": "messages_started", "role": "publisher"})
+
+    assert endpoint == EventWindowEndpoint(
+        key={"event": "messages_started", "role": "publisher"},
+        time_shift=timedelta(0),
+    )
+
+
+def test_event_window_bridge_extracts_results_and_selected_interval(tmp_path):
+    log_path = write_events_log(
+        tmp_path,
+        [
+            {
+                "event": "deployment",
+                "phase": "start",
+                "kind": "StatefulSet",
+                "name": "publisher",
+                "replicas": 2,
+                "namespace": "test",
+            },
+            {
+                "event": "metadata",
+                "experiment_name": "window-demo",
+                "experiment_class": "WindowDemo",
+                "command": "run",
+                "kube_config": "kind",
+            },
+            {"event": "experiment_started", "timestamp": "2026-01-01 12:00:00"},
+            {"event": "experiment_finished", "timestamp": "2026-01-01 12:30:00"},
+            {
+                "event": "messages_started",
+                "role": "publisher",
+                "timestamp": "2026-01-01 12:05:00",
+            },
+            {"event": "messages_finished", "timestamp": "2026-01-01 12:20:00"},
+        ],
+    )
+
+    metadata = ExampleWindowBridge().get_metadata(log_path)
+
+    assert metadata["results"] == {
+        "complete": {"start": "2026-01-01T12:00:00", "end": "2026-01-01T12:30:30"},
+        "stable": {"start": "2026-01-01T12:08:00", "end": "2026-01-01T12:19:30"},
+    }
+    assert metadata["stack"]["start_time"] == "2026-01-01T12:08:00"
+    assert metadata["stack"]["end_time"] == "2026-01-01T12:19:30"
+    assert metadata["stack"]["container_name"] == "example-container"
+    assert metadata["stack"]["stateful_sets"] == ["publisher"]
+    assert metadata["experiment"]["name"] == "window-demo"
+
+
+def test_event_window_bridge_raises_when_selected_interval_is_missing(tmp_path):
+    log_path = write_events_log(
+        tmp_path,
+        [
+            {
+                "event": "deployment",
+                "phase": "start",
+                "kind": "StatefulSet",
+                "name": "publisher",
+                "replicas": 2,
+                "namespace": "test",
+            },
+            {
+                "event": "metadata",
+                "experiment_name": "window-demo",
+                "experiment_class": "WindowDemo",
+            },
+            {"event": "experiment_started", "timestamp": "2026-01-01 12:00:00"},
+            {"event": "experiment_finished", "timestamp": "2026-01-01 12:30:00"},
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Missing `stable` analysis window"):
+        ExampleWindowBridge().get_metadata(log_path)
+
+
+@pytest.mark.parametrize(
+    ("bridge_cls", "container_name"),
+    [
+        (Libp2pBridge, LIBP2P_CONTAINER_NAME),
+        (WakuBridge, WAKU_CONTAINER_NAME),
+    ],
+)
+def test_protocol_bridges_define_complete_and_stable_event_windows(bridge_cls, container_name):
+    bridge = bridge_cls()
+
+    assert bridge.interval == "complete"
+    assert bridge.container_name == container_name
+    assert bridge.event_windows == {
+        "complete": {
+            "start": EventWindowEndpoint(
+                key={"event": "wait_for_clear_finished"}, time_shift=timedelta(0)
+            ),
+            "end": EventWindowEndpoint(
+                key={"event": "internal_run_finished"}, time_shift=timedelta(seconds=30)
+            ),
+        },
+        "stable": {
+            "start": EventWindowEndpoint(
+                key={"event": "start_messages"}, time_shift=timedelta(minutes=3)
+            ),
+            "end": EventWindowEndpoint(
+                key={"event": "publisher_messages_finished"},
+                time_shift=timedelta(seconds=-30),
+            ),
+        },
+    }

--- a/src/deployments/libp2p/bridge.py
+++ b/src/deployments/libp2p/bridge.py
@@ -1,46 +1,37 @@
-# Python imports
+# Python Imports
 import logging
 from datetime import timedelta
-from pathlib import Path
-from typing import Literal
+from typing import Dict, Literal
 
 # Project Imports
-from src.deployments.core.base_bridge import BaseBridge, EventMapping
+from src.deployments.core.event_window_bridge import (
+    EventWindowBridge,
+    EventWindowEndpoint,
+    event_window,
+)
 from src.deployments.libp2p.builders.helpers import LIBP2P_CONTAINER_NAME
 
 logger = logging.getLogger(__name__)
 
 
-class Bridge(BaseBridge):
+class Bridge(EventWindowBridge):
     interval: Literal["complete", "stable"] = "complete"
     """Time interval for start and end times.
 
     complete: From the beginning to the end of the whole experiment run code
 
     stable: Just the time where nodes should have stablized.
-    Calculated in _get_metadata_events by adding an offset from when message publishing starts and ends.
+    Calculated by adding offsets to message publishing start/end events.
     """
 
-    def get_metadata(self, events_log_path: str) -> dict:
-        metadata = super().get_metadata(events_log_path)
-        events = self._get_metadata_events(events_log_path)
-        metadata["results"] = events
-        metadata["stack"]["start_time"] = events[self.interval]["start"]
-        metadata["stack"]["end_time"] = events[self.interval]["end"]
-        metadata["stack"]["container_name"] = LIBP2P_CONTAINER_NAME
-        return metadata
-
-    def _get_metadata_events(self, events_log_path: str):
-        events = [
-            ("wait_for_clear_finished", Path("complete", "start"), timedelta(seconds=0)),
-            ("internal_run_finished", Path("complete", "end"), timedelta(seconds=30)),
-            ("start_messages", Path("stable", "start"), timedelta(minutes=3)),
-            ("publisher_messages_finished", Path("stable", "end"), timedelta(seconds=-30)),
-        ]
-        events_list = list(
-            map(
-                lambda obj: EventMapping(key={"event": obj[0]}, target=obj[1], time_shift=obj[2]),
-                events,
-            )
-        )
-        return self._get_metadata_from_events_list(events_log_path, events_list)
+    container_name: str = LIBP2P_CONTAINER_NAME
+    event_windows: Dict[str, Dict[str, EventWindowEndpoint]] = {
+        "complete": {
+            "start": event_window("wait_for_clear_finished"),
+            "end": event_window("internal_run_finished", timedelta(seconds=30)),
+        },
+        "stable": {
+            "start": event_window("start_messages", timedelta(minutes=3)),
+            "end": event_window("publisher_messages_finished", timedelta(seconds=-30)),
+        },
+    }

--- a/src/deployments/libp2p/bridge.py
+++ b/src/deployments/libp2p/bridge.py
@@ -1,20 +1,16 @@
 # Python Imports
 import logging
 from datetime import timedelta
-from typing import Dict, Literal
+from typing import List, Literal
 
 # Project Imports
-from src.deployments.core.event_window_bridge import (
-    EventWindowBridge,
-    EventWindowEndpoint,
-    event_window,
-)
+import src.deployments.core.event_window_bridge as event_window_bridge
 from src.deployments.libp2p.builders.helpers import LIBP2P_CONTAINER_NAME
 
 logger = logging.getLogger(__name__)
 
 
-class Bridge(EventWindowBridge):
+class Bridge(event_window_bridge.EventWindowBridge):
     interval: Literal["complete", "stable"] = "complete"
     """Time interval for start and end times.
 
@@ -25,13 +21,19 @@ class Bridge(EventWindowBridge):
     """
 
     container_name: str = LIBP2P_CONTAINER_NAME
-    event_windows: Dict[str, Dict[str, EventWindowEndpoint]] = {
-        "complete": {
-            "start": event_window("wait_for_clear_finished"),
-            "end": event_window("internal_run_finished", timedelta(seconds=30)),
-        },
-        "stable": {
-            "start": event_window("start_messages", timedelta(minutes=3)),
-            "end": event_window("publisher_messages_finished", timedelta(seconds=-30)),
-        },
-    }
+
+    def event_windows(self) -> List[event_window_bridge.EventWindow]:
+        return [
+            event_window_bridge.EventWindow(
+                key="complete",
+                start=event_window_bridge.EventBound("wait_for_clear_finished"),
+                end=event_window_bridge.EventBound("internal_run_finished", timedelta(seconds=30)),
+            ),
+            event_window_bridge.EventWindow(
+                key="stable",
+                start=event_window_bridge.EventBound("start_messages", timedelta(minutes=3)),
+                end=event_window_bridge.EventBound(
+                    "publisher_messages_finished", timedelta(seconds=-30)
+                ),
+            ),
+        ]

--- a/src/deployments/waku/bridge.py
+++ b/src/deployments/waku/bridge.py
@@ -1,18 +1,14 @@
 import logging
 from datetime import timedelta
-from typing import Dict, Literal
+from typing import List, Literal
 
-from src.deployments.core.event_window_bridge import (
-    EventWindowBridge,
-    EventWindowEndpoint,
-    event_window,
-)
+import src.deployments.core.event_window_bridge as event_window_bridge
 from src.deployments.waku.builders.helpers import WAKU_CONTAINER_NAME
 
 logger = logging.getLogger(__name__)
 
 
-class Bridge(EventWindowBridge):
+class Bridge(event_window_bridge.EventWindowBridge):
     interval: Literal["complete", "stable"] = "complete"
     """Time interval for start and end times.
 
@@ -23,13 +19,19 @@ class Bridge(EventWindowBridge):
     """
 
     container_name: str = WAKU_CONTAINER_NAME
-    event_windows: Dict[str, Dict[str, EventWindowEndpoint]] = {
-        "complete": {
-            "start": event_window("wait_for_clear_finished"),
-            "end": event_window("internal_run_finished", timedelta(seconds=30)),
-        },
-        "stable": {
-            "start": event_window("start_messages", timedelta(minutes=3)),
-            "end": event_window("publisher_messages_finished", timedelta(seconds=-30)),
-        },
-    }
+
+    def event_windows(self) -> List[event_window_bridge.EventWindow]:
+        return [
+            event_window_bridge.EventWindow(
+                key="complete",
+                start=event_window_bridge.EventBound("wait_for_clear_finished"),
+                end=event_window_bridge.EventBound("internal_run_finished", timedelta(seconds=30)),
+            ),
+            event_window_bridge.EventWindow(
+                key="stable",
+                start=event_window_bridge.EventBound("start_messages", timedelta(minutes=3)),
+                end=event_window_bridge.EventBound(
+                    "publisher_messages_finished", timedelta(seconds=-30)
+                ),
+            ),
+        ]

--- a/src/deployments/waku/bridge.py
+++ b/src/deployments/waku/bridge.py
@@ -1,44 +1,35 @@
 import logging
 from datetime import timedelta
-from pathlib import Path
-from typing import Literal
+from typing import Dict, Literal
 
-from src.deployments.core.base_bridge import BaseBridge, EventMapping
+from src.deployments.core.event_window_bridge import (
+    EventWindowBridge,
+    EventWindowEndpoint,
+    event_window,
+)
 from src.deployments.waku.builders.helpers import WAKU_CONTAINER_NAME
 
 logger = logging.getLogger(__name__)
 
 
-class Bridge(BaseBridge):
+class Bridge(EventWindowBridge):
     interval: Literal["complete", "stable"] = "complete"
     """Time interval for start and end times.
 
     complete: From the beginning to the end of the whole experiment run code
 
     stable: Just the time where nodes should have stablized.
-    Calculated in _get_metadata_events by adding an offset from when message publishing starts and ends.
+    Calculated by adding offsets to message publishing start/end events.
     """
 
-    def get_metadata(self, events_log_path: str) -> dict:
-        metadata = super().get_metadata(events_log_path)
-        events = self._get_metadata_events(events_log_path)
-        metadata["results"] = events
-        metadata["stack"]["start_time"] = events[self.interval]["start"]
-        metadata["stack"]["end_time"] = events[self.interval]["end"]
-        metadata["stack"]["container_name"] = WAKU_CONTAINER_NAME
-        return metadata
-
-    def _get_metadata_events(self, events_log_path: str):
-        events = [
-            ("wait_for_clear_finished", Path("complete", "start"), timedelta(seconds=0)),
-            ("internal_run_finished", Path("complete", "end"), timedelta(seconds=30)),
-            ("start_messages", Path("stable", "start"), timedelta(minutes=3)),
-            ("publisher_messages_finished", Path("stable", "end"), timedelta(seconds=-30)),
-        ]
-        events_list = list(
-            map(
-                lambda obj: EventMapping(key={"event": obj[0]}, target=obj[1], time_shift=obj[2]),
-                events,
-            )
-        )
-        return self._get_metadata_from_events_list(events_log_path, events_list)
+    container_name: str = WAKU_CONTAINER_NAME
+    event_windows: Dict[str, Dict[str, EventWindowEndpoint]] = {
+        "complete": {
+            "start": event_window("wait_for_clear_finished"),
+            "end": event_window("internal_run_finished", timedelta(seconds=30)),
+        },
+        "stable": {
+            "start": event_window("start_messages", timedelta(minutes=3)),
+            "end": event_window("publisher_messages_finished", timedelta(seconds=-30)),
+        },
+    }


### PR DESCRIPTION
The rationale is to factor out a repeated bridge pattern: “given an events log, define named time windows from event markers, optionally shift the bounds, then expose the selected interval as stack start/end.”

Before this abstraction, each protocol bridge tends to repeat the same shape:
```python
complete.start = wait_for_clear_finished
complete.end = internal_run_finished + 30s
stable.start = start_messages + 3m
stable.end = publisher_messages_finished - 30s
```

`EventWindowEndpoint` is the small data model for one bound of a window:
```
key: dict
time_shift: timedelta
```

So instead of manually constructing `EventMapping(...)` everywhere, callers can write:
```
"stable": {
    "start": event_window("start_messages", timedelta(minutes=3)),
    "end": event_window("publisher_messages_finished", timedelta(seconds=-30)),
}
```

`EventWindowBridge` is the reusable bridge base for classes where metadata is driven by those windows. It does three things:
1. Converts event_windows into EventMappings.
2. Calls the existing _get_metadata_from_events_list(...) machinery.
3. Copies the selected interval into:
```
metadata["stack"]["start_time"]
metadata["stack"]["end_time"]
metadata["results"]
metadata["stack"]["container_name"]
```

That lets bridges for waku, libp2p or service discovery become declarative, they only define container_name, available windows, and default selected interval.