### PR TITLE
Shadow: scrape gossipsub control/efficiency metrics

### DIFF
--- a/src/analysis/metrics/libp2p/gossipsub_summary.py
+++ b/src/analysis/metrics/libp2p/gossipsub_summary.py
@@ -1,0 +1,77 @@
+"""Reduce the gossipsub control/efficiency counter CSVs (dumped by the
+`with_gossipsub_detail_metrics` scrape) into per-muxer report numbers.
+
+These are monotonic counters, so per node the total over the run is the last value.
+We aggregate the across-node median (the typical node) for each metric, and derive the
+duplicate ratio (duplicates / delivered), the cleanest single "how efficient was the
+mesh" number. Meant for the Shadow section, where the run is deterministic so the
+counts are exact and comparable across versions.
+"""
+
+import logging
+import re
+from pathlib import Path
+from typing import Dict, Optional
+
+import pandas as pd
+
+# Relay pods are pod-0..pod-(N-1); this excludes the bootstrap and the publisher
+# (named bootstrap-* / pod-api-requester-* on the cluster).
+_RELAY_POD = re.compile(r"pod-\d+$")
+
+logger = logging.getLogger(__name__)
+
+# scrape folder (under the run's metrics dir) -> report label. Order is the table order.
+GOSSIPSUB_DETAIL: Dict[str, str] = {
+    "gossipsub/ihave-recv": "IHAVE received",
+    "gossipsub/iwant-sent": "IWANT sent",
+    "gossipsub/iwant-recv": "IWANT received",
+    "gossipsub/graft-sent": "GRAFT sent",
+    "gossipsub/graft-recv": "GRAFT received",
+    "gossipsub/prune-sent": "PRUNE sent",
+    "gossipsub/prune-recv": "PRUNE received",
+    "gossipsub/received": "messages received",
+    "gossipsub/duplicate": "duplicate messages",
+    "gossipsub/idontwant-saved": "IDONTWANT saved",
+}
+
+
+def _per_node_totals(metrics_dir: Path, folder: str, muxer: str) -> Optional[pd.Series]:
+    """Last value per relay node for one counter metric = its total over the run.
+    Excludes the bootstrap and publisher hosts (only `pod-<n>` are relays)."""
+    csv = metrics_dir / folder / muxer
+    if not csv.exists():
+        logger.warning(f"gossipsub summary: missing {csv}")
+        return None
+    df = pd.read_csv(csv, parse_dates=["Time"], index_col="Time")
+    cols = [c for c in df.columns if _RELAY_POD.fullmatch(c)]
+    if not cols:
+        return None
+    return df[cols].ffill().iloc[-1]
+
+
+def summarize(metrics_dir: Path, muxer: str) -> Dict[str, float]:
+    """Across-node median of the per-node totals for each gossipsub detail metric,
+    plus the duplicate ratio. `metrics_dir` is the run's `metrics/` dump."""
+    totals: Dict[str, pd.Series] = {}
+    summary: Dict[str, float] = {}
+    for folder, label in GOSSIPSUB_DETAIL.items():
+        series = _per_node_totals(metrics_dir, folder, muxer)
+        if series is None or series.dropna().empty:
+            continue
+        totals[folder] = series
+        summary[label] = round(float(series.median()), 1)
+
+    recv = totals.get("gossipsub/received")
+    dup = totals.get("gossipsub/duplicate")
+    if recv is not None and dup is not None:
+        ratio = (dup / recv.where(recv > 0)).dropna()
+        if not ratio.empty:
+            summary["duplicate ratio"] = round(float(ratio.median()), 3)
+    return summary
+
+
+def summary_table(metrics_dir: Path, muxers) -> pd.DataFrame:
+    """A muxer-by-metric table of the medians, for the report / logs."""
+    rows = {muxer: summarize(metrics_dir, muxer) for muxer in muxers}
+    return pd.DataFrame(rows).reindex(list(GOSSIPSUB_DETAIL.values()) + ["duplicate ratio"])

--- a/src/analysis/metrics/libp2p/metrics.py
+++ b/src/analysis/metrics/libp2p/metrics.py
@@ -108,3 +108,43 @@ def libp2p_metrics(namespace: str) -> Iterator[MetricToScrape]:
     yield high_peers(namespace)
     yield container_memory_bytes(namespace)
     yield nim_gc_memory_bytes(namespace)
+
+
+def _gossipsub_counter(namespace: str, name: str, metric: str, folder: str) -> MetricToScrape:
+    # These pubsub/gossipsub counters carry a per-topic label; sum by pod to get one
+    # monotonic series per node. The per-node total over the run is the last value.
+    # `pod` is the pod name on both Shadow (the importer tags it) and the cluster (the
+    # libp2p-nodes scrape relabels it), unlike `instance` which is the podIP on k8s.
+    return MetricToScrape(
+        name=name,
+        query=f"sum by (pod) ({metric}{{namespace='{namespace}'}})",
+        extract_field="pod",
+        folder_name=folder,
+    )
+
+
+# Gossipsub control traffic (IHAVE/IWANT/GRAFT/PRUNE) and message efficiency counters.
+# Reported off the Shadow runs, where the mesh and schedule are deterministic so these
+# are exact (on the cluster they are too noisy to compare). Reduced per node by last
+# value (total over the run); see gossipsub_summary.py.
+_GOSSIPSUB_DETAIL = [
+    ("gs_ihave_recv", "libp2p_pubsub_received_ihave_total", "gossipsub/ihave-recv/"),
+    ("gs_iwant_sent", "libp2p_pubsub_broadcast_iwant_total", "gossipsub/iwant-sent/"),
+    ("gs_iwant_recv", "libp2p_pubsub_received_iwant_total", "gossipsub/iwant-recv/"),
+    ("gs_graft_sent", "libp2p_pubsub_broadcast_graft_total", "gossipsub/graft-sent/"),
+    ("gs_graft_recv", "libp2p_pubsub_received_graft_total", "gossipsub/graft-recv/"),
+    ("gs_prune_sent", "libp2p_pubsub_broadcast_prune_total", "gossipsub/prune-sent/"),
+    ("gs_prune_recv", "libp2p_pubsub_received_prune_total", "gossipsub/prune-recv/"),
+    ("gs_duplicate", "libp2p_gossipsub_duplicate_total", "gossipsub/duplicate/"),
+    ("gs_received", "libp2p_gossipsub_received_total", "gossipsub/received/"),
+    (
+        "gs_idontwant_saved",
+        "libp2p_gossipsub_idontwant_saved_messages_total",
+        "gossipsub/idontwant-saved/",
+    ),
+]
+
+
+def gossipsub_detail_metrics(namespace: str) -> Iterator[MetricToScrape]:
+    for name, metric, folder in _GOSSIPSUB_DETAIL:
+        yield _gossipsub_counter(namespace, name, metric, folder)

--- a/src/analysis/metrics/libp2p/scrape.py
+++ b/src/analysis/metrics/libp2p/scrape.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Self
 from pydantic import BaseModel, Field
 
 from src.analysis.metrics.config import MetricToScrape, ScrapeConfig
-from src.analysis.metrics.libp2p.metrics import libp2p_metrics
+from src.analysis.metrics.libp2p.metrics import gossipsub_detail_metrics, libp2p_metrics
 from src.analysis.utils.time_utils import TimeRange
 
 
@@ -20,6 +20,7 @@ class Nimlibp2pScrapeBuilder(BaseModel):
     namespace: Optional[str] = None
     metrics_to_scrape: List[MetricToScrape] = Field(default_factory=list)
     has_libp2p_metrics: bool = False
+    has_gossipsub_detail: bool = False
 
     def with_dump_location(self, folder: str) -> Self:
         self.dump_location = folder
@@ -52,12 +53,20 @@ class Nimlibp2pScrapeBuilder(BaseModel):
         self.has_libp2p_metrics = True
         return self
 
+    def with_gossipsub_detail_metrics(self) -> Self:
+        # Gossipsub control-traffic + efficiency counters (IHAVE/IWANT/GRAFT/PRUNE,
+        # duplicates, IDONTWANT). Deferred like with_libp2p_metrics so namespace can be set.
+        self.has_gossipsub_detail = True
+        return self
+
     def build(self) -> ScrapeConfig:
         assert self.namespace, "Missing namespace"
 
         all_metrics = deepcopy(self.metrics_to_scrape)
         if self.has_libp2p_metrics:
             all_metrics.extend(libp2p_metrics(namespace=self.namespace))
+        if self.has_gossipsub_detail:
+            all_metrics.extend(gossipsub_detail_metrics(namespace=self.namespace))
 
         assert self.name, "Missing name"
         return ScrapeConfig(

--- a/src/analysis/metrics/shadow_metrics.py
+++ b/src/analysis/metrics/shadow_metrics.py
@@ -11,6 +11,7 @@ from typing import List, Optional
 
 import requests
 
+from src.analysis.metrics.libp2p import gossipsub_summary
 from src.analysis.metrics.libp2p.scrape import Nimlibp2pScrapeBuilder
 from src.analysis.metrics.scrapper import Scrapper
 
@@ -184,11 +185,18 @@ def scrape_run_metrics(
             )
             .with_interval(start_dt, end_dt, run_dir.name)
             .with_libp2p_metrics()
+            .with_gossipsub_detail_metrics()
             .build()
         )
         config.url = f"{vm.url}/api/v1/"
         Scrapper(config=config).query_and_dump_metrics()
     logger.info(f"Dumped Shadow metrics CSVs under {dump_location}/")
+
+    # The gossipsub control/efficiency counters are the reason to run Shadow deterministically;
+    # log the per-node medians so they show up next to delivery in the run output.
+    gs = gossipsub_summary.summarize(dump_location, run_dir.name)
+    if gs:
+        logger.info(f"Gossipsub detail (per-node median) for {run_dir.name}: {gs}")
     return dump_location
 
 


### PR DESCRIPTION
Adds a gossipsub-detail metric set (IHAVE/IWANT/GRAFT/PRUNE sent+received, duplicates, received, IDONTWANT-saved) to the Shadow scrape, reduced per node into across-node medians + a duplicate ratio. The data is already in every node's `/metrics` dump; this just queries and summarizes it.