### PR TITLE
shadow-gossipsub: select muxer and discovery (static | kad-dht)

### DIFF
--- a/src/deployments/experiments/libp2p/multi_shadow_gossipsub.py
+++ b/src/deployments/experiments/libp2p/multi_shadow_gossipsub.py
@@ -1,5 +1,10 @@
-# Drives shadow-gossipsub at multiple scales via the Multiple meta-experiment.
-# Run with: uv run python deployment.py multi-shadow-gossipsub --skip-check
+# Drives shadow-gossipsub across scales and/or muxers via the Multiple meta-experiment.
+# Defaults give the scale sweep; env vars turn it into the muxer regression matrix, e.g.
+#   SHADOW_MUXERS=mplex,yamux,quic SHADOW_SIZES=1000 SHADOW_DISCOVERY=kad-dht \
+#     uv run python deployment.py multi-shadow-gossipsub --values <base.yaml> --skip-check
+# The base (message count, timing, image, resources) comes from --values; the runner
+# only overlays the swept dimensions on top.
+import os
 from typing import Any, Iterable, List
 
 from src.deployments.experiments.libp2p.shadow_gossipsub import ShadowGossipsubExperiment
@@ -7,9 +12,18 @@ from src.deployments.experiments.multi_experiment import Multiple
 from src.deployments.registry import experiment
 
 
+def _env_list(name: str, default: str) -> list:
+    return [x.strip() for x in os.environ.get(name, default).split(",") if x.strip()]
+
+
+SIZES = [int(x) for x in _env_list("SHADOW_SIZES", "10,30,100")]
+MUXERS = _env_list("SHADOW_MUXERS", "yamux")
+DISCOVERY = os.environ.get("SHADOW_DISCOVERY", "static")
+
+
 @experiment(name="multi-shadow-gossipsub")
 class MultiShadowGossipsub(Multiple):
-    """Run shadow-gossipsub multiple times at different scales."""
+    """Run shadow-gossipsub across scales and/or muxers (see env vars above)."""
 
     def model_post_init(self, __context: Any) -> None:
         self.config.name = ShadowGossipsubExperiment.name
@@ -20,8 +34,9 @@ class MultiShadowGossipsub(Multiple):
         return list(self.exp_params())
 
     def exp_params(self) -> Iterable[dict]:
-        for num_nodes in (10, 30, 100):
-            yield {"num_nodes": num_nodes}
+        for size in SIZES:
+            for muxer in MUXERS:
+                yield {"num_nodes": size, "muxer": muxer, "discovery": DISCOVERY}
 
     def get_name_from_params(self, params: dict) -> str:
-        return f"num_nodes_{params['num_nodes']}"
+        return f"nodes_{params['num_nodes']}__muxer_{params['muxer']}__disc_{params['discovery']}"

--- a/src/deployments/experiments/libp2p/multi_shadow_gossipsub.py
+++ b/src/deployments/experiments/libp2p/multi_shadow_gossipsub.py
@@ -39,4 +39,5 @@ class MultiShadowGossipsub(Multiple):
                 yield {"num_nodes": size, "muxer": muxer, "discovery": DISCOVERY}
 
     def get_name_from_params(self, params: dict) -> str:
-        return f"nodes_{params['num_nodes']}__muxer_{params['muxer']}__disc_{params['discovery']}"
+        disc = "kad" if params["discovery"] == "kad-dht" else params["discovery"]
+        return f"n{params['num_nodes']}-{params['muxer']}-{disc}"

--- a/src/deployments/experiments/libp2p/shadow_gossipsub.py
+++ b/src/deployments/experiments/libp2p/shadow_gossipsub.py
@@ -31,6 +31,9 @@ class ExpConfig(BaseModel):
     message_size_bytes: NonNegativeInt = 1000
     delay_seconds: NonNegativeFloat = 2.0
     connect_to: NonNegativeInt = 2
+    muxer: str = "yamux"  # yamux | mplex | quic
+    discovery: str = "static"  # static (CONNECTTO dial) | kad-dht (bootstrap anchor)
+    start_sleep: NonNegativeInt = 60  # node STARTSLEEP before mesh formation
     # Timing (simulated seconds). Publisher starts after the mesh forms (~60s).
     publisher_start_s: NonNegativeInt = 90
     sim_stop_time_s: NonNegativeInt = 180
@@ -70,6 +73,9 @@ class ShadowGossipsubExperiment(BaseExperiment[ExpConfig]):
             sim_stop_time_s=cfg.sim_stop_time_s,
             publisher_start_s=cfg.publisher_start_s,
             connect_to=cfg.connect_to,
+            muxer=cfg.muxer,
+            discovery=cfg.discovery,
+            start_sleep=cfg.start_sleep,
             metrics_interval_s=cfg.metrics_interval_s,
         )
         publisher_config = render_publisher_config(

--- a/src/deployments/experiments/libp2p/shadow_gossipsub.py
+++ b/src/deployments/experiments/libp2p/shadow_gossipsub.py
@@ -47,6 +47,8 @@ class ExpConfig(BaseModel):
     # Floor (µs) for lsquic engine tick re-arms; needs the tick-floor node image.
     # 0 = stock lsquic behavior (which livelocks quic under Shadow).
     lsquic_tick_floor_us: NonNegativeInt = 0
+    # Per-pod process start stagger (pod-i starts at 5000 + i*jitter ms); 0 = lockstep.
+    start_jitter_ms: NonNegativeInt = 0
     # Job-pod resources, sized for ~10 peers; bump for bigger sims.
     cpu_request: str = "2"
     cpu_limit: str = "4"
@@ -91,6 +93,7 @@ class ShadowGossipsubExperiment(BaseExperiment[ExpConfig]):
             model_unblocked_syscall_latency=cfg.model_unblocked_syscall_latency,
             strace_logging_mode=cfg.strace_logging_mode,
             lsquic_tick_floor_us=cfg.lsquic_tick_floor_us,
+            start_jitter_ms=cfg.start_jitter_ms,
         )
         publisher_config = render_publisher_config(
             num_nodes=cfg.num_nodes,

--- a/src/deployments/experiments/libp2p/shadow_gossipsub.py
+++ b/src/deployments/experiments/libp2p/shadow_gossipsub.py
@@ -62,8 +62,10 @@ class ShadowGossipsubExperiment(BaseExperiment[ExpConfig]):
         self.log_event("run_start")
         cfg = self.config
         namespace = self.namespace
-        # unique per run (output folder name carries a random suffix)
-        run_id = self.output_folder.name.lower().replace("_", "-")[:50].strip("-")
+        # unique per run (output folder name carries a random suffix). Cap the length
+        # so the derived `shadow-<run_id>-reader` log-reader pod stays within the k8s
+        # 63-char name limit.
+        run_id = self.output_folder.name.lower().replace("_", "-")[:45].strip("-")
         cm_name = f"shadow-{run_id}"
         job_name = f"shadow-{run_id}"
         pvc_name = f"shadow-{run_id}-data"

--- a/src/deployments/experiments/libp2p/shadow_gossipsub.py
+++ b/src/deployments/experiments/libp2p/shadow_gossipsub.py
@@ -1,7 +1,7 @@
 # Shadow GossipSub experiment: N nim libp2p peers + 1 publisher inside Shadow on a
 # single k8s pod. See the "Using Shadow at DST" runbook in Notion.
 import logging
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, NonNegativeFloat, NonNegativeInt
 
@@ -31,8 +31,8 @@ class ExpConfig(BaseModel):
     message_size_bytes: NonNegativeInt = 1000
     delay_seconds: NonNegativeFloat = 2.0
     connect_to: NonNegativeInt = 2
-    muxer: str = "yamux"  # yamux | mplex | quic
-    discovery: str = "static"  # static (CONNECTTO dial) | kad-dht (bootstrap anchor)
+    muxer: Literal["yamux", "mplex", "quic"] = "yamux"
+    discovery: Literal["static", "kad-dht"] = "static"  # CONNECTTO dial vs kad bootstrap
     start_sleep: NonNegativeInt = 60  # node STARTSLEEP before mesh formation
     # Timing (simulated seconds). Publisher starts after the mesh forms (~60s).
     publisher_start_s: NonNegativeInt = 90

--- a/src/deployments/experiments/libp2p/shadow_gossipsub.py
+++ b/src/deployments/experiments/libp2p/shadow_gossipsub.py
@@ -39,6 +39,14 @@ class ExpConfig(BaseModel):
     sim_stop_time_s: NonNegativeInt = 180
     # storeMetrics scrape cadence (s); short so the last scrape is post-traffic.
     metrics_interval_s: NonNegativeInt = 15
+    # Determinism + diagnostics. seed is rendered into shadow.yaml (Shadow default 1);
+    # strace is global and heavy — small-N diagnosis only.
+    seed: NonNegativeInt = 1
+    model_unblocked_syscall_latency: bool = False
+    strace_logging_mode: str = "off"  # off | standard | deterministic
+    # Floor (µs) for lsquic engine tick re-arms; needs the tick-floor node image.
+    # 0 = stock lsquic behavior (which livelocks quic under Shadow).
+    lsquic_tick_floor_us: NonNegativeInt = 0
     # Job-pod resources, sized for ~10 peers; bump for bigger sims.
     cpu_request: str = "2"
     cpu_limit: str = "4"
@@ -79,6 +87,10 @@ class ShadowGossipsubExperiment(BaseExperiment[ExpConfig]):
             discovery=cfg.discovery,
             start_sleep=cfg.start_sleep,
             metrics_interval_s=cfg.metrics_interval_s,
+            seed=cfg.seed,
+            model_unblocked_syscall_latency=cfg.model_unblocked_syscall_latency,
+            strace_logging_mode=cfg.strace_logging_mode,
+            lsquic_tick_floor_us=cfg.lsquic_tick_floor_us,
         )
         publisher_config = render_publisher_config(
             num_nodes=cfg.num_nodes,

--- a/src/deployments/shadow/builders.py
+++ b/src/deployments/shadow/builders.py
@@ -56,6 +56,7 @@ def render_shadow_yaml(
     model_unblocked_syscall_latency: bool = False,
     strace_logging_mode: str = "off",
     lsquic_tick_floor_us: int = 0,
+    start_jitter_ms: int = 0,
     requester_app_path: str = _REQUESTER_APP_PATH,
 ) -> dict:
     """Build the shadow.yaml dict: N peer hosts running `./main` + a publisher host
@@ -85,16 +86,21 @@ def render_shadow_yaml(
     if discovery == "kad-dht":
         peer_env["NODE_ROLE"] = "RoleNormal"
         peer_env["SERVICE"] = "bootstrap-0"
-    peer_process = {
-        "path": "./main",
-        "start_time": "5s",
-        "expected_final_state": "running",  # daemon: don't error when alive at stop_time
-        "environment": peer_env,
-    }
+    # start_jitter_ms staggers per-pod process start so peers don't wake and dial at
+    # one simulated instant (lockstep wakes force simultaneous-dial collisions that
+    # never occur on real hosts).
     hosts = {
         f"pod-{i}": {
             "network_node_id": 0,
-            "processes": [peer_process],
+            "processes": [
+                {
+                    "path": "./main",
+                    "start_time": f"{5000 + i * start_jitter_ms}ms",
+                    # daemon: don't error when alive at stop_time
+                    "expected_final_state": "running",
+                    "environment": peer_env,
+                }
+            ],
         }
         for i in range(num_nodes)
     }

--- a/src/deployments/shadow/builders.py
+++ b/src/deployments/shadow/builders.py
@@ -52,6 +52,10 @@ def render_shadow_yaml(
     discovery: str = "static",
     start_sleep: int = 60,
     metrics_interval_s: int = 15,
+    seed: int = 1,
+    model_unblocked_syscall_latency: bool = False,
+    strace_logging_mode: str = "off",
+    lsquic_tick_floor_us: int = 0,
     requester_app_path: str = _REQUESTER_APP_PATH,
 ) -> dict:
     """Build the shadow.yaml dict: N peer hosts running `./main` + a publisher host
@@ -75,6 +79,9 @@ def render_shadow_yaml(
         "STARTSLEEP": str(start_sleep),
         "METRICS_INTERVAL_S": str(metrics_interval_s),
     }
+    if lsquic_tick_floor_us > 0:
+        # Needs the tick-floor test-node image (stock images ignore the env var).
+        peer_env["LSQUIC_TICK_FLOOR_US"] = str(lsquic_tick_floor_us)
     if discovery == "kad-dht":
         peer_env["NODE_ROLE"] = "RoleNormal"
         peer_env["SERVICE"] = "bootstrap-0"
@@ -110,6 +117,11 @@ def render_shadow_yaml(
                         "MAXCONNECTIONS": str(num_nodes + 100),
                         "STARTSLEEP": str(start_sleep),
                         "METRICS_INTERVAL_S": str(metrics_interval_s),
+                        **(
+                            {"LSQUIC_TICK_FLOOR_US": str(lsquic_tick_floor_us)}
+                            if lsquic_tick_floor_us > 0
+                            else {}
+                        ),
                     },
                 }
             ],
@@ -128,16 +140,25 @@ def render_shadow_yaml(
             }
         ],
     }
-    return {
+    # Always render the seed so the run's shadow.yaml records it (Shadow defaults to 1).
+    config = {
         "general": {
             "stop_time": f"{sim_stop_time_s}s",
             "progress": True,
+            "seed": seed,
         },
         "network": {
             "graph": {"type": "1_gbit_switch"},
         },
         "hosts": hosts,
     }
+    if model_unblocked_syscall_latency:
+        config["general"]["model_unblocked_syscall_latency"] = True
+    if strace_logging_mode != "off":
+        # Global (all hosts) and voluminous — a straced host writes ~100s of MB per
+        # simulated minute of activity. Diagnostics at small N only.
+        config["experimental"] = {"strace_logging_mode": strace_logging_mode}
+    return config
 
 
 def render_publisher_config(

--- a/src/deployments/shadow/builders.py
+++ b/src/deployments/shadow/builders.py
@@ -1,6 +1,6 @@
 # Builders for Shadow simulator runs: config values -> kubernetes-client objects
 # and yaml dicts. Pure data, no I/O. See the "Using Shadow at DST" runbook.
-from typing import Optional
+from typing import Literal, Optional
 
 from kubernetes.client import (
     V1Capabilities,
@@ -48,8 +48,8 @@ def render_shadow_yaml(
     sim_stop_time_s: int,
     publisher_start_s: int,
     connect_to: int = 2,
-    muxer: str = "yamux",
-    discovery: str = "static",
+    muxer: Literal["yamux", "mplex", "quic"] = "yamux",
+    discovery: Literal["static", "kad-dht"] = "static",
     start_sleep: int = 60,
     metrics_interval_s: int = 15,
     seed: int = 1,

--- a/src/deployments/shadow/builders.py
+++ b/src/deployments/shadow/builders.py
@@ -42,6 +42,110 @@ _SHADOW_SECURITY = V1SecurityContext(
 )
 
 
+def _peer_env(
+    *,
+    num_nodes: int,
+    connect_to: int,
+    muxer: str,
+    discovery: str,
+    start_sleep: int,
+    metrics_interval_s: int,
+    lsquic_tick_floor_us: int,
+) -> dict:
+    """Environment for a relay (pod-*) node."""
+    env = {
+        "PEERS": str(num_nodes),
+        "CONNECTTO": str(connect_to),
+        "SHADOWENV": "true",  # env.nim requires the literal string "true"
+        "MUXER": muxer,
+        "DISCOVERY": discovery,
+        "STARTSLEEP": str(start_sleep),
+        "METRICS_INTERVAL_S": str(metrics_interval_s),
+    }
+    if lsquic_tick_floor_us > 0:
+        # Needs the tick-floor test-node image (stock images ignore the env var).
+        env["LSQUIC_TICK_FLOOR_US"] = str(lsquic_tick_floor_us)
+    if discovery == "kad-dht":
+        env["NODE_ROLE"] = "RoleNormal"
+        env["SERVICE"] = "bootstrap-0"
+    return env
+
+
+def _peer_hosts(num_nodes: int, peer_env: dict, start_jitter_ms: int) -> dict:
+    """The N relay hosts (pod-0..pod-(N-1)). start_jitter_ms staggers per-pod process
+    start so peers don't wake and dial at one simulated instant (lockstep wakes force
+    simultaneous-dial collisions that never occur on real hosts)."""
+    return {
+        f"pod-{i}": {
+            "network_node_id": 0,
+            "processes": [
+                {
+                    "path": "./main",
+                    "start_time": f"{5000 + i * start_jitter_ms}ms",
+                    # daemon: don't error when alive at stop_time
+                    "expected_final_state": "running",
+                    "environment": peer_env,
+                }
+            ],
+        }
+        for i in range(num_nodes)
+    }
+
+
+def _bootstrap_host(
+    *,
+    num_nodes: int,
+    muxer: str,
+    start_sleep: int,
+    metrics_interval_s: int,
+    lsquic_tick_floor_us: int,
+) -> dict:
+    """The kad-dht anchor (bootstrap-0); peers discover through it by hostname."""
+    env = {
+        "PEERS": str(num_nodes),
+        "SHADOWENV": "true",
+        "MUXER": muxer,
+        "DISCOVERY": "kad-dht",
+        "NODE_ROLE": "RoleBootstrap",
+        # the single anchor must accept every node's bootstrap dial, so lift its cap
+        # above the network size (default is 250).
+        "MAXCONNECTIONS": str(num_nodes + 100),
+        "STARTSLEEP": str(start_sleep),
+        "METRICS_INTERVAL_S": str(metrics_interval_s),
+    }
+    if lsquic_tick_floor_us > 0:
+        env["LSQUIC_TICK_FLOOR_US"] = str(lsquic_tick_floor_us)
+    return {
+        "network_node_id": 0,
+        "processes": [
+            {
+                "path": "./main",
+                "start_time": "5s",
+                "expected_final_state": "running",
+                "environment": env,
+            }
+        ],
+    }
+
+
+def _publisher_host(publisher_start_s: int, requester_app_path: str) -> dict:
+    """The publisher host: runs the pod-api-requester in batch mode against the peers."""
+    return {
+        "network_node_id": 0,
+        "processes": [
+            {
+                "path": "/usr/bin/python3",
+                "args": (
+                    f"{requester_app_path}"
+                    f" --mode batch"
+                    f" --config {_CONFIG_MOUNT}/{_PUBLISHER_CONFIG}"
+                ),
+                "start_time": f"{publisher_start_s}s",
+            }
+        ],
+    }
+
+
 def render_shadow_yaml(
     *,
     num_nodes: int,
@@ -71,81 +175,25 @@ def render_shadow_yaml(
     if connect_to >= num_nodes:
         raise ValueError(f"connect_to ({connect_to}) must be smaller than num_nodes ({num_nodes}).")
 
-    peer_env = {
-        "PEERS": str(num_nodes),
-        "CONNECTTO": str(connect_to),
-        "SHADOWENV": "true",  # env.nim requires the literal string "true"
-        "MUXER": muxer,
-        "DISCOVERY": discovery,
-        "STARTSLEEP": str(start_sleep),
-        "METRICS_INTERVAL_S": str(metrics_interval_s),
-    }
-    if lsquic_tick_floor_us > 0:
-        # Needs the tick-floor test-node image (stock images ignore the env var).
-        peer_env["LSQUIC_TICK_FLOOR_US"] = str(lsquic_tick_floor_us)
+    peer_env = _peer_env(
+        num_nodes=num_nodes,
+        connect_to=connect_to,
+        muxer=muxer,
+        discovery=discovery,
+        start_sleep=start_sleep,
+        metrics_interval_s=metrics_interval_s,
+        lsquic_tick_floor_us=lsquic_tick_floor_us,
+    )
+    hosts = _peer_hosts(num_nodes, peer_env, start_jitter_ms)
     if discovery == "kad-dht":
-        peer_env["NODE_ROLE"] = "RoleNormal"
-        peer_env["SERVICE"] = "bootstrap-0"
-    # start_jitter_ms staggers per-pod process start so peers don't wake and dial at
-    # one simulated instant (lockstep wakes force simultaneous-dial collisions that
-    # never occur on real hosts).
-    hosts = {
-        f"pod-{i}": {
-            "network_node_id": 0,
-            "processes": [
-                {
-                    "path": "./main",
-                    "start_time": f"{5000 + i * start_jitter_ms}ms",
-                    # daemon: don't error when alive at stop_time
-                    "expected_final_state": "running",
-                    "environment": peer_env,
-                }
-            ],
-        }
-        for i in range(num_nodes)
-    }
-    if discovery == "kad-dht":
-        hosts["bootstrap-0"] = {
-            "network_node_id": 0,
-            "processes": [
-                {
-                    "path": "./main",
-                    "start_time": "5s",
-                    "expected_final_state": "running",
-                    "environment": {
-                        "PEERS": str(num_nodes),
-                        "SHADOWENV": "true",
-                        "MUXER": muxer,
-                        "DISCOVERY": "kad-dht",
-                        "NODE_ROLE": "RoleBootstrap",
-                        # the single anchor must accept every node's bootstrap dial,
-                        # so lift its cap above the network size (default is 250).
-                        "MAXCONNECTIONS": str(num_nodes + 100),
-                        "STARTSLEEP": str(start_sleep),
-                        "METRICS_INTERVAL_S": str(metrics_interval_s),
-                        **(
-                            {"LSQUIC_TICK_FLOOR_US": str(lsquic_tick_floor_us)}
-                            if lsquic_tick_floor_us > 0
-                            else {}
-                        ),
-                    },
-                }
-            ],
-        }
-    hosts["publisher"] = {
-        "network_node_id": 0,
-        "processes": [
-            {
-                "path": "/usr/bin/python3",
-                "args": (
-                    f"{requester_app_path}"
-                    f" --mode batch"
-                    f" --config {_CONFIG_MOUNT}/{_PUBLISHER_CONFIG}"
-                ),
-                "start_time": f"{publisher_start_s}s",
-            }
-        ],
-    }
+        hosts["bootstrap-0"] = _bootstrap_host(
+            num_nodes=num_nodes,
+            muxer=muxer,
+            start_sleep=start_sleep,
+            metrics_interval_s=metrics_interval_s,
+            lsquic_tick_floor_us=lsquic_tick_floor_us,
+        )
+    hosts["publisher"] = _publisher_host(publisher_start_s, requester_app_path)
     # Always render the seed so the run's shadow.yaml records it (Shadow defaults to 1).
     config = {
         "general": {

--- a/src/deployments/shadow/builders.py
+++ b/src/deployments/shadow/builders.py
@@ -105,6 +105,9 @@ def render_shadow_yaml(
                         "MUXER": muxer,
                         "DISCOVERY": "kad-dht",
                         "NODE_ROLE": "RoleBootstrap",
+                        # the single anchor must accept every node's bootstrap dial,
+                        # so lift its cap above the network size (default is 250).
+                        "MAXCONNECTIONS": str(num_nodes + 100),
                         "STARTSLEEP": str(start_sleep),
                         "METRICS_INTERVAL_S": str(metrics_interval_s),
                     },

--- a/src/deployments/shadow/builders.py
+++ b/src/deployments/shadow/builders.py
@@ -49,6 +49,8 @@ def render_shadow_yaml(
     publisher_start_s: int,
     connect_to: int = 2,
     muxer: str = "yamux",
+    discovery: str = "static",
+    start_sleep: int = 60,
     metrics_interval_s: int = 15,
     requester_app_path: str = _REQUESTER_APP_PATH,
 ) -> dict:
@@ -56,7 +58,11 @@ def render_shadow_yaml(
     running the pod-api-requester in batch mode against the peers' `/publish`
     endpoints. The traffic shape (message count, size, pacing) lives in the
     requester's own config (see `render_publisher_config`), mounted at
-    `{_CONFIG_MOUNT}/{_PUBLISHER_CONFIG}`."""
+    `{_CONFIG_MOUNT}/{_PUBLISHER_CONFIG}`.
+
+    discovery selects mesh formation: "static" dials CONNECTTO peers by pod-N
+    hostname; "kad-dht" adds a `bootstrap-0` anchor host that peers discover
+    through (Shadow resolves it by hostname, so no k8s Service is needed)."""
     if connect_to >= num_nodes:
         raise ValueError(f"connect_to ({connect_to}) must be smaller than num_nodes ({num_nodes}).")
 
@@ -65,8 +71,13 @@ def render_shadow_yaml(
         "CONNECTTO": str(connect_to),
         "SHADOWENV": "true",  # env.nim requires the literal string "true"
         "MUXER": muxer,
+        "DISCOVERY": discovery,
+        "STARTSLEEP": str(start_sleep),
         "METRICS_INTERVAL_S": str(metrics_interval_s),
     }
+    if discovery == "kad-dht":
+        peer_env["NODE_ROLE"] = "RoleNormal"
+        peer_env["SERVICE"] = "bootstrap-0"
     peer_process = {
         "path": "./main",
         "start_time": "5s",
@@ -80,6 +91,26 @@ def render_shadow_yaml(
         }
         for i in range(num_nodes)
     }
+    if discovery == "kad-dht":
+        hosts["bootstrap-0"] = {
+            "network_node_id": 0,
+            "processes": [
+                {
+                    "path": "./main",
+                    "start_time": "5s",
+                    "expected_final_state": "running",
+                    "environment": {
+                        "PEERS": str(num_nodes),
+                        "SHADOWENV": "true",
+                        "MUXER": muxer,
+                        "DISCOVERY": "kad-dht",
+                        "NODE_ROLE": "RoleBootstrap",
+                        "STARTSLEEP": str(start_sleep),
+                        "METRICS_INTERVAL_S": str(metrics_interval_s),
+                    },
+                }
+            ],
+        }
     hosts["publisher"] = {
         "network_node_id": 0,
         "processes": [

--- a/src/deployments/shadow/tests/test_builders.py
+++ b/src/deployments/shadow/tests/test_builders.py
@@ -4,6 +4,10 @@ import pytest
 from ruamel.yaml import YAML
 
 from src.deployments.shadow.builders import (
+    _bootstrap_host,
+    _peer_env,
+    _peer_hosts,
+    _publisher_host,
     build_configmap,
     build_pvc,
     build_shadow_job,
@@ -67,6 +71,77 @@ class TestRenderPublisherConfig:
         assert cfg["requests"][0]["endpoint"] == cfg["endpoints"][0]["name"]
         assert cfg["actions"][0]["requests"] == [cfg["requests"][0]["name"]]
         assert cfg["actions"][0]["targets"] == [cfg["targets"][0]["name"]]
+
+
+# --------------------------------------------------------------------------- #
+# host builders (the pieces render_shadow_yaml assembles)
+# --------------------------------------------------------------------------- #
+class TestHostBuilders:
+    def _env(self, **over):
+        base = dict(
+            num_nodes=5,
+            connect_to=2,
+            muxer="yamux",
+            discovery="static",
+            start_sleep=60,
+            metrics_interval_s=15,
+            lsquic_tick_floor_us=0,
+        )
+        base.update(over)
+        return _peer_env(**base)
+
+    def test_peer_env_static_omits_kad_and_tickfloor(self):
+        env = self._env()
+        assert env["MUXER"] == "yamux" and env["DISCOVERY"] == "static"
+        assert "NODE_ROLE" not in env and "SERVICE" not in env
+        assert "LSQUIC_TICK_FLOOR_US" not in env
+
+    def test_peer_env_kad_adds_role_and_service(self):
+        env = self._env(discovery="kad-dht")
+        assert env["NODE_ROLE"] == "RoleNormal"
+        assert env["SERVICE"] == "bootstrap-0"
+
+    def test_peer_env_tickfloor_only_when_set(self):
+        assert (
+            _peer_env(
+                num_nodes=5,
+                connect_to=2,
+                muxer="quic",
+                discovery="static",
+                start_sleep=60,
+                metrics_interval_s=15,
+                lsquic_tick_floor_us=10000,
+            )["LSQUIC_TICK_FLOOR_US"]
+            == "10000"
+        )
+
+    def test_peer_hosts_stagger_start_time_by_jitter(self):
+        hosts = _peer_hosts(3, {"MUXER": "yamux"}, start_jitter_ms=50)
+        assert [hosts[f"pod-{i}"]["processes"][0]["start_time"] for i in range(3)] == [
+            "5000ms",
+            "5050ms",
+            "5100ms",
+        ]
+        assert all(hosts[h]["processes"][0]["expected_final_state"] == "running" for h in hosts)
+
+    def test_bootstrap_host_lifts_connection_cap(self):
+        h = _bootstrap_host(
+            num_nodes=1000,
+            muxer="yamux",
+            start_sleep=60,
+            metrics_interval_s=15,
+            lsquic_tick_floor_us=0,
+        )
+        env = h["processes"][0]["environment"]
+        assert env["NODE_ROLE"] == "RoleBootstrap"
+        assert env["MAXCONNECTIONS"] == "1100"  # num_nodes + 100
+
+    def test_publisher_host_runs_requester_batch(self):
+        h = _publisher_host(90, "/app/api_requester.py")
+        proc = h["processes"][0]
+        assert proc["path"] == "/usr/bin/python3"
+        assert "--mode batch" in proc["args"]
+        assert proc["start_time"] == "90s"
 
 
 # --------------------------------------------------------------------------- #

--- a/src/deployments/shadow/tests/test_builders.py
+++ b/src/deployments/shadow/tests/test_builders.py
@@ -108,7 +108,7 @@ class TestRenderShadowYaml:
         )
         peer = sy["hosts"]["pod-0"]["processes"][0]
         assert peer["path"] == "./main"
-        assert peer["start_time"] == "5s"
+        assert peer["start_time"] == "5000ms"
         assert peer["expected_final_state"] == "running"
         env = peer["environment"]
         assert env["PEERS"] == "3"


### PR DESCRIPTION
The shadow experiment can only run yamux in static mode currently, this PR adds muxer and discovery selection.

- `render_shadow_yaml` gains `discovery` and `start_sleep`.
- `shadow-gossipsub` ExpConfig exposes `muxer`, `discovery`, `start_sleep` and passes them through.
- `multi-shadow-gossipsub` is now env-configurable (`SHADOW_MUXERS`/`SHADOW_SIZES`/`SHADOW_DISCOVERY`).
- kad-dht bootstrap connection cap is lifted above the network size (otherwise only 250 nodes bootstrap), and matrix run names are shortened so the log-reader pod stays under the 63-char name limit.
- new determinism/diagnostics/quic knobs: `seed`, `strace_logging_mode`, `model_unblocked_syscall_latency`, `lsquic_tick_floor_us` (needs the tick-floor node image), `start_jitter_ms`.

Validated at 1000 nodes (kad-dht) against the cluster regression: mplex and yamux both hit 100% delivery. quic is now solved as well: the freeze was a zero-delay tick livelock in the lsquic wrapper (fixed by the tick-floor image + `lsquic_tick_floor_us`) plus simultaneous-dial collisions from lockstep starts (fixed by `start_jitter_ms`) - quic@1000 completes in ~1h25m at 100% delivery (600000/600000).
