### PR TITLE
WakuExperiment: updates

### DIFF
--- a/log_multi_analysis.py
+++ b/log_multi_analysis.py
@@ -130,6 +130,7 @@ def get_analyzer_for_dev_testing(metadata) -> Analyzer:
     data_puller = DataPuller().with_kwargs(stack)
     stateful_sets = stack["stateful_sets"]
     nodes_per_statefulset = stack["nodes_per_statefulset"]
+    out_folder = metadata["experiment"]["dump"]["output_folder"]
 
     # TODO: We search for all StatefulSets in our exp["stack"],
     # but the bootstrap nodes are relay=False, so they are filtered here.
@@ -146,10 +147,10 @@ def get_analyzer_for_dev_testing(metadata) -> Analyzer:
         .with_reliability_check(
             stateful_sets=[ss[0] for ss in reliability],
             nodes_per_ss=[ss[1] for ss in reliability],
-            expected_num_peers=params["num_nodes"],
+            expected_num_peers=params["num_relay_nodes"],
             expected_num_messages=params["num_messages"],
         )
-        .with_dump_analysis_dir(f"local_data/simulations_data/{metadata['stack']['name']}/")
+        .with_dump_analysis_dir(f"{out_folder}/analysis/")
     )
 
 
@@ -211,7 +212,8 @@ async def main():
     summary = defaultdict(int)
 
     all_results = []
-    for exp in get_experiments():
+    exp_class = "WakuExperiment"
+    for exp in get_experiments(experiment_class=exp_class):
         try:
             results = await process_experiment(exp)
             all_results.append(results)

--- a/src/analysis/mesh_analysis/readers/tracers/tests/test_waku_tracer.py
+++ b/src/analysis/mesh_analysis/readers/tracers/tests/test_waku_tracer.py
@@ -1,0 +1,90 @@
+import re
+
+import pandas as pd
+
+from src.analysis.mesh_analysis.readers.tracers.waku_tracer import WakuTracer
+
+
+def mock_queries(data, tracer):
+    results = [[] for _ in tracer.patterns]
+    for i, pattern_group in enumerate(tracer.patterns):
+        query_results = [[] for _ in pattern_group.trace_pairs]
+        for log_line in data:
+            for j, trace_pair in enumerate(pattern_group.trace_pairs):
+                pattern = trace_pair.regex
+                match = re.search(pattern, log_line[0])
+                if match:
+                    match_as_list = list(match.groups())
+                    match_as_list.extend(log_line[1:])
+                    query_results[j].append(match_as_list)
+            results[i].extend(query_results)
+    return results
+
+
+def test_received_regex_matches_text():
+    tracer = WakuTracer().with_received_pattern_group()
+
+    line = (
+        "received relay message my_peer_id=16U*GiNg1a "
+        "msg_hash=0x17cfd30767acac9b86c18333ba918abef93cc23f65b6c98c845c682584f92583 "
+        "from_peer_id=16U*wJXtuH receivedTime=1763643976019361536"
+    )
+
+    parsed_logs = mock_queries([[line]], tracer)
+    dfs = tracer.trace(parsed_logs)
+    received_df = dfs["received"][0]
+
+    assert list(received_df.columns[:4]) == [
+        "receiver_peer_id",
+        "msg_hash",
+        "sender_peer_id",
+        "timestamp",
+    ]
+    assert received_df.loc[0, "receiver_peer_id"] == "16U*GiNg1a"
+    assert (
+        received_df.loc[0, "msg_hash"]
+        == "0x17cfd30767acac9b86c18333ba918abef93cc23f65b6c98c845c682584f92583"
+    )
+    assert received_df.loc[0, "sender_peer_id"] == "16U*wJXtuH"
+    assert received_df.loc[0, "timestamp"] == pd.Timestamp(1763643976019361536, unit="ns")
+    assert pd.api.types.is_datetime64_ns_dtype(received_df["timestamp"])
+
+
+def test_received_regex_matches_json():
+    tracer = WakuTracer().with_received_pattern_group()
+
+    line = (
+        '{"lvl":"DBG",'
+        '"ts":2026-07-16 15:10:00.145+00:00,'
+        '"msg":"received relay message",'
+        '"topics":"waku relay",'
+        '"tid":7,'
+        '"file":"protocol.nim:221",'
+        '"my_peer_id":"16U*S6zwhq",'
+        '"msg_hash":"0x4d19ab4d7deebcd5c1935d7c27caab678566dbb14f3bf7858d09d466e7c79af7",'
+        '"msg_id":"b9cfa467b62a...67128d31aecc",'
+        '"from_peer_id":"16U*74x9yd",'
+        '"topic":"/waku/2/rs/0/0",'
+        '"contentTopic":"/my-app/1/dst/proto",'
+        '"receivedTime":1784214600145432320,'
+        '"payloadSizeBytes":1000.0}'
+    )
+
+    parsed_logs = mock_queries([[line]], tracer)
+    dfs = tracer.trace(parsed_logs)
+    received_df = dfs["received"][0]
+
+    assert list(received_df.columns[:4]) == [
+        "receiver_peer_id",
+        "msg_hash",
+        "sender_peer_id",
+        "timestamp",
+    ]
+    assert received_df.loc[0, "receiver_peer_id"] == "16U*S6zwhq"
+    assert (
+        received_df.loc[0, "msg_hash"]
+        == "0x4d19ab4d7deebcd5c1935d7c27caab678566dbb14f3bf7858d09d466e7c79af7"
+    )
+    assert received_df.loc[0, "sender_peer_id"] == "16U*74x9yd"
+    assert received_df.loc[0, "timestamp"] == pd.Timestamp(1784214600145432320, unit="ns")
+    assert pd.api.types.is_datetime64_ns_dtype(received_df["timestamp"])

--- a/src/analysis/mesh_analysis/readers/tracers/tests/test_waku_tracer.py
+++ b/src/analysis/mesh_analysis/readers/tracers/tests/test_waku_tracer.py
@@ -55,7 +55,7 @@ def test_received_regex_matches_json():
 
     line = (
         '{"lvl":"DBG",'
-        '"ts":2026-07-16 15:10:00.145+00:00,'
+        '"ts":"2026-07-16 15:10:00.145+00:00",'
         '"msg":"received relay message",'
         '"topics":"waku relay",'
         '"tid":7,'

--- a/src/analysis/mesh_analysis/readers/tracers/waku_tracer.py
+++ b/src/analysis/mesh_analysis/readers/tracers/waku_tracer.py
@@ -56,7 +56,7 @@ class WakuTracer(MessageTracer):
             name="sent",
             trace_pairs=[
                 TracePair(
-                    regex=r"sent relay message.*?my_peer_id=([\w*]+).*?msg_hash=(0x[\da-f]+).*?to_peer_id=([\w*]+).*?sentTime=(\d+)",
+                    regex=r"sent relay message.*?my_peer_id[\s\":=]+([\w*]+).*?msg_hash[\s\":=]+(0x[\da-f]+).*?to_peer_id[\s\":=]+([\w*]+).*?sentTime[\s\":=]+(\d+)",
                     convert=self._trace_sent_in_logs,
                 ),
                 TracePair(

--- a/src/analysis/mesh_analysis/readers/tracers/waku_tracer.py
+++ b/src/analysis/mesh_analysis/readers/tracers/waku_tracer.py
@@ -27,7 +27,7 @@ class WakuTracer(MessageTracer):
                 "received",
                 trace_pairs=[
                     TracePair(
-                        regex=r"received relay message.*?my_peer_id=([\w*]+).*?msg_hash=(0x[\da-f]+).*?from_peer_id=([\w*]+).*?receivedTime=(\d+)",
+                        regex=r"received relay message.*?my_peer_id[\s\":=]+([\w*]+).*?msg_hash[\s\":=]+(0x[\da-f]+).*?from_peer_id[\s\":=]+([\w*]+).*?receivedTime[\s\":=]+(\d+)",
                         convert=self._trace_received_in_logs,
                     ),
                     TracePair(

--- a/src/deployments/experiments/multi_waku.py
+++ b/src/deployments/experiments/multi_waku.py
@@ -1,0 +1,117 @@
+from typing import Any, Iterable, List, Optional
+
+from pydantic import BaseModel
+
+from src.deployments.core.configs.container import Image
+from src.deployments.experiments.multi_experiment import Multiple
+from src.deployments.experiments.waku import WakuExperiment
+from src.deployments.registry import experiment
+
+
+def shallow_merge(a: BaseModel, b: BaseModel):
+    data = {**a.model_dump(), **b.model_dump()}
+    return a.__class__.model_validate(data)
+
+
+def get_num_messages(delay):
+    """Returns the typical num_messages given a delay."""
+    if delay == 10:
+        return 60
+    elif delay == 5:
+        return 125
+    elif delay == 1:
+        return 600
+    else:
+        raise ValueError(f"delay: {delay}")
+
+
+@experiment(name="multi-waku")
+class MultiWaku(Multiple):
+    """Run waku multiple times with different parameters."""
+
+    def model_post_init(self, __context: Any) -> None:
+        self.config.name = WakuExperiment.name
+        super().model_post_init(__context)
+
+    def get_params_paths(self) -> Optional[dict]:
+        """Return dict mapping keys to values.yaml paths"""
+        return None
+
+    def exp_params(self) -> Iterable[dict]:
+        version_list = [
+            "soutullostatus/nwaku-jq-curl:v0.33.0-rc.3",
+            "soutullostatus/nwaku-jq-curl:v0.34.0-rc1",
+            "soutullostatus/nwaku-jq-curl:v0.35.1",
+            "pearsonwhite/nwaku:v0.36.0-rc.0",
+            "soutullostatus/nwaku-jq-curl:v0.37.0-rc.4",
+            "pearsonwhite/nwaku:quic-b778d16",
+            "pearsonwhite/nwaku:quic_b778d16_with_order_fix-amd",
+        ]
+
+        versions = {Image.from_str(item).tag: Image.from_str(item) for item in version_list}
+
+        quic_supported = [
+            "v0.37.0-rc.4",
+            "quic-b778d16",
+            "abort-fix",
+            "c3090fb62febef41a4436eb328944a63486b8e30-linux-amd64",
+            "quic_b778d16_with_order_fix-amd",
+        ]
+        format_changed = [
+            "quic-b778d16",
+            "abort-fix",
+            "c3090fb62febef41a4436eb328944a63486b8e30-linux-amd64",
+            "quic_b778d16_with_order_fix-amd",
+        ]
+
+        base = {
+            "num_bootstrap_nodes": 3,
+            "delay_cold_start": 180,
+        }
+
+        configs = []
+        for num_relay_nodes in [1000]:
+            for delay in [1, 5, 10]:
+                num_messages = get_num_messages(delay)
+                for size in [1, 50]:
+                    for version, image in versions.items():
+                        # Version dependent config params.
+                        if version in quic_supported:
+                            muxers = ["default", "quic"]
+                            log_level = "DEBUG"
+                            cmd_type = "2"
+                        else:
+                            muxers = ["default"]
+                            log_level = "INFO"
+                            cmd_type = "1"
+                        if version in format_changed:
+                            format_json = True
+                        else:
+                            format_json = False
+                        for muxer in muxers:
+                            config_params = {
+                                **base,
+                                "num_relay_nodes": num_relay_nodes,
+                                "delay_after_publish": delay,
+                                "num_messages": num_messages,
+                                "format_json": format_json,
+                                "log_level": log_level,
+                                "cmd_type": cmd_type,
+                                "image": image,
+                                "muxer": muxer,
+                                "msg_size_kbytes": size,
+                            }
+                            configs.append(config_params)
+
+        return configs
+
+    def get_params_list(self) -> List[dict]:
+        return [item for item in self.exp_params()]
+
+    def get_name_from_params(self, params: dict) -> str:
+        version = params["image"].tag
+        keys = ["num_nodes", "num_messages"]
+        used_keys = filter(lambda item: item in keys, params.items())
+        param_list = [f"{key}_{value}" for key, value in used_keys]
+        param_list.append(f"version_{version}")
+        return "__".join(param_list)

--- a/src/deployments/experiments/multi_waku.py
+++ b/src/deployments/experiments/multi_waku.py
@@ -110,8 +110,8 @@ class MultiWaku(Multiple):
 
     def get_name_from_params(self, params: dict) -> str:
         version = params["image"].tag
-        keys = ["num_nodes", "num_messages"]
-        used_keys = filter(lambda item: item in keys, params.items())
+        keys = ["num_relay_nodes"]
+        used_keys = filter(lambda item: item[0] in keys, params.items())
         param_list = [f"{key}_{value}" for key, value in used_keys]
         param_list.append(f"version_{version}")
         return "__".join(param_list)

--- a/src/deployments/experiments/waku.py
+++ b/src/deployments/experiments/waku.py
@@ -208,9 +208,9 @@ class WakuExperiment(BaseExperiment[ExpConfig]):
         relay_name = relay_nodes.metadata.name
         bootstrap_name = deployments["bootstrap"].metadata.name
         namespace = relay_nodes.metadata.namespace
-        logger.info(f"Starting disconnect+publish loop for nodes in `{relay_name}`")
+        logger.info(f"Starting publish loop for nodes in `{relay_name}`")
 
-        if grab_metrics:
+        if self.config.grab_metrics:
             await self.dump_metrics(relay_name, 10, "pre_publish")
 
         self.log_event("start_messages")
@@ -234,7 +234,7 @@ class WakuExperiment(BaseExperiment[ExpConfig]):
         await asyncio.sleep(20)
         self.log_event("publisher_wait_finished")
 
-        if grab_metrics:
+        if self.config.grab_metrics:
             logger.info("Grabbing some metrics")
             for name, num_nodes, desc in [
                 (relay_name, self.config.num_relay_nodes, "relay metrics"),

--- a/src/deployments/experiments/waku.py
+++ b/src/deployments/experiments/waku.py
@@ -173,7 +173,7 @@ class WakuExperiment(BaseExperiment[ExpConfig]):
             try:
                 metrics = await grab_metrics(self.namespace, f"{node_name}-{node_index}")
                 self.dump(metrics, folder_prefix / f"metrics_{node_name}-{node_index}.log")
-            except client.exceptions.ApiException as e:
+            except (client.exceptions.ApiException, RuntimeError, ValueError) as e:
                 logger.error(f"Exception when grabbing /metrics: {e}")
 
         for index in range(0, num_nodes):

--- a/src/deployments/experiments/waku.py
+++ b/src/deployments/experiments/waku.py
@@ -1,14 +1,18 @@
 import asyncio
 import logging
+import os
 import random
 import traceback
-from typing import Dict
+from pathlib import Path
+from typing import Dict, Literal, Optional, Union
 
 from kubernetes import client
-from pydantic import BaseModel, ConfigDict, NonNegativeFloat, NonNegativeInt
+from pydantic import BaseModel, ConfigDict, Field, NonNegativeFloat, NonNegativeInt
 
+from src.deployments.core.configs.container import Image
 from src.deployments.core.configs.statefulset import StatefulSetConfig
-from src.deployments.experiments.base_experiment import BaseExperiment
+from src.deployments.core.pod_interaction import exec_command_in_pod
+from src.deployments.experiments.base_experiment import BaseExperiment, V1Deployable
 from src.deployments.libp2p.builders.nodes import Nodes
 from src.deployments.pod_api_requester.builder import PodApiRequesterBuilder
 from src.deployments.pod_api_requester.configs import Target
@@ -20,35 +24,91 @@ from src.deployments.waku.builders.builders import WakuStatefulSetBuilder
 
 logger = logging.getLogger(__name__)
 
+Muxer = Literal["default", "quic"]
 
-def build_nodes(
-    namespace: str, nodes: NonNegativeInt, bootstrap_nodes: NonNegativeInt
-) -> Dict[str, dict]:
-    config = StatefulSetConfig()
-    api_client = client.ApiClient()
+LogLevel = Literal["INFO", "DEBUG"]
 
-    def to_dict(deployment) -> dict:
-        return api_client.sanitize_for_serialization(deployment)
 
-    builder = WakuStatefulSetBuilder()
-    nodes = (
-        builder.with_waku_config(name="nodes-0", namespace=namespace, num_nodes=nodes)
-        .with_regression()
-        .build()
+class ExpConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    num_messages: NonNegativeInt = 20
+    num_relay_nodes: NonNegativeInt = 20
+    num_bootstrap_nodes: NonNegativeInt = 5
+    msg_size_kbytes: NonNegativeInt = 1
+    delay_cold_start: NonNegativeFloat = 1
+    delay_after_publish: NonNegativeFloat = 0.5
+    muxer: Muxer = "default"
+    log_level: LogLevel = "INFO"
+    format_json: bool = False
+    cmd_type: int = 1
+    image: Image = Field(
+        default_factory=lambda: Image.from_str("soutullostatus/nwaku-jq-curl:v0.37.0-rc.4")
     )
+    grab_metrics: bool = False
 
-    bootstrap = (
-        WakuStatefulSetBuilder(config=config)
-        .with_waku_config(name="bootstrap", namespace=namespace, num_nodes=bootstrap_nodes)
-        .with_bootstrap()
-        .with_args({"--max-connections": 500}, on_duplicate="replace")
-        .build()
+
+def build_relay_nodes(namespace: str, config: ExpConfig) -> V1Deployable:
+    nodes_builder = (
+        WakuStatefulSetBuilder()
+        .with_waku_config(name="relay-0", namespace=namespace, num_nodes=config.num_relay_nodes)
+        .with_regression(config.cmd_type, config.num_bootstrap_nodes)
+        .with_env("SERVICE", "zerotesting-bootstrap")
+        .with_args({"--log-level": config.log_level}, on_duplicate="replace")
+        .with_image(config.image)
     )
+    if config.format_json:
+        nodes_builder.with_args({"--log-format": "JSON"}, on_duplicate="replace")
+    if config.muxer == "quic":
+        nodes_builder.with_args({"--quic-support": True}, on_duplicate="replace").with_args(
+            {"--quic-port": 60000}, on_duplicate="replace"
+        )
+    return nodes_builder.build()
 
+
+def build_bootstrap_nodes(namespace: str, config: ExpConfig) -> V1Deployable:
+    bootstrap_builder = (
+        WakuStatefulSetBuilder()
+        .with_waku_config(
+            name="bootstrap-0", namespace=namespace, num_nodes=config.num_bootstrap_nodes
+        )
+        .with_bootstrap(config.cmd_type)
+        .with_env("SERVICE", "zerotesting-bootstrap")
+        .with_args({"--log-level": config.log_level}, on_duplicate="replace")
+        .with_image(config.image)
+    )
+    if config.format_json:
+        bootstrap_builder.with_args({"--log-format": "JSON"}, on_duplicate="replace")
+    if config.muxer == "quic":
+        bootstrap_builder.with_args({"--quic-support": True}, on_duplicate="replace").with_args(
+            {"--quic-port": 60000}, on_duplicate="replace"
+        )
+    return bootstrap_builder.build()
+
+
+def build_nodes(namespace: str, config: ExpConfig) -> Dict[str, V1Deployable]:
+    bootstrap = build_bootstrap_nodes(namespace, config)
+    nodes = build_relay_nodes(namespace, config)
     return {
-        "bootstrap": to_dict(bootstrap),
-        "nodes": to_dict(nodes),
+        "bootstrap": bootstrap,
+        "relay": nodes,
     }
+
+
+async def grab_metrics(namespace, pod_name, metrics_port: int = 8008) -> str:
+    try:
+        command = exec_command_in_pod(
+            namespace,
+            pod_name,
+            ["/bin/sh", "-c", f"curl -s localhost:{metrics_port}/metrics"],
+        )
+        await command.collect_output_async()
+        if not command.ok:
+            raise RuntimeError(f"Command failed: {command}")
+        logger.debug(f"Retreived /metrics from pod: `{pod_name}` response: `{command.output}`")
+        return command.output
+    except client.exceptions.ApiException as e:
+        logger.error(f"Exception when grabbing /metrics: {e}")
 
 
 def build_store_nodes(namespace: str) -> dict:
@@ -67,14 +127,26 @@ def build_store_nodes(namespace: str) -> dict:
     return api_client.sanitize_for_serialization(deployment)
 
 
-class ExpConfig(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    num_messages: NonNegativeInt = 20
-    num_nodes: NonNegativeInt = 20
-    num_bootstrap_nodes: NonNegativeInt = 5
-    delay_cold_start: NonNegativeFloat = 1
-    delay_after_publish: NonNegativeFloat = 0.5
+async def publish(namespace, random_name, msg_size_kbytes, cluster_id):
+    try:
+        target = Target(
+            name="waku-node",
+            name_template=random_name,
+            service="zerotesting-service",
+            port=8645,
+        )
+        await waku_publish(
+            namespace=namespace,
+            target=target,
+            msg_size_kbytes=msg_size_kbytes,
+            cluster_id=cluster_id,
+        )
+    except PodApiApplicationError as e:
+        logger.error(f"PodApiApplicationError: {e} {traceback.format_exc()}")
+    except PodApiError as e:
+        logger.error(f"PodApiError: {e} {traceback.format_exc()}")
+    except Exception as e:
+        logger.error(f"Other exception: {e} {traceback.format_exc()}")
 
 
 @experiment(name="waku")
@@ -88,59 +160,89 @@ class WakuExperiment(BaseExperiment[ExpConfig]):
         logger.info(event)
         return super().log_event(event)
 
+    def dump(self, obj, file_name):
+        out_path = Path(self.output_folder) / file_name
+        os.makedirs(out_path.parent, exist_ok=True)
+        with open(out_path, "w") as out_file:
+            out_file.write(obj)
+
+    async def dump_metrics(
+        self, node_name: str, num_nodes: NonNegativeInt, folder_prefix: Optional[Union[Path, str]]
+    ):
+        folder_prefix = Path(folder_prefix) if folder_prefix else Path("")
+
+        async def _dump(node_index: int):
+            logger.debug(f"Grabbing metrics for {node_name}-{node_index}")
+            metrics = await grab_metrics(self.namespace, f"{node_name}-{node_index}")
+            self.dump(metrics, folder_prefix / f"metrics_{node_name}-{node_index}.log")
+
+        for index in range(0, num_nodes):
+            # Running as a batch causes failures, so run one at a time.
+            await _dump(node_index=index)
+
     async def _run(self):
         self.log_event("run_start")
 
         # Publisher
         publisher = (
-            PodApiRequesterBuilder()
-            .with_namespace(self.namespace)
-            .with_mode("server")
-            # .with_debug()
-            # .with_image(Image(repo="pearsonwhite/pod-api-requester", tag="9497aebc1483572b5bd4a4712bfcb76a63d04cf8"))
-            .build()
+            PodApiRequesterBuilder().with_namespace(self.namespace).with_mode("server").build()
         )
+
+        if self.config.cmd_type == 1:
+            cluster_id = 2
+        elif self.config.cmd_type == 2:
+            cluster_id = 0
+        else:
+            raise ValueError()
 
         await self.deploy(deployment=publisher, wait_for_ready=True)
 
         # Nodes
-        deployments = build_nodes(
-            self.namespace, self.config.num_nodes, self.config.num_bootstrap_nodes
-        )
+        deployments = build_nodes(self.namespace, self.config)
         for deployment in deployments.values():
             await self.deploy(deployment=deployment)
 
         await asyncio.sleep(self.config.delay_cold_start)
-        nodes = deployments["nodes"]
-        num_nodes = nodes["spec"]["replicas"]
-        name = nodes["metadata"]["name"]
-        namespace = nodes["metadata"]["namespace"]
-        logger.info(f"Starting disconnect+publish loop for nodes in `{name}`")
-        self.log_event("start_messages")
-        for _ in range(0, self.config.num_messages):
-            index = random.randint(0, num_nodes - 1)
-            random_name = f"{name}-{index}"
-            self.log_event({"event": "publish", "node": random_name})
-            try:
-                target = Target(
-                    name="waku-node",
-                    name_template=random_name,
-                    service="zerotesting-service",
-                    port=8645,
-                )
-                await waku_publish(namespace=namespace, target=target)
-            except PodApiApplicationError as e:
-                logger.error(f"PodApiApplicationError: {e} {traceback.format_exc()}")
-            except PodApiError as e:
-                logger.error(f"PodApiError: {e} {traceback.format_exc()}")
-            except Exception as e:
-                logger.error(f"Other exception: {e} {traceback.format_exc()}")
+        relay_nodes = deployments["relay"]
+        num_relay_nodes = relay_nodes.spec.replicas
+        relay_name = relay_nodes.metadata.name
+        bootstrap_name = deployments["bootstrap"].metadata.name
+        namespace = relay_nodes.metadata.namespace
+        logger.info(f"Starting disconnect+publish loop for nodes in `{relay_name}`")
 
+        if grab_metrics:
+            await self.dump_metrics(relay_name, 10, "pre_publish")
+
+        self.log_event("start_messages")
+        tasks = []
+        for message_index in range(0, self.config.num_messages):
+            index = random.randint(0, num_relay_nodes - 1)
+            random_name = f"{relay_name}-{index}"
+            self.log_event(
+                {"event": "publish", "node": random_name, "message_index": message_index}
+            )
+            tasks.append(
+                asyncio.create_task(
+                    publish(namespace, random_name, self.config.msg_size_kbytes, cluster_id)
+                )
+            )
             await asyncio.sleep(self.config.delay_after_publish)
+        await asyncio.gather(*tasks)
 
         self.log_event("publisher_messages_finished")
 
         await asyncio.sleep(20)
         self.log_event("publisher_wait_finished")
+
+        if grab_metrics:
+            logger.info("Grabbing some metrics")
+            for name, num_nodes, desc in [
+                (relay_name, self.config.num_relay_nodes, "relay metrics"),
+                (bootstrap_name, self.config.num_bootstrap_nodes, "bootstrap metrics"),
+            ]:
+                try:
+                    await self.dump_metrics(name, min(10, num_nodes), "post_publish")
+                except Exception as e:
+                    logger.error(f"Failed in grabbing {desc}: {e}")
 
         self.log_event("internal_run_finished")

--- a/src/deployments/experiments/waku.py
+++ b/src/deployments/experiments/waku.py
@@ -96,19 +96,16 @@ def build_nodes(namespace: str, config: ExpConfig) -> Dict[str, V1Deployable]:
 
 
 async def grab_metrics(namespace, pod_name, metrics_port: int = 8008) -> str:
-    try:
-        command = exec_command_in_pod(
-            namespace,
-            pod_name,
-            ["/bin/sh", "-c", f"curl -s localhost:{metrics_port}/metrics"],
-        )
-        await command.collect_output_async()
-        if not command.ok:
-            raise RuntimeError(f"Command failed: {command}")
-        logger.debug(f"Retreived /metrics from pod: `{pod_name}` response: `{command.output}`")
-        return command.output
-    except client.exceptions.ApiException as e:
-        logger.error(f"Exception when grabbing /metrics: {e}")
+    command = exec_command_in_pod(
+        namespace,
+        pod_name,
+        ["/bin/sh", "-c", f"curl -s localhost:{metrics_port}/metrics"],
+    )
+    await command.collect_output_async()
+    if not command.ok:
+        raise RuntimeError(f"Command failed: {command}")
+    logger.debug(f"Retreived /metrics from pod: `{pod_name}` response: `{command.output}`")
+    return command.output
 
 
 def build_store_nodes(namespace: str) -> dict:
@@ -173,8 +170,11 @@ class WakuExperiment(BaseExperiment[ExpConfig]):
 
         async def _dump(node_index: int):
             logger.debug(f"Grabbing metrics for {node_name}-{node_index}")
-            metrics = await grab_metrics(self.namespace, f"{node_name}-{node_index}")
-            self.dump(metrics, folder_prefix / f"metrics_{node_name}-{node_index}.log")
+            try:
+                metrics = await grab_metrics(self.namespace, f"{node_name}-{node_index}")
+                self.dump(metrics, folder_prefix / f"metrics_{node_name}-{node_index}.log")
+            except client.exceptions.ApiException as e:
+                logger.error(f"Exception when grabbing /metrics: {e}")
 
         for index in range(0, num_nodes):
             # Running as a batch causes failures, so run one at a time.

--- a/src/deployments/waku/builders/bootstrap.py
+++ b/src/deployments/waku/builders/bootstrap.py
@@ -3,32 +3,10 @@ from kubernetes.client import V1ResourceRequirements
 
 # Project Imports
 from src.deployments.core.builders import default_readiness_probe_health
-from src.deployments.core.configs.command import CommandConfig
 from src.deployments.core.configs.container import ContainerConfig
 from src.deployments.core.configs.pod import PodSpecConfig, PodTemplateSpecConfig
 from src.deployments.core.configs.statefulset import StatefulSetConfig, StatefulSetSpecConfig
-from src.deployments.waku.builders.helpers import WAKU_COMMAND_STR, find_waku_container_config
-
-
-def apply_command_config(config: CommandConfig):
-    command = config.find_command(WAKU_COMMAND_STR)
-    if command is None:
-        raise ValueError(f"Waku command not found. CommandConfig: `{config}`")
-    command.args.extend(
-        [
-            ("--relay", False),
-            ("--rest", True),
-            ("--rest-address", "0.0.0.0"),
-            ("--max-connections", 1000),
-            ("--discv5-discovery", True),
-            ("--discv5-enr-auto-update", True),
-            ("--log-level", "INFO"),
-            ("--metrics-server", True),
-            ("--metrics-server-address", "0.0.0.0"),
-            ("--nat", "extip:$IP"),
-            ("--cluster-id", 2),
-        ]
-    )
+from src.deployments.waku.builders.helpers import find_waku_container_config
 
 
 def apply_container_config(config: ContainerConfig, *, overwrite: bool = False):
@@ -62,7 +40,6 @@ def apply_stateful_set_spec_config(
 def apply_stateful_set_config(
     config: StatefulSetConfig, namespace: str, *, overwrite: bool = False
 ):
-    config.name = "bootstrap"
     apply_stateful_set_spec_config(config.stateful_set_spec, namespace, overwrite=overwrite)
 
 
@@ -72,9 +49,8 @@ def create_resources() -> V1ResourceRequirements:
     )
 
 
-def create_args() -> dict:
-    return {
-        "--cluster-id": 2,
+def create_args(cmd_type: int) -> dict:
+    base = {
         "--discv5-discovery": True,
         "--discv5-enr-auto-update": True,
         "--log-level": "INFO",
@@ -86,3 +62,17 @@ def create_args() -> dict:
         "--rest-address": "0.0.0.0",
         "--rest": True,
     }
+    if cmd_type == 1:
+        return {
+            **base,
+            "--cluster-id": 2,
+            "--shard": 0,
+        }
+    elif cmd_type == 2:
+        return {
+            **base,
+            "--num-shards-in-network": 1,
+            "--shard": 0,
+        }
+
+    raise ValueError(f"Invalid cmd_type: `{cmd_type}`")

--- a/src/deployments/waku/builders/builders.py
+++ b/src/deployments/waku/builders/builders.py
@@ -1,6 +1,9 @@
 # Python imports
 from typing import List, Literal, Optional, Self
 
+from kubernetes.client import (
+    V1EnvVar,
+)
 from pydantic import PositiveInt
 
 # Project imports
@@ -35,22 +38,25 @@ class WakuStatefulSetBuilder(StatefulSetBuilder):
         self.config.stateful_set_spec.replicas = num_nodes
         return self
 
-    def with_regression(self) -> Self:
+    def with_regression(self, cmd_type: int, num_enrs: int) -> Self:
         if not self.config.name:
             raise ValueError(f"Must configure node first. Config: `{self.config}`")
-        self.with_args(RegressionNodes.create_args())
-        self.with_enr(3, [f"zerotesting-bootstrap.{self.config.namespace}"])
+        self.with_args(RegressionNodes.create_args(cmd_type))
+        self.with_enr(num_enrs, [f"zerotesting-bootstrap.{self.config.namespace}"])
+        self.config.stateful_set_spec.pod_template_spec_config.pod_spec_config.with_dns_service(
+            f"zerotesting-bootstrap.{self.config.namespace}.svc.cluster.local"
+        )
         container = find_waku_container_config(self.config)
         container.with_resources(Nodes.create_resources())
         return self
 
-    def with_bootstrap(self) -> Self:
+    def with_bootstrap(self, cmd_type: int) -> Self:
         if not self.config.name:
             raise ValueError(f"Must configure node first. Config: `{self.config}`")
         WakuBootstrapNode.apply_stateful_set_config(
             self.config, self.config.namespace, overwrite=True
         )
-        self.with_args(WakuBootstrapNode.create_args())
+        self.with_args(WakuBootstrapNode.create_args(cmd_type))
         return self
 
     def with_store(self) -> Self:
@@ -104,4 +110,9 @@ class WakuStatefulSetBuilder(StatefulSetBuilder):
     def with_pull_policy(self, policy: Literal["IfNotPresent", "Always", "Never"]) -> Self:
         config = find_waku_container_config(self.config)
         config.image_pull_policy = policy
+        return self
+
+    def with_env(self, key: str, value: str) -> Self:
+        config = find_waku_container_config(self.config)
+        config.with_env_var(V1EnvVar(name=key, value=str(value)))
         return self

--- a/src/deployments/waku/builders/builders.py
+++ b/src/deployments/waku/builders/builders.py
@@ -43,7 +43,7 @@ class WakuStatefulSetBuilder(StatefulSetBuilder):
             raise ValueError(f"Must configure node first. Config: `{self.config}`")
         self.with_args(RegressionNodes.create_args(cmd_type))
         self.with_enr(num_enrs, [f"zerotesting-bootstrap.{self.config.namespace}"])
-        self.config.stateful_set_spec.pod_template_spec_config.pod_spec_config.with_dns_service(
+        self.config.stateful_set_spec.pod_template_spec_config.pod_spec_config.with_dns_search(
             f"zerotesting-bootstrap.{self.config.namespace}.svc.cluster.local"
         )
         container = find_waku_container_config(self.config)

--- a/src/deployments/waku/builders/regression.py
+++ b/src/deployments/waku/builders/regression.py
@@ -1,8 +1,7 @@
 class RegressionNodes:
     @staticmethod
-    def create_args() -> dict:
-        return {
-            "--cluster-id": 2,
+    def create_args(cmd_type: int) -> dict:
+        base = {
             "--discv5-discovery": True,
             "--discv5-enr-auto-update": True,
             "--log-level": "INFO",
@@ -14,5 +13,19 @@ class RegressionNodes:
             "--rest-address": "0.0.0.0",
             "--rest-admin": True,
             "--rest": True,
-            "--shard": 0,
         }
+
+        if cmd_type == 1:
+            return {
+                **base,
+                "--cluster-id": 2,
+                "--shard": 0,
+            }
+        elif cmd_type == 2:
+            return {
+                **base,
+                "--num-shards-in-network": 1,
+                "--shard": 0,
+            }
+
+        raise ValueError(f"Invalid cmd_type: `{cmd_type}`")


### PR DESCRIPTION
This is more of a temporary patch to encapsulate some needed changes for running the latest nWaku versions. I expect this logic to change at some point. Hence, it may seem incomplete.

---

Update WakuExperiment

* Add ExpConfig params for image, etc.
* Add option to grab /metrics
* Update builders for new regression params
* Add MultiWakuExperiment with some known versions

Update WakuTracer to support JSON formatted logs

Sometime after nWaku v0.37.0-rc.4, logs the chronicles logging library
adding color fomratting via ANSI escape sequences resulting in difficult
to read logs. To fix this, add this arg to the nWaku node:
`--log-format=JSON`. This change allows the tracer to read the new log
format.