### PR TITLE
Shadow WAN network model

### DIFF
--- a/src/deployments/experiments/libp2p/shadow_gossipsub.py
+++ b/src/deployments/experiments/libp2p/shadow_gossipsub.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, NonNegativeFloat, NonNegativeInt
+from pydantic import BaseModel, ConfigDict, NonNegativeFloat, NonNegativeInt, PositiveInt
 
 from src.analysis.mesh_analysis.analyzers.data_puller import DataPuller
 from src.analysis.mesh_analysis.analyzers.nimlibp2p_analyzer import Nimlibp2pAnalyzer
@@ -49,10 +49,8 @@ class ExpConfig(BaseModel):
     lsquic_tick_floor_us: NonNegativeInt = 0
     # Per-pod process start stagger (pod-i starts at 5000 + i*jitter ms); 0 = lockstep.
     start_jitter_ms: NonNegativeInt = 0
-    # WAN network model. latency_ms > 0 (or a sub-1Gbit bandwidth) swaps the ~0-latency
-    # 1_gbit_switch for a GML link with these properties (all hosts share one network node).
-    latency_ms: NonNegativeInt = 0
-    bandwidth_mbit: NonNegativeInt = 1000
+    latency_ms: Optional[NonNegativeInt] = None
+    bandwidth_mbit: Optional[PositiveInt] = None
     # Job-pod resources, sized for ~10 peers; bump for bigger sims.
     cpu_request: str = "2"
     cpu_limit: str = "4"

--- a/src/deployments/experiments/libp2p/shadow_gossipsub.py
+++ b/src/deployments/experiments/libp2p/shadow_gossipsub.py
@@ -49,6 +49,10 @@ class ExpConfig(BaseModel):
     lsquic_tick_floor_us: NonNegativeInt = 0
     # Per-pod process start stagger (pod-i starts at 5000 + i*jitter ms); 0 = lockstep.
     start_jitter_ms: NonNegativeInt = 0
+    # WAN network model. latency_ms > 0 (or a sub-1Gbit bandwidth) swaps the ~0-latency
+    # 1_gbit_switch for a GML link with these properties (all hosts share one network node).
+    latency_ms: NonNegativeInt = 0
+    bandwidth_mbit: NonNegativeInt = 1000
     # Job-pod resources, sized for ~10 peers; bump for bigger sims.
     cpu_request: str = "2"
     cpu_limit: str = "4"
@@ -94,6 +98,8 @@ class ShadowGossipsubExperiment(BaseExperiment[ExpConfig]):
             strace_logging_mode=cfg.strace_logging_mode,
             lsquic_tick_floor_us=cfg.lsquic_tick_floor_us,
             start_jitter_ms=cfg.start_jitter_ms,
+            latency_ms=cfg.latency_ms,
+            bandwidth_mbit=cfg.bandwidth_mbit,
         )
         publisher_config = render_publisher_config(
             num_nodes=cfg.num_nodes,

--- a/src/deployments/shadow/builders.py
+++ b/src/deployments/shadow/builders.py
@@ -147,6 +147,10 @@ def _publisher_host(publisher_start_s: int, requester_app_path: str) -> dict:
     }
 
 
+_SWITCH_BANDWIDTH_MBIT = 1000
+_SWITCH_LATENCY_MS = 0
+
+
 def _wan_gml(latency_ms: int, bandwidth_mbit: int) -> LiteralScalarString:
     """A one-node GML graph with a self-loop, so every host (all on network_node_id 0)
     sees `latency_ms` one-way delay and `bandwidth_mbit` up/down. Shadow's GML parser
@@ -184,8 +188,8 @@ def render_shadow_yaml(
     strace_logging_mode: str = "off",
     lsquic_tick_floor_us: int = 0,
     start_jitter_ms: int = 0,
-    latency_ms: int = 0,
-    bandwidth_mbit: int = 1000,
+    latency_ms: Optional[int] = None,
+    bandwidth_mbit: Optional[int] = None,
     requester_app_path: str = _REQUESTER_APP_PATH,
 ) -> dict:
     """Build the shadow.yaml dict: N peer hosts running `./main` + a publisher host
@@ -220,14 +224,20 @@ def render_shadow_yaml(
         )
     hosts["publisher"] = _publisher_host(publisher_start_s, requester_app_path)
 
-    # Network: the built-in 1_gbit_switch is ~0-latency, which is unrealistic and can
-    # skew latency-sensitive behaviour. Set latency_ms (or a sub-1Gbit bandwidth) to model
-    # a WAN via a one-node GML with a self-loop (all hosts share network_node_id 0), the
-    # same shape the standalone shadow harness used.
-    if latency_ms > 0 or bandwidth_mbit < 1000:
-        graph = {"type": "gml", "inline": _wan_gml(latency_ms, bandwidth_mbit)}
-    else:
+    if latency_ms is None and bandwidth_mbit is None:
         graph = {"type": "1_gbit_switch"}
+    else:
+        if latency_ms is not None and latency_ms < 0:
+            raise ValueError(f"latency_ms must be >= 0, got {latency_ms}")
+        if bandwidth_mbit is not None and bandwidth_mbit <= 0:
+            raise ValueError(f"bandwidth_mbit must be > 0, got {bandwidth_mbit}")
+        graph = {
+            "type": "gml",
+            "inline": _wan_gml(
+                _SWITCH_LATENCY_MS if latency_ms is None else latency_ms,
+                _SWITCH_BANDWIDTH_MBIT if bandwidth_mbit is None else bandwidth_mbit,
+            ),
+        }
 
     # Always render the seed so the run's shadow.yaml records it (Shadow defaults to 1).
     config = {

--- a/src/deployments/shadow/builders.py
+++ b/src/deployments/shadow/builders.py
@@ -24,6 +24,7 @@ from kubernetes.client import (
     V1VolumeMount,
 )
 from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import LiteralScalarString
 
 # The pod-api-requester app is baked into the Shadow base image; the publisher host
 # runs it in batch mode and reads its traffic config from the mounted ConfigMap.
@@ -146,6 +147,28 @@ def _publisher_host(publisher_start_s: int, requester_app_path: str) -> dict:
     }
 
 
+def _wan_gml(latency_ms: int, bandwidth_mbit: int) -> LiteralScalarString:
+    """A one-node GML graph with a self-loop, so every host (all on network_node_id 0)
+    sees `latency_ms` one-way delay and `bandwidth_mbit` up/down. Shadow's GML parser
+    wants multi-line GML (one attribute per line); return it as a YAML literal block so
+    the inline value keeps its newlines."""
+    gml = f"""graph [
+  directed 0
+  node [
+    id 0
+    host_bandwidth_up "{bandwidth_mbit} Mbit"
+    host_bandwidth_down "{bandwidth_mbit} Mbit"
+  ]
+  edge [
+    source 0
+    target 0
+    latency "{latency_ms} ms"
+  ]
+]
+"""
+    return LiteralScalarString(gml)
+
+
 def render_shadow_yaml(
     *,
     num_nodes: int,
@@ -161,6 +184,8 @@ def render_shadow_yaml(
     strace_logging_mode: str = "off",
     lsquic_tick_floor_us: int = 0,
     start_jitter_ms: int = 0,
+    latency_ms: int = 0,
+    bandwidth_mbit: int = 1000,
     requester_app_path: str = _REQUESTER_APP_PATH,
 ) -> dict:
     """Build the shadow.yaml dict: N peer hosts running `./main` + a publisher host
@@ -194,6 +219,16 @@ def render_shadow_yaml(
             lsquic_tick_floor_us=lsquic_tick_floor_us,
         )
     hosts["publisher"] = _publisher_host(publisher_start_s, requester_app_path)
+
+    # Network: the built-in 1_gbit_switch is ~0-latency, which is unrealistic and can
+    # skew latency-sensitive behaviour. Set latency_ms (or a sub-1Gbit bandwidth) to model
+    # a WAN via a one-node GML with a self-loop (all hosts share network_node_id 0), the
+    # same shape the standalone shadow harness used.
+    if latency_ms > 0 or bandwidth_mbit < 1000:
+        graph = {"type": "gml", "inline": _wan_gml(latency_ms, bandwidth_mbit)}
+    else:
+        graph = {"type": "1_gbit_switch"}
+
     # Always render the seed so the run's shadow.yaml records it (Shadow defaults to 1).
     config = {
         "general": {
@@ -201,9 +236,7 @@ def render_shadow_yaml(
             "progress": True,
             "seed": seed,
         },
-        "network": {
-            "graph": {"type": "1_gbit_switch"},
-        },
+        "network": {"graph": graph},
         "hosts": hosts,
     }
     if model_unblocked_syscall_latency:

--- a/src/deployments/shadow/tests/test_builders.py
+++ b/src/deployments/shadow/tests/test_builders.py
@@ -210,13 +210,33 @@ class TestRenderShadowYaml:
         gml = str(graph["inline"])
         assert 'latency "10 ms"' in gml
         assert 'host_bandwidth_up "50 Mbit"' in gml
-        # zero latency + zero loss keeps the plain switch
-        assert (
-            render_shadow_yaml(num_nodes=3, sim_stop_time_s=180, publisher_start_s=90)["network"][
-                "graph"
-            ]["type"]
-            == "1_gbit_switch"
-        )
+
+    def _graph(self, **kwargs):
+        return render_shadow_yaml(num_nodes=3, sim_stop_time_s=180, publisher_start_s=90, **kwargs)[
+            "network"
+        ]["graph"]
+
+    def test_unset_network_keeps_the_builtin_switch(self):
+        assert self._graph()["type"] == "1_gbit_switch"
+
+    def test_bandwidth_above_the_switch_is_applied_not_ignored(self):
+        gml = str(self._graph(bandwidth_mbit=2000)["inline"])
+        assert 'host_bandwidth_up "2000 Mbit"' in gml
+
+    def test_one_knob_set_keeps_the_switch_value_for_the_other(self):
+        assert 'host_bandwidth_up "1000 Mbit"' in str(self._graph(latency_ms=50)["inline"])
+        assert 'latency "0 ms"' in str(self._graph(bandwidth_mbit=50)["inline"])
+
+    def test_explicit_zero_latency_still_builds_a_link(self):
+        assert self._graph(latency_ms=0)["type"] == "gml"
+
+    def test_out_of_range_values_are_rejected(self):
+        with pytest.raises(ValueError):
+            self._graph(latency_ms=-1)
+        with pytest.raises(ValueError):
+            self._graph(bandwidth_mbit=0)
+        with pytest.raises(ValueError):
+            self._graph(bandwidth_mbit=-10)
 
     def test_connect_to_must_be_less_than_num_nodes(self):
         with pytest.raises(ValueError):

--- a/src/deployments/shadow/tests/test_builders.py
+++ b/src/deployments/shadow/tests/test_builders.py
@@ -197,6 +197,27 @@ class TestRenderShadowYaml:
         assert sy["general"]["progress"] is True
         assert sy["network"]["graph"]["type"] == "1_gbit_switch"
 
+    def test_wan_network_uses_gml_with_link_properties(self):
+        sy = render_shadow_yaml(
+            num_nodes=3,
+            sim_stop_time_s=180,
+            publisher_start_s=90,
+            latency_ms=10,
+            bandwidth_mbit=50,
+        )
+        graph = sy["network"]["graph"]
+        assert graph["type"] == "gml"
+        gml = str(graph["inline"])
+        assert 'latency "10 ms"' in gml
+        assert 'host_bandwidth_up "50 Mbit"' in gml
+        # zero latency + zero loss keeps the plain switch
+        assert (
+            render_shadow_yaml(num_nodes=3, sim_stop_time_s=180, publisher_start_s=90)["network"][
+                "graph"
+            ]["type"]
+            == "1_gbit_switch"
+        )
+
     def test_connect_to_must_be_less_than_num_nodes(self):
         with pytest.raises(ValueError):
             render_shadow_yaml(num_nodes=2, sim_stop_time_s=10, publisher_start_s=5, connect_to=2)


### PR DESCRIPTION
Adds `latency_ms` / `bandwidth_mbit` knobs that replace the ~0-latency `1_gbit_switch` with a one-node GML link, so Shadow runs can model a realistic WAN. Default keeps the switch unchanged. Mirrors the existing k8s network-shaping (netem delay + tbf bandwidth); packet loss omitted on both for now. Stacked on #316.