### PR TITLE
Improve experiment config CLI params

### DIFF
--- a/deployment.py
+++ b/deployment.py
@@ -12,8 +12,8 @@ from ruamel import yaml
 # Project Imports
 from src.analysis.utils.log_utils import init_logger
 from src.deployments.core.k8s_kubeconfig import set_config_file
-from src.deployments.experiments.base_experiment import ARG_NOT_SET
 from src.deployments.registry import registry as experiment_registry
+from src.deployments.utils.parser import ARG_NOT_SET
 
 logger = logging.getLogger(__name__)
 

--- a/src/deployments/deployment/waku/experiments/jswaku/jswaku.py
+++ b/src/deployments/deployment/waku/experiments/jswaku/jswaku.py
@@ -211,7 +211,7 @@ class JsWakuNodes(BaseExperiment, BaseModel):
             cls.name,
             help="Run an experiment with lightpush nodes that are disconnected/reconnected.",
         )
-        BaseExperiment.add_args(subparser)
+        BaseExperiment.add_base_args(subparser)
 
     def _preprocess_event(self, event: Any) -> Any:
         if isinstance(event, str):

--- a/src/deployments/deployment/waku/experiments/jswaku/jswaku.py
+++ b/src/deployments/deployment/waku/experiments/jswaku/jswaku.py
@@ -201,17 +201,15 @@ if curl -s -X GET http://$node:${jswaku_external_port}/waku/v1/peer-info \
         return prefix + ["\n".join(script) + "\n"]
 
 
-@experiment(name="jswaku")
-class JsWakuNodes(BaseExperiment, BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+class EmptyConfig(BaseModel):
+    pass
 
-    @classmethod
-    def add_parser(cls, subparsers) -> None:
-        subparser = subparsers.add_parser(
-            cls.name,
-            help="Run an experiment with lightpush nodes that are disconnected/reconnected.",
-        )
-        BaseExperiment.add_base_args(subparser)
+
+@experiment(name="jswaku")
+class JsWakuNodes(BaseExperiment[EmptyConfig]):
+    """Run an experiment with lightpush nodes that are disconnected/reconnected."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def _preprocess_event(self, event: Any) -> Any:
         if isinstance(event, str):

--- a/src/deployments/experiments/base_experiment.py
+++ b/src/deployments/experiments/base_experiment.py
@@ -42,6 +42,7 @@ from src.deployments.core.k8s_deploy import kubectl_apply
 from src.deployments.core.k8s_object import k8s_obj_to_dict
 from src.deployments.core.k8s_rollout import wait_for_rollout
 from src.deployments.registry import registry as experiment_registry
+from src.deployments.utils.parser import _config_model_fields_to_args
 from src.utils.yaml_utils import get_YAML
 
 V1Deployable = Union[
@@ -62,7 +63,6 @@ V1Deployable = Union[
 
 logger = logging.getLogger(__name__)
 
-ARG_NOT_SET = object()
 
 TCfg = TypeVar("TCfg", bound=BaseModel)
 
@@ -118,8 +118,19 @@ class BaseExperiment(ABC, BaseModel, Generic[TCfg]):
             **self.model_dump(exclude={"metadata"}),
         }
 
+    @classmethod
+    def add_parser(cls, subparsers) -> None:
+        subparser = subparsers.add_parser(cls.name, help=cls.__doc__)
+        cls.add_base_args(subparser)
+        cls.add_config_args(subparser)
+        cls.add_args(subparser)
+
+    @classmethod
+    def add_args(cls, subparser) -> None:
+        pass
+
     @staticmethod
-    def add_args(subparser: ArgumentParser):
+    def add_base_args(subparser: ArgumentParser):
         subparser.add_argument(
             "--skip-check",
             action="store_true",
@@ -138,8 +149,15 @@ class BaseExperiment(ABC, BaseModel, Generic[TCfg]):
             type=str,
             required=False,
             default="zerotesting",
+            metavar="(str)",
             help="The namespace for deployments.",
         )
+
+    @classmethod
+    def add_config_args(cls, subparser: ArgumentParser) -> None:
+        config_model = cls.model_fields["config"].annotation
+        for flag, kwargs in _config_model_fields_to_args(config_model):
+            subparser.add_argument(flag, **kwargs)
 
     async def deploy(
         self,

--- a/src/deployments/experiments/base_experiment.py
+++ b/src/deployments/experiments/base_experiment.py
@@ -43,6 +43,7 @@ from src.deployments.core.k8s_object import k8s_obj_to_dict
 from src.deployments.core.k8s_rollout import wait_for_rollout
 from src.deployments.registry import registry as experiment_registry
 from src.deployments.utils.parser import _config_model_fields_to_args
+from src.utils.cli_utils import flag_exists
 from src.utils.yaml_utils import get_YAML
 
 V1Deployable = Union[
@@ -72,7 +73,6 @@ class BaseExperiment(ABC, BaseModel, Generic[TCfg]):
 
     How to use:
         - Inherit from this class.
-        - Call `BaseExperiment.add_args` in the child class's `add_parser`
         - Implement `_run` in the child class.
     """
 
@@ -118,12 +118,18 @@ class BaseExperiment(ABC, BaseModel, Generic[TCfg]):
             **self.model_dump(exclude={"metadata"}),
         }
 
+    def __init_subclass__(cls, **kwargs):
+        """Ensure add_parser is not overridden."""
+        super().__init_subclass__(**kwargs)
+        if cls.add_parser.__func__ is not BaseExperiment.add_parser.__func__:
+            raise TypeError("Cannot override add_parser method")
+
     @classmethod
     def add_parser(cls, subparsers) -> None:
         subparser = subparsers.add_parser(cls.name, help=cls.__doc__)
+        cls.add_args(subparser)
         cls.add_base_args(subparser)
         cls.add_config_args(subparser)
-        cls.add_args(subparser)
 
     @classmethod
     def add_args(cls, subparser) -> None:
@@ -147,8 +153,7 @@ class BaseExperiment(ABC, BaseModel, Generic[TCfg]):
         subparser.add_argument(
             "--namespace",
             type=str,
-            required=False,
-            default="zerotesting",
+            required=True,
             metavar="(str)",
             help="The namespace for deployments.",
         )
@@ -157,6 +162,9 @@ class BaseExperiment(ABC, BaseModel, Generic[TCfg]):
     def add_config_args(cls, subparser: ArgumentParser) -> None:
         config_model = cls.model_fields["config"].annotation
         for flag, kwargs in _config_model_fields_to_args(config_model):
+            if flag_exists(subparser, flag):
+                # Do not generate config flag if it already exists.
+                continue
             subparser.add_argument(flag, **kwargs)
 
     async def deploy(

--- a/src/deployments/experiments/libp2p/connmanager.py
+++ b/src/deployments/experiments/libp2p/connmanager.py
@@ -115,13 +115,9 @@ class ExpConfig(BaseModel):
 
 @experiment(name="connmanager")
 class ConnManagerExperiment(BaseExperiment[ExpConfig]):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    """Connection manager experiment"""
 
-    @classmethod
-    def add_parser(cls, subparsers) -> None:
-        subparser = subparsers.add_parser(cls.name, help="Connection manager experiment")
-        BaseExperiment.add_base_args(subparser)
-        subparser.set_defaults(namespace="nimlibp2p")
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def _get_metadata(self) -> dict:
         return Libp2pBridge().get_metadata(self.events_log_path)
@@ -698,13 +694,6 @@ class ConnManagerAScale(Multiple):
         self.config.delay = 15
         super().model_post_init(__context)
 
-    @classmethod
-    def add_parser(cls, subparsers) -> None:
-        subparser = subparsers.add_parser(cls.name, help="Run A at scale steps")
-        Multiple.add_base_args(subparser)
-        BaseExperiment.add_base_args(subparser)
-        subparser.set_defaults(namespace="nimlibp2p")
-
     def get_params_list(self) -> list[dict]:
         return [
             {
@@ -730,13 +719,6 @@ class ConnManagerEScale(Multiple):
         self.config.delay = 15
         super().model_post_init(__context)
 
-    @classmethod
-    def add_parser(cls, subparsers) -> None:
-        subparser = subparsers.add_parser(cls.name, help="Run E at scale steps")
-        Multiple.add_base_args(subparser)
-        BaseExperiment.add_base_args(subparser)
-        subparser.set_defaults(namespace="nimlibp2p")
-
     def get_params_list(self) -> list[dict]:
         return [
             {
@@ -758,13 +740,6 @@ class ConnManagerGScale(Multiple):
         self.config.name = "connmanager"
         self.config.delay = 15
         super().model_post_init(__context)
-
-    @classmethod
-    def add_parser(cls, subparsers) -> None:
-        subparser = subparsers.add_parser(cls.name, help="Run G at scale steps")
-        Multiple.add_base_args(subparser)
-        BaseExperiment.add_base_args(subparser)
-        subparser.set_defaults(namespace="nimlibp2p")
 
     def get_params_list(self) -> list[dict]:
         return [
@@ -788,13 +763,6 @@ class ConnManagerHubScale(Multiple):
         self.config.name = "connmanager"
         self.config.delay = 15
         super().model_post_init(__context)
-
-    @classmethod
-    def add_parser(cls, subparsers) -> None:
-        subparser = subparsers.add_parser(cls.name, help="Run A with varying hub counts")
-        Multiple.add_base_args(subparser)
-        BaseExperiment.add_base_args(subparser)
-        subparser.set_defaults(namespace="nimlibp2p")
 
     def get_params_list(self) -> list[dict]:
         return [{"run": "A", "num_hubs": n} for n in HUB_SCALE_STEPS]

--- a/src/deployments/experiments/libp2p/connmanager.py
+++ b/src/deployments/experiments/libp2p/connmanager.py
@@ -120,7 +120,7 @@ class ConnManagerExperiment(BaseExperiment[ExpConfig]):
     @classmethod
     def add_parser(cls, subparsers) -> None:
         subparser = subparsers.add_parser(cls.name, help="Connection manager experiment")
-        BaseExperiment.add_args(subparser)
+        BaseExperiment.add_base_args(subparser)
         subparser.set_defaults(namespace="nimlibp2p")
 
     def _get_metadata(self) -> dict:
@@ -701,8 +701,8 @@ class ConnManagerAScale(Multiple):
     @classmethod
     def add_parser(cls, subparsers) -> None:
         subparser = subparsers.add_parser(cls.name, help="Run A at scale steps")
-        Multiple.add_args(subparser)
-        BaseExperiment.add_args(subparser)
+        Multiple.add_base_args(subparser)
+        BaseExperiment.add_base_args(subparser)
         subparser.set_defaults(namespace="nimlibp2p")
 
     def get_params_list(self) -> list[dict]:
@@ -733,8 +733,8 @@ class ConnManagerEScale(Multiple):
     @classmethod
     def add_parser(cls, subparsers) -> None:
         subparser = subparsers.add_parser(cls.name, help="Run E at scale steps")
-        Multiple.add_args(subparser)
-        BaseExperiment.add_args(subparser)
+        Multiple.add_base_args(subparser)
+        BaseExperiment.add_base_args(subparser)
         subparser.set_defaults(namespace="nimlibp2p")
 
     def get_params_list(self) -> list[dict]:
@@ -762,8 +762,8 @@ class ConnManagerGScale(Multiple):
     @classmethod
     def add_parser(cls, subparsers) -> None:
         subparser = subparsers.add_parser(cls.name, help="Run G at scale steps")
-        Multiple.add_args(subparser)
-        BaseExperiment.add_args(subparser)
+        Multiple.add_base_args(subparser)
+        BaseExperiment.add_base_args(subparser)
         subparser.set_defaults(namespace="nimlibp2p")
 
     def get_params_list(self) -> list[dict]:
@@ -792,8 +792,8 @@ class ConnManagerHubScale(Multiple):
     @classmethod
     def add_parser(cls, subparsers) -> None:
         subparser = subparsers.add_parser(cls.name, help="Run A with varying hub counts")
-        Multiple.add_args(subparser)
-        BaseExperiment.add_args(subparser)
+        Multiple.add_base_args(subparser)
+        BaseExperiment.add_base_args(subparser)
         subparser.set_defaults(namespace="nimlibp2p")
 
     def get_params_list(self) -> list[dict]:

--- a/src/deployments/experiments/libp2p/gossipsub_priority_queues.py
+++ b/src/deployments/experiments/libp2p/gossipsub_priority_queues.py
@@ -15,7 +15,6 @@ from src.deployments.libp2p.builders.builders import Option as NimLibp2p
 from src.deployments.libp2p.builders.helpers import find_libp2p_container_config
 from src.deployments.pod_api_requester.builder import PodApiRequesterBuilder
 from src.deployments.registry import experiment
-from src.deployments.utils.parser import ARG_NOT_SET
 
 logger = logging.getLogger(__name__)
 
@@ -88,62 +87,6 @@ class ExpConfig(BaseModel):
 @experiment(name="gossipsub-priority-queues")
 class GossipSubPriorityQueuesExperiment(BaseExperiment[ExpConfig]):
     model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    @classmethod
-    def add_parser(cls, subparsers):
-        subparser = subparsers.add_parser(cls.name, help="GossipSub Priority Queue Load Testing")
-        BaseExperiment.add_base_args(subparser)
-        subparser.set_defaults(namespace="libp2p-lab")
-
-        # Scenario
-        subparser.add_argument("--scenario", type=str, default=ARG_NOT_SET)
-
-        # Node counts
-        subparser.add_argument("--num-normal-nodes", type=int, default=ARG_NOT_SET)
-        subparser.add_argument("--num-slow-nodes", type=int, default=ARG_NOT_SET)
-        subparser.add_argument("--total-peers", type=int, default=ARG_NOT_SET)
-
-        # Connection
-        subparser.add_argument("--connect-to", type=int, default=ARG_NOT_SET)
-        subparser.add_argument("--muxer", type=str, choices=["yamux", "quic"], default=ARG_NOT_SET)
-
-        # GossipSub mesh
-        subparser.add_argument("--gossipsub-d", type=int, default=ARG_NOT_SET)
-        subparser.add_argument("--gossipsub-d-low", type=int, default=ARG_NOT_SET)
-        subparser.add_argument("--gossipsub-d-high", type=int, default=ARG_NOT_SET)
-        subparser.add_argument("--gossipsub-d-out", type=int, default=ARG_NOT_SET)
-        subparser.add_argument("--gossipsub-d-lazy", type=int, default=ARG_NOT_SET)
-
-        # Queues
-        subparser.add_argument("--high-queue-size", type=int, default=ARG_NOT_SET)
-        subparser.add_argument("--medium-queue-size", type=int, default=ARG_NOT_SET)
-        subparser.add_argument("--low-queue-size", type=int, default=ARG_NOT_SET)
-
-        # Penalty
-        subparser.add_argument("--slow-peer-penalty-weight", type=float, default=ARG_NOT_SET)
-        subparser.add_argument("--slow-peer-penalty-decay", type=float, default=ARG_NOT_SET)
-
-        # Bandwidth
-        subparser.add_argument("--slow-ingress-bandwidth", type=str, default=ARG_NOT_SET)
-        subparser.add_argument("--slow-egress-bandwidth", type=str, default=ARG_NOT_SET)
-
-        # Publisher
-        subparser.add_argument("--num-messages", type=int, default=ARG_NOT_SET)
-        subparser.add_argument("--message-size-bytes", type=int, default=ARG_NOT_SET)
-        subparser.add_argument("--message-rate-per-sec", type=float, default=ARG_NOT_SET)
-        subparser.add_argument(
-            "--publish-from-role", type=str, choices=["normal", "slow", "all"], default=ARG_NOT_SET
-        )
-
-        # Timing
-        subparser.add_argument("--delay-cold-start", type=int, default=ARG_NOT_SET)
-        subparser.add_argument("--run-duration-s", type=int, default=ARG_NOT_SET)
-
-        # Images
-        subparser.add_argument("--image-repo", type=str, default=ARG_NOT_SET)
-        subparser.add_argument("--image-tag", type=str, default=ARG_NOT_SET)
-        subparser.add_argument("--publisher-image-repo", type=str, default=ARG_NOT_SET)
-        subparser.add_argument("--publisher-image-tag", type=str, default=ARG_NOT_SET)
 
     def _get_metadata(self) -> dict:
         return Libp2pBridge().get_metadata(self.events_log_path)

--- a/src/deployments/experiments/libp2p/gossipsub_priority_queues.py
+++ b/src/deployments/experiments/libp2p/gossipsub_priority_queues.py
@@ -8,13 +8,14 @@ from pydantic import BaseModel, ConfigDict
 
 from src.deployments.core.builders import ServiceBuilder
 from src.deployments.core.configs.container import Image
-from src.deployments.experiments.base_experiment import ARG_NOT_SET, BaseExperiment
+from src.deployments.experiments.base_experiment import BaseExperiment
 from src.deployments.libp2p.bridge import Bridge as Libp2pBridge
 from src.deployments.libp2p.builders.builders import Libp2pStatefulSetBuilder
 from src.deployments.libp2p.builders.builders import Option as NimLibp2p
 from src.deployments.libp2p.builders.helpers import find_libp2p_container_config
 from src.deployments.pod_api_requester.builder import PodApiRequesterBuilder
 from src.deployments.registry import experiment
+from src.deployments.utils.parser import ARG_NOT_SET
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +92,7 @@ class GossipSubPriorityQueuesExperiment(BaseExperiment[ExpConfig]):
     @classmethod
     def add_parser(cls, subparsers):
         subparser = subparsers.add_parser(cls.name, help="GossipSub Priority Queue Load Testing")
-        BaseExperiment.add_args(subparser)
+        BaseExperiment.add_base_args(subparser)
         subparser.set_defaults(namespace="libp2p-lab")
 
         # Scenario

--- a/src/deployments/experiments/libp2p/kad_dht.py
+++ b/src/deployments/experiments/libp2p/kad_dht.py
@@ -25,13 +25,9 @@ class ExpConfig(BaseModel):
 
 @experiment(name="kad-dht")
 class KadDHTExperiment(BaseExperiment[ExpConfig]):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    """KAD DHT experiment"""
 
-    @classmethod
-    def add_parser(cls, subparsers) -> None:
-        subparser = subparsers.add_parser(cls.name, help="KAD DHT experiment")
-        BaseExperiment.add_base_args(subparser)
-        subparser.set_defaults(namespace="nimlibp2p")
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     async def _run(self):
         self.log_event("run_start")

--- a/src/deployments/experiments/libp2p/kad_dht.py
+++ b/src/deployments/experiments/libp2p/kad_dht.py
@@ -30,7 +30,7 @@ class KadDHTExperiment(BaseExperiment[ExpConfig]):
     @classmethod
     def add_parser(cls, subparsers) -> None:
         subparser = subparsers.add_parser(cls.name, help="KAD DHT experiment")
-        BaseExperiment.add_args(subparser)
+        BaseExperiment.add_base_args(subparser)
         subparser.set_defaults(namespace="nimlibp2p")
 
     async def _run(self):

--- a/src/deployments/experiments/libp2p/multi_nimlibp2p.py
+++ b/src/deployments/experiments/libp2p/multi_nimlibp2p.py
@@ -26,8 +26,8 @@ class MultiNimlibp2p(Multiple):
         subparser = subparsers.add_parser(
             cls.name, help="Run nimlibp2p multiple times with different parameters."
         )
-        Multiple.add_args(subparser)
-        BaseExperiment.add_args(subparser)
+        Multiple.add_base_args(subparser)
+        BaseExperiment.add_base_args(subparser)
 
     def get_params_paths(self) -> Optional[dict]:
         """Return dict mapping keys to values.yaml paths"""

--- a/src/deployments/experiments/libp2p/multi_nimlibp2p.py
+++ b/src/deployments/experiments/libp2p/multi_nimlibp2p.py
@@ -3,7 +3,6 @@ from typing import Any, Iterable, List, Optional
 from pydantic import BaseModel
 
 from src.deployments.core.configs.container import Image
-from src.deployments.experiments.base_experiment import BaseExperiment
 from src.deployments.experiments.libp2p.nimlibp2p import NimLibp2pExperiment
 from src.deployments.experiments.multi_experiment import Multiple
 from src.deployments.registry import experiment
@@ -16,18 +15,11 @@ def shallow_merge(a: BaseModel, b: BaseModel):
 
 @experiment(name="multi_nimlibp2p")
 class MultiNimlibp2p(Multiple):
+    """Run nimlibp2p multiple times with different parameters."""
 
     def model_post_init(self, __context: Any) -> None:
         self.config.name = NimLibp2pExperiment.name
         super().model_post_init(__context)
-
-    @classmethod
-    def add_parser(cls, subparsers) -> None:
-        subparser = subparsers.add_parser(
-            cls.name, help="Run nimlibp2p multiple times with different parameters."
-        )
-        Multiple.add_base_args(subparser)
-        BaseExperiment.add_base_args(subparser)
 
     def get_params_paths(self) -> Optional[dict]:
         """Return dict mapping keys to values.yaml paths"""

--- a/src/deployments/experiments/libp2p/multi_shadow_gossipsub.py
+++ b/src/deployments/experiments/libp2p/multi_shadow_gossipsub.py
@@ -2,7 +2,6 @@
 # Run with: uv run python deployment.py multi-shadow-gossipsub --skip-check
 from typing import Any, Iterable, List
 
-from src.deployments.experiments.base_experiment import BaseExperiment
 from src.deployments.experiments.libp2p.shadow_gossipsub import ShadowGossipsubExperiment
 from src.deployments.experiments.multi_experiment import Multiple
 from src.deployments.registry import experiment
@@ -10,19 +9,12 @@ from src.deployments.registry import experiment
 
 @experiment(name="multi-shadow-gossipsub")
 class MultiShadowGossipsub(Multiple):
+    """Run shadow-gossipsub multiple times at different scales."""
+
     def model_post_init(self, __context: Any) -> None:
         self.config.name = ShadowGossipsubExperiment.name
         self.config.delay = 60  # Shadow runs finish in seconds; no long inter-run wait
         super().model_post_init(__context)
-
-    @classmethod
-    def add_parser(cls, subparsers) -> None:
-        subparser = subparsers.add_parser(
-            cls.name, help="Run shadow-gossipsub multiple times at different scales."
-        )
-        Multiple.add_base_args(subparser)
-        BaseExperiment.add_base_args(subparser)
-        subparser.set_defaults(namespace="zerotesting-shadow")
 
     def get_params_list(self) -> List[dict]:
         return list(self.exp_params())

--- a/src/deployments/experiments/libp2p/multi_shadow_gossipsub.py
+++ b/src/deployments/experiments/libp2p/multi_shadow_gossipsub.py
@@ -20,8 +20,8 @@ class MultiShadowGossipsub(Multiple):
         subparser = subparsers.add_parser(
             cls.name, help="Run shadow-gossipsub multiple times at different scales."
         )
-        Multiple.add_args(subparser)
-        BaseExperiment.add_args(subparser)
+        Multiple.add_base_args(subparser)
+        BaseExperiment.add_base_args(subparser)
         subparser.set_defaults(namespace="zerotesting-shadow")
 
     def get_params_list(self) -> List[dict]:

--- a/src/deployments/experiments/libp2p/nimlibp2p.py
+++ b/src/deployments/experiments/libp2p/nimlibp2p.py
@@ -29,6 +29,8 @@ BOOTSTRAP_NAME = "bootstrap"
 
 
 class ExpConfig(BaseModel):
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
     num_relay_nodes: NonNegativeInt = 30
     num_messages: NonNegativeInt = 20
     message_size_bytes: NonNegativeInt = 1000
@@ -36,9 +38,10 @@ class ExpConfig(BaseModel):
     delay_after_publish: NonNegativeFloat = 1
     muxer: Muxer = "yamux"
     image: Image = Image(repo="pearsonwhite/dst-nimlibp2p-logging", tag="wip-4.2-1.16.0-amd")
-    # "kad-dht" discovers peers through a bootstrap node; "static" uses the CONNECTTO dial.
     discovery: Discovery = "static"
+    """ "kad-dht" discovers peers through a bootstrap node; "static" uses the CONNECTTO dial."""
     connect_to: NonNegativeInt = 10
+    """Number of nodes to try to connect to for each node when starting up"""
     bootstrap_nodes: NonNegativeInt = 1
     network_delay: NonNegativeInt = 0
     network_jitter: NonNegativeInt = 0
@@ -153,11 +156,6 @@ async def publish(config, namespace, random_name):
 @experiment(name="nimlibp2p")
 class NimLibp2pExperiment(BaseExperiment[ExpConfig]):
     model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    @classmethod
-    def add_parser(cls, subparsers) -> None:
-        subparser = subparsers.add_parser(cls.name, help="nimlibp2p2 experiment")
-        BaseExperiment.add_args(subparser)
 
     def _get_metadata(self) -> dict:
         return Bridge().get_metadata(self.events_log_path)

--- a/src/deployments/experiments/libp2p/shadow_gossipsub.py
+++ b/src/deployments/experiments/libp2p/shadow_gossipsub.py
@@ -58,7 +58,7 @@ class ShadowGossipsubExperiment(BaseExperiment[ExpConfig]):
         subparser = subparsers.add_parser(
             cls.name, help="Run a GossipSub mesh + publisher inside the Shadow simulator."
         )
-        BaseExperiment.add_args(subparser)
+        BaseExperiment.add_base_args(subparser)
         subparser.set_defaults(namespace="zerotesting-shadow")
 
     async def _run(self):

--- a/src/deployments/experiments/libp2p/shadow_gossipsub.py
+++ b/src/deployments/experiments/libp2p/shadow_gossipsub.py
@@ -51,15 +51,9 @@ class ExpConfig(BaseModel):
 
 @experiment(name="shadow-gossipsub")
 class ShadowGossipsubExperiment(BaseExperiment[ExpConfig]):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    """Run a GossipSub mesh + publisher inside the Shadow simulator."""
 
-    @classmethod
-    def add_parser(cls, subparsers) -> None:
-        subparser = subparsers.add_parser(
-            cls.name, help="Run a GossipSub mesh + publisher inside the Shadow simulator."
-        )
-        BaseExperiment.add_base_args(subparser)
-        subparser.set_defaults(namespace="zerotesting-shadow")
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     async def _run(self):
         self.log_event("run_start")

--- a/src/deployments/experiments/multi_experiment.py
+++ b/src/deployments/experiments/multi_experiment.py
@@ -12,9 +12,10 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict
 
-from src.deployments.experiments.base_experiment import ARG_NOT_SET, BaseExperiment
+from src.deployments.experiments.base_experiment import BaseExperiment
 from src.deployments.registry import experiment
 from src.deployments.registry import registry as experiment_registry
+from src.deployments.utils.parser import ARG_NOT_SET
 from src.utils.dict_utils import dict_set
 
 logger = logging.getLogger(__name__)
@@ -56,11 +57,11 @@ class Multiple(BaseExperiment[Config]):
         subparser = subparsers.add_parser(
             cls.name, help="Run an experiment multiple times with different parameters."
         )
-        Multiple.add_args(subparser)
-        BaseExperiment.add_args(subparser)
+        Multiple.add_base_args(subparser)
+        BaseExperiment.add_base_args(subparser)
 
     @classmethod
-    def add_args(cls, subparser) -> None:
+    def add_base_args(cls, subparser) -> None:
         subparser.add_argument(
             "--name", type=str, required=False, help="Name of the experiment to run."
         )

--- a/src/deployments/experiments/multi_experiment.py
+++ b/src/deployments/experiments/multi_experiment.py
@@ -50,18 +50,12 @@ class Config(BaseModel):
 
 @experiment(name="multi")
 class Multiple(BaseExperiment[Config]):
+    """Run an experiment multiple times with different parameters."""
+
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @classmethod
-    def add_parser(cls, subparsers) -> None:
-        subparser = subparsers.add_parser(
-            cls.name, help="Run an experiment multiple times with different parameters."
-        )
-        Multiple.add_base_args(subparser)
-        BaseExperiment.add_base_args(subparser)
-
-    @classmethod
-    def add_base_args(cls, subparser) -> None:
+    def add_args(cls, subparser) -> None:
         subparser.add_argument(
             "--name", type=str, required=False, help="Name of the experiment to run."
         )

--- a/src/deployments/experiments/service_discovery.py
+++ b/src/deployments/experiments/service_discovery.py
@@ -41,7 +41,7 @@ class ServiceDiscovery(BaseExperiment[ExpConfig]):
     @classmethod
     def add_parser(cls, subparsers) -> None:
         subparser = subparsers.add_parser(cls.name, help="Service discovery experiment")
-        BaseExperiment.add_args(subparser)
+        BaseExperiment.add_base_args(subparser)
         subparser.set_defaults(namespace="nimlibp2p")
 
     def log_event(self, event):

--- a/src/deployments/experiments/service_discovery.py
+++ b/src/deployments/experiments/service_discovery.py
@@ -36,13 +36,9 @@ class ExpConfig(BaseModel):
 
 @experiment(name="service-discovery")
 class ServiceDiscovery(BaseExperiment[ExpConfig]):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    """Service discovery experiment"""
 
-    @classmethod
-    def add_parser(cls, subparsers) -> None:
-        subparser = subparsers.add_parser(cls.name, help="Service discovery experiment")
-        BaseExperiment.add_base_args(subparser)
-        subparser.set_defaults(namespace="nimlibp2p")
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def log_event(self, event):
         logger.info(event)

--- a/src/deployments/experiments/tests/base_experiment/test_cli_parser.py
+++ b/src/deployments/experiments/tests/base_experiment/test_cli_parser.py
@@ -253,3 +253,21 @@ def _test_help_string(
 
     for expected_string in expected:
         assert expected_string in captured.out
+
+
+def test_cannot_override_params():
+    parser = argparse.ArgumentParser(description="Test parser", formatter_class=_HelpFormatter)
+    subparsers = parser.add_subparsers(dest="experiment", required=True)
+    with pytest.raises(TypeError):
+
+        class NoOverrideParamExp(BaseExperiment[EmptyExpConfig]):
+            model_config = ConfigDict(use_attribute_docstrings=True)
+
+            name: ClassVar[str] = "NoOverrideParamExp"
+
+            @classmethod
+            def add_parser(cls, subparsers) -> None:
+                subparser = subparsers.add_parser(cls.name, help=cls.__doc__)
+
+        NoOverrideParamExp.add_parser(subparsers)
+        _exp = NoOverrideParamExp()

--- a/src/deployments/experiments/tests/base_experiment/test_cli_parser.py
+++ b/src/deployments/experiments/tests/base_experiment/test_cli_parser.py
@@ -1,6 +1,6 @@
 import argparse
 import logging
-from typing import ClassVar, List, Literal, Optional, Type
+from typing import ClassVar, List, Literal, Type
 
 import pytest
 from pydantic import BaseModel, ConfigDict, Field, NonNegativeFloat, NonNegativeInt
@@ -198,36 +198,6 @@ class ExpWithDescription(BaseExperiment[EmptyExpConfig]):
     ]
 
 
-class ExpWithCustomParserExperiment(BaseExperiment[EmptyExpConfig]):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    @classmethod
-    def add_parser(cls, subparsers) -> None:
-        subparser = subparsers.add_parser(
-            cls.name, help=cls.__doc__, formatter_class=_HelpFormatter
-        )
-        subparser.add_argument(
-            "--custom-arg",
-            type=str,
-            required=False,
-            default="custom-arg",
-            metavar="(str)",
-            help="A custom arg added via a custom add_parser function",
-        )
-
-    async def _run(self):
-        pass
-
-    name: ClassVar[str] = "ExpWithCustomParserExperiment"
-    expected_param_strings: ClassVar[List[str]] = [
-        "ExpWithCustomParserExperiment",
-        "--custom-arg (str)",
-        "custom add_parser function",
-    ]
-
-    unexpected_param_strings: ClassVar[List[str]] = BASE_EXP_EXPECTED
-
-
 class CustomArgsExperiment(BaseExperiment[EmptyExpConfig]):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -262,29 +232,11 @@ def test_experiments(capsys, Exp: Type[BaseExperiment]):
     _test_help_string(capsys, Exp, "description", getattr(Exp, "expected_description", []))
 
 
-def test_experiment_custom(capsys):
-    """add_parser should add help for base args and config args."""
-    _test_help_string(
-        capsys,
-        ExpWithCustomParserExperiment,
-        "description",
-        getattr(ExpWithCustomParserExperiment, "expected_description", []),
-    )
-    _test_help_string(
-        capsys,
-        ExpWithCustomParserExperiment,
-        "params",
-        getattr(ExpWithCustomParserExperiment, "expected_param_strings", []),
-        unexpected=getattr(ExpWithCustomParserExperiment, "unexpected_param_strings", []),
-    )
-
-
 def _test_help_string(
     capsys,
     Exp: Type[BaseExperiment],
     which_help_str: Literal["description", "params"],
     expected: List[str],
-    unexpected: Optional[List[str]] = None,
 ):
     """add_parser should add help for base args and config args."""
     parser = argparse.ArgumentParser(description="Test parser", formatter_class=_HelpFormatter)
@@ -301,7 +253,3 @@ def _test_help_string(
 
     for expected_string in expected:
         assert expected_string in captured.out
-
-    if unexpected:
-        for string in unexpected:
-            assert string not in captured.out

--- a/src/deployments/experiments/tests/base_experiment/test_cli_parser.py
+++ b/src/deployments/experiments/tests/base_experiment/test_cli_parser.py
@@ -1,6 +1,6 @@
 import argparse
 import logging
-from typing import ClassVar, List, Literal, Type
+from typing import ClassVar, List, Literal, Optional, Type
 
 import pytest
 from pydantic import BaseModel, ConfigDict, Field, NonNegativeFloat, NonNegativeInt
@@ -152,9 +152,12 @@ class BasicExp(BaseExperiment[BasicExpConfig]):
     name: ClassVar[str] = "BasicExp"
 
 
-BASE_EXP_CONFIG_EXPECTED = [
+BASE_EXPECTED = [
     "-h, --help",
     "show this help message and exit",
+]
+
+BASE_EXP_EXPECTED = [
     "--skip-check",
     "If present, does not wait",
     "--dry-run",
@@ -203,7 +206,6 @@ class ExpWithCustomParserExperiment(BaseExperiment[EmptyExpConfig]):
         subparser = subparsers.add_parser(
             cls.name, help=cls.__doc__, formatter_class=_HelpFormatter
         )
-        cls.add_args(subparser)
         subparser.add_argument(
             "--custom-arg",
             type=str,
@@ -222,6 +224,8 @@ class ExpWithCustomParserExperiment(BaseExperiment[EmptyExpConfig]):
         "--custom-arg (str)",
         "custom add_parser function",
     ]
+
+    unexpected_param_strings: ClassVar[List[str]] = BASE_EXP_EXPECTED
 
 
 class CustomArgsExperiment(BaseExperiment[EmptyExpConfig]):
@@ -253,7 +257,7 @@ class CustomArgsExperiment(BaseExperiment[EmptyExpConfig]):
 )
 def test_experiments(capsys, Exp: Type[BaseExperiment]):
     """add_parser should add help for base args and config args."""
-    _test_help_string(capsys, Exp, "params", BASE_EXP_CONFIG_EXPECTED)
+    _test_help_string(capsys, Exp, "params", BASE_EXPECTED + BASE_EXP_EXPECTED)
     _test_help_string(capsys, Exp, "params", getattr(Exp, "expected_param_strings", []))
     _test_help_string(capsys, Exp, "description", getattr(Exp, "expected_description", []))
 
@@ -266,6 +270,13 @@ def test_experiment_custom(capsys):
         "description",
         getattr(ExpWithCustomParserExperiment, "expected_description", []),
     )
+    _test_help_string(
+        capsys,
+        ExpWithCustomParserExperiment,
+        "params",
+        getattr(ExpWithCustomParserExperiment, "expected_param_strings", []),
+        unexpected=getattr(ExpWithCustomParserExperiment, "unexpected_param_strings", []),
+    )
 
 
 def _test_help_string(
@@ -273,6 +284,7 @@ def _test_help_string(
     Exp: Type[BaseExperiment],
     which_help_str: Literal["description", "params"],
     expected: List[str],
+    unexpected: Optional[List[str]] = None,
 ):
     """add_parser should add help for base args and config args."""
     parser = argparse.ArgumentParser(description="Test parser", formatter_class=_HelpFormatter)
@@ -289,3 +301,7 @@ def _test_help_string(
 
     for expected_string in expected:
         assert expected_string in captured.out
+
+    if unexpected:
+        for string in unexpected:
+            assert string not in captured.out

--- a/src/deployments/experiments/tests/base_experiment/test_cli_parser.py
+++ b/src/deployments/experiments/tests/base_experiment/test_cli_parser.py
@@ -1,0 +1,291 @@
+import argparse
+import logging
+from typing import ClassVar, List, Literal, Type
+
+import pytest
+from pydantic import BaseModel, ConfigDict, Field, NonNegativeFloat, NonNegativeInt
+
+from src.deployments.experiments.base_experiment import BaseExperiment
+from src.deployments.utils.parser import ARG_NOT_SET
+
+logger = logging.getLogger(__name__)
+
+
+class _HelpFormatter(argparse.HelpFormatter):
+    def __init__(self, prog):
+        super().__init__(prog, max_help_position=100, width=220)
+
+
+# Test ExpConfig help strings.
+
+
+class ExpConfigWithoutHelpString(BaseModel):
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    str_arg: str = "Alice"
+
+    expected_param_strings: ClassVar[List[str]] = ["str-arg (str)"]
+
+
+class ExpConfigWithHelpString(BaseModel):
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    str_arg: str = "Alice"
+    """Help string for Alice"""
+
+    expected_param_strings: ClassVar[List[str]] = ["str-arg (str)", "Help string for Alice"]
+
+
+class ExpConfigWithFieldDescription(BaseModel):
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    str_arg: str = Field(description="Help string for Alice", default="Alice")
+
+    expected_param_strings: ClassVar[List[str]] = ["str-arg (str)", "Help string for Alice"]
+
+
+class ExpConfigWithoutDocStringsAttr(BaseModel):
+    """
+    Test that we can still generate if we're missing this line:
+    model_config = ConfigDict(use_attribute_docstrings=True)
+    """
+
+    num_relay_nodes: NonNegativeInt = 30
+    """Docstring here will not show up. That's ok."""
+    num_messages: NonNegativeInt = 20
+    message_size_bytes: NonNegativeInt = 1000
+
+    expected_param_strings: ClassVar[List[str]] = [
+        "num-relay-nodes (int)",
+        "num-messages",
+        "message-size-bytes",
+    ]
+
+
+Choice = Literal["choice_1", "choice_2", "choice_3"]
+
+
+class ClassArg(BaseModel):
+    pass
+
+
+class ExpConfigTypes(BaseModel):
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    int_arg: NonNegativeInt = 30
+    float_arg: NonNegativeFloat = 1
+    str_arg: str = "Alice"
+    choice_arg: Choice = "choice_1"
+    literal_arg: Literal["literal_1", "literal_2"] = "literal_1"
+    class_arg: ClassArg = ClassArg()
+    flag_arg: bool = False
+
+    expected_param_strings: ClassVar[List[str]] = [
+        "int-arg (int)",
+        "float-arg (float)",
+        "str-arg (str)",
+        "--choice-arg (choices: ['choice_1', 'choice_2', 'choice_3'])",
+        "--literal-arg (choices: ['literal_1', 'literal_2'])",
+        "class-arg (ClassArg)",
+        "flag-arg",
+    ]
+
+
+@pytest.fixture(scope="class")
+def TestBaseExp(request):
+    """Fixture for creating an arbitrary Experiment that derives from BaseExperiment[ExpConfig] using a custom ExpConfig."""
+    config_cls = request.param
+
+    DynamicClass = type(f"DynamicTestExp_{config_cls.__name__}", (BaseExperiment[config_cls],), {})
+    DynamicClass.config_cls = config_cls
+    DynamicClass.name = f"TestBaseExpWith{config_cls}"
+
+    return DynamicClass
+
+
+@pytest.mark.parametrize(
+    "TestBaseExp",
+    [
+        ExpConfigWithoutHelpString,
+        ExpConfigWithHelpString,
+        ExpConfigWithFieldDescription,
+        ExpConfigWithoutDocStringsAttr,
+        ExpConfigTypes,
+    ],
+    indirect=True,
+)
+class TestExperimentLogic:
+    # TODO: add other expconfigs (types, etc.)
+    def test_class_methods_work(self, capsys, TestBaseExp: Type[BaseExperiment]):
+        parser = argparse.ArgumentParser(
+            description="Test description", formatter_class=_HelpFormatter
+        )
+        subparsers = parser.add_subparsers(dest="experiment", required=True)
+        subparser = subparsers.add_parser(TestBaseExp.__name__, help=TestBaseExp.__doc__)
+        TestBaseExp.add_config_args(subparser)
+
+        with pytest.raises(SystemExit):
+            _args = parser.parse_args([TestBaseExp.__name__, "--help"])
+        captured = capsys.readouterr()
+
+        for expected_string in TestBaseExp.config_cls.expected_param_strings:
+            assert expected_string in captured.out
+
+
+# Test Experiment class subparsers
+
+
+class BasicExpConfig(BaseModel):
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    basic_config_arg: str = "Alice"
+
+    expected_param_strings: ClassVar[List[str]] = [
+        "basic-config-arg (str)",
+    ]
+
+
+class BasicExp(BaseExperiment[BasicExpConfig]):
+    async def _run(self):
+        pass
+
+    name: ClassVar[str] = "BasicExp"
+
+
+BASE_EXP_CONFIG_EXPECTED = [
+    "-h, --help",
+    "show this help message and exit",
+    "--skip-check",
+    "If present, does not wait",
+    "--dry-run",
+    "If True, does not actually deploy",
+    "--namespace (str)",
+    "The namespace for deployments.",
+]
+
+
+class EmptyExpConfig(BaseModel):
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+
+class ExpWithoutDescription(BaseExperiment[EmptyExpConfig]):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    name: ClassVar[str] = "ExpWithoutDescription"
+    expected_description: ClassVar[List[str]] = ["ExpWithoutDescription"]
+
+    async def _run(self):
+        pass
+
+
+class ExpWithDescription(BaseExperiment[EmptyExpConfig]):
+    """
+    A dummy experiment.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    async def _run(self):
+        pass
+
+    name: ClassVar[str] = "ExpWithDescription"
+    expected_description: ClassVar[List[str]] = [
+        "ExpWithDescription",
+        "A dummy experiment.",
+    ]
+
+
+class ExpWithCustomParserExperiment(BaseExperiment[EmptyExpConfig]):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @classmethod
+    def add_parser(cls, subparsers) -> None:
+        subparser = subparsers.add_parser(
+            cls.name, help=cls.__doc__, formatter_class=_HelpFormatter
+        )
+        cls.add_args(subparser)
+        subparser.add_argument(
+            "--custom-arg",
+            type=str,
+            required=False,
+            default="custom-arg",
+            metavar="(str)",
+            help="A custom arg added via a custom add_parser function",
+        )
+
+    async def _run(self):
+        pass
+
+    name: ClassVar[str] = "ExpWithCustomParserExperiment"
+    expected_param_strings: ClassVar[List[str]] = [
+        "ExpWithCustomParserExperiment",
+        "--custom-arg (str)",
+        "custom add_parser function",
+    ]
+
+
+class CustomArgsExperiment(BaseExperiment[EmptyExpConfig]):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @classmethod
+    def add_args(cls, subparser) -> None:
+        subparser.add_argument(
+            "--my-custom-arg",
+            type=str,
+            default=ARG_NOT_SET,
+            help="My custom arg.",
+            metavar="(str)",
+        )
+
+    expected_param_strings: ClassVar[List[str]] = [
+        "--my-custom-arg (str)",
+        "My custom arg.",
+    ]
+
+    async def _run(self):
+        pass
+
+    name: ClassVar[str] = "CustomArgsExperiment"
+
+
+@pytest.mark.parametrize(
+    "Exp", [ExpWithoutDescription, ExpWithDescription, BasicExp, CustomArgsExperiment]
+)
+def test_experiments(capsys, Exp: Type[BaseExperiment]):
+    """add_parser should add help for base args and config args."""
+    _test_help_string(capsys, Exp, "params", BASE_EXP_CONFIG_EXPECTED)
+    _test_help_string(capsys, Exp, "params", getattr(Exp, "expected_param_strings", []))
+    _test_help_string(capsys, Exp, "description", getattr(Exp, "expected_description", []))
+
+
+def test_experiment_custom(capsys):
+    """add_parser should add help for base args and config args."""
+    _test_help_string(
+        capsys,
+        ExpWithCustomParserExperiment,
+        "description",
+        getattr(ExpWithCustomParserExperiment, "expected_description", []),
+    )
+
+
+def _test_help_string(
+    capsys,
+    Exp: Type[BaseExperiment],
+    which_help_str: Literal["description", "params"],
+    expected: List[str],
+):
+    """add_parser should add help for base args and config args."""
+    parser = argparse.ArgumentParser(description="Test parser", formatter_class=_HelpFormatter)
+    subparsers = parser.add_subparsers(dest="experiment", required=True)
+    Exp.add_parser(subparsers)
+
+    with pytest.raises(SystemExit):
+        if which_help_str == "params":
+            command = [Exp.name, "--help"]
+        elif which_help_str == "description":
+            command = ["--help"]
+        _args = parser.parse_args(command)
+    captured = capsys.readouterr()
+
+    for expected_string in expected:
+        assert expected_string in captured.out

--- a/src/deployments/experiments/waku.py
+++ b/src/deployments/experiments/waku.py
@@ -81,11 +81,6 @@ class ExpConfig(BaseModel):
 class WakuExperiment(BaseExperiment[ExpConfig]):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    @classmethod
-    def add_parser(cls, subparsers) -> None:
-        subparser = subparsers.add_parser(cls.name, help="Dummy experiment to run and test things.")
-        BaseExperiment.add_args(subparser)
-
     def _get_metadata(self) -> dict:
         return Bridge().get_metadata(self.events_log_path)
 

--- a/src/deployments/utils/parser.py
+++ b/src/deployments/utils/parser.py
@@ -64,6 +64,7 @@ def _field_to_arg(field_name: str, field: FieldInfo) -> tuple[str, dict[str, Any
         choices = get_args(annotation)
         if choices:
             kwargs["type"] = type(choices[0])
+            kwargs["choices"] = choices
 
     if field.description:
         kwargs["help"] = field.description

--- a/src/deployments/utils/parser.py
+++ b/src/deployments/utils/parser.py
@@ -1,30 +1,36 @@
 # Python Imports
-from argparse import ArgumentParser
-from typing import Any, get_args, get_origin, Union
+from typing import Any, Literal, Union, get_args, get_origin
+
+from pydantic import BaseModel
 from pydantic.fields import FieldInfo
-from argparse import ArgumentParser
-from typing import get_args, get_origin, Union, Literal
-import json
-import logging
-import os
-import random
-from abc import ABC, abstractmethod
-from argparse import ArgumentParser
-from collections import defaultdict
-from contextlib import ExitStack
-from copy import deepcopy
-from datetime import datetime, timezone
-from pathlib import Path
-from typing import Any, Dict, Generic, Optional, TypeVar, Union
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
-from ruamel import yaml
 
 ARG_NOT_SET = object()
+
+
+from typing import Any, Literal, Union, get_args, get_origin
+
+
+def _annotation_display(annotation) -> str:
+    annotation = _unwrap_optional(annotation)
+    origin = get_origin(annotation)
+
+    if annotation in (int, float, str, bool):
+        return f"({annotation.__name__})"
+
+    if origin is Literal:
+        values = ", ".join(repr(v) for v in get_args(annotation))
+        return f"(choices: [{values}])"
+
+    if hasattr(annotation, "__name__"):
+        return f"({annotation.__name__})"
+
+    return str(annotation)
+
 
 def _unwrap_optional(annotation):
     origin = get_origin(annotation)
     if origin is Union:
-        args = [a for a in get_args(annotation) if a is not type(None)]
+        args = [arg for arg in get_args(annotation) if arg is not type(None)]
         if len(args) == 1:
             return args[0]
     return annotation
@@ -38,11 +44,12 @@ def _field_to_arg(field_name: str, field: FieldInfo) -> tuple[str, dict[str, Any
         "dest": field_name,
         "default": ARG_NOT_SET,
         "required": False,
-        "type" : str,
+        "type": str,
     }
 
     if annotation is bool:
         kwargs["action"] = "store_true"
+        del kwargs["type"]
 
     if annotation in (int, float, str):
         kwargs["type"] = annotation
@@ -61,7 +68,12 @@ def _field_to_arg(field_name: str, field: FieldInfo) -> tuple[str, dict[str, Any
     if field.description:
         kwargs["help"] = field.description
 
+    type_label = _annotation_display(annotation)
+    if "type" in kwargs.keys():
+        kwargs["metavar"] = f"{type_label}"
+
     return flag, kwargs
+
 
 def _config_model_fields_to_args(config_model: type[BaseModel]) -> list[tuple[str, dict[str, Any]]]:
     args = []

--- a/src/deployments/utils/parser.py
+++ b/src/deployments/utils/parser.py
@@ -7,9 +7,6 @@ from pydantic.fields import FieldInfo
 ARG_NOT_SET = object()
 
 
-from typing import Any, Literal, Union, get_args, get_origin
-
-
 def _annotation_display(annotation) -> str:
     annotation = _unwrap_optional(annotation)
     origin = get_origin(annotation)

--- a/src/deployments/utils/parser.py
+++ b/src/deployments/utils/parser.py
@@ -1,0 +1,70 @@
+# Python Imports
+from argparse import ArgumentParser
+from typing import Any, get_args, get_origin, Union
+from pydantic.fields import FieldInfo
+from argparse import ArgumentParser
+from typing import get_args, get_origin, Union, Literal
+import json
+import logging
+import os
+import random
+from abc import ABC, abstractmethod
+from argparse import ArgumentParser
+from collections import defaultdict
+from contextlib import ExitStack
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Generic, Optional, TypeVar, Union
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
+from ruamel import yaml
+
+ARG_NOT_SET = object()
+
+def _unwrap_optional(annotation):
+    origin = get_origin(annotation)
+    if origin is Union:
+        args = [a for a in get_args(annotation) if a is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    return annotation
+
+
+def _field_to_arg(field_name: str, field: FieldInfo) -> tuple[str, dict[str, Any]]:
+    annotation = _unwrap_optional(field.annotation)
+    flag = f"--{field_name.replace('_', '-')}"
+
+    kwargs: dict[str, Any] = {
+        "dest": field_name,
+        "default": ARG_NOT_SET,
+        "required": False,
+        "type" : str,
+    }
+
+    if annotation is bool:
+        kwargs["action"] = "store_true"
+
+    if annotation in (int, float, str):
+        kwargs["type"] = annotation
+
+    origin = get_origin(annotation)
+    if origin is Union:
+        args = [arg for arg in get_args(annotation) if arg is not type(None)]
+        if len(args) == 1 and args[0] in (int, float, str):
+            kwargs["type"] = args[0]
+
+    if origin is Literal:
+        choices = get_args(annotation)
+        if choices:
+            kwargs["type"] = type(choices[0])
+
+    if field.description:
+        kwargs["help"] = field.description
+
+    return flag, kwargs
+
+def _config_model_fields_to_args(config_model: type[BaseModel]) -> list[tuple[str, dict[str, Any]]]:
+    args = []
+    for field_name, field in config_model.model_fields.items():
+        args.append(_field_to_arg(field_name, field))
+    return args

--- a/src/utils/cli_utils.py
+++ b/src/utils/cli_utils.py
@@ -3,6 +3,14 @@ import re
 from typing import List, Optional
 
 
+def flag_exists(parser, flag_name):
+    """Check if a flag exists in the given parser."""
+    for action in parser._actions:
+        if flag_name in action.option_strings:
+            return True
+    return False
+
+
 def get_flag_value(flag: str, command: List[str]) -> Optional[int]:
     for node in command:
         matches = re.search(f"--{flag}=(?P<numMessages>\\d+)", node)


### PR DESCRIPTION
* Automatically generate params for experiment configs
* Easier to extend BaseExperiment subparser

Before:
```
 python ./deployment.py waku --help
usage: deployment.py waku [-h] [--skip-check] [--dry-run] [--namespace NAMESPACE]

options:
  -h, --help            show this help message and exit
  --skip-check          If present, does not wait until the namespace is empty before running the test.
  --dry-run             If True, does not actually deploy kubernetes configs but run kubectl apply --dry-run.
  --namespace NAMESPACE
                        The namespace for deployments.
```

After:
```
> python ./deployment.py waku --help
usage: deployment.py waku [-h] [--skip-check] [--dry-run] [--namespace (str)] [--num-messages (int)] [--num-nodes (int)] [--num-bootstrap-nodes (int)] [--delay-cold-start (float)]
                          [--delay-after-publish (float)]

options:
  -h, --help            show this help message and exit
  --skip-check          If present, does not wait until the namespace is empty before running the test.
  --dry-run             If True, does not actually deploy kubernetes configs but run kubectl apply --dry-run.
  --namespace (str)     The namespace for deployments.
  --num-messages (int)
  --num-nodes (int)
  --num-bootstrap-nodes (int)
  --delay-cold-start (float)
  --delay-after-publish (float)
```
Now we can do this:
```python ./deployment.py nimlibp2p --num-relay-nodes=80 --namespace zerotesting```
Without having to explicitly add the `--num-relay-nodes` param. It is automatically derived from the field in ExpConfig:
```
class ExpConfig(BaseModel):
    model_config = ConfigDict(use_attribute_docstrings=True)

    num_relay_nodes: NonNegativeInt = 30
```