### PR TITLE
Fix kad matrix runner stale num_nodes key

### DIFF
--- a/src/deployments/experiments/libp2p/multi_nimlibp2p_kad.py
+++ b/src/deployments/experiments/libp2p/multi_nimlibp2p_kad.py
@@ -52,7 +52,7 @@ class MultiNimlibp2pKad(Multiple):
         base = {
             "discovery": "kad-dht",
             "bootstrap_nodes": 1,
-            "num_nodes": NUM_NODES,
+            "num_relay_nodes": NUM_NODES,
             "num_messages": NUM_MESSAGES,
             "delay_after_publish": 1,  # 1 msg/s
             "delay_cold_start": COLD_START,
@@ -77,5 +77,5 @@ class MultiNimlibp2pKad(Multiple):
             f"version_{params['version']}"
             f"__muxer_{params['muxer']}"
             f"__size_{params['message_size_bytes']}"
-            f"__nodes_{params['num_nodes']}"
+            f"__nodes_{params['num_relay_nodes']}"
         )


### PR DESCRIPTION
The `num_nodes` -> `num_relay_nodes` rename (87d5889) updated `nimlibp2p.py` but not `multi_nimlibp2p_kad.py`, which still passed `num_nodes`. pydantic silently drops the unknown key, so the kad regression matrix deploys 30 nodes instead of `REGRESSION_NUM_NODES` (default 1000), with no error. Caught via `--dry-run` showing `replicas: 30`.