### PR TITLE
Frontend Enhancements - 1

### DIFF
--- a/dst_dashboard/README.md
+++ b/dst_dashboard/README.md
@@ -25,6 +25,11 @@ export DST_JWT_SECRET=<a real secret>                       # Required outside l
 longer defines experiments. Experiments live only in MongoDB and are managed
 exclusively through the API (see below).
 
+## Building Frontend Docker
+```bash
+docker build --build-arg REACT_APP_API_URL=https://api.dashboard.lab.vac.dev -f Dockerfile . -t mamoutoudiarra/dst-dashboard-frontend:dev-v0.8
+```
+
 ## Managing experiments
 
 Creating, updating, and deleting experiments requires an admin bearer token.

--- a/dst_dashboard/frontend/src/App.js
+++ b/dst_dashboard/frontend/src/App.js
@@ -4,6 +4,7 @@ import { ThemeProvider } from './context/ThemeContext';
 import Navbar from './components/Navbar';
 import Footer from './components/Footer';
 import PageLoader from './components/PageLoader';
+import PageTransition from './components/PageTransition';
 
 const HomePage = lazy(() => import('./pages/HomePage'));
 const ExperimentsPage = lazy(() => import('./pages/ExperimentsPage'));
@@ -18,19 +19,21 @@ function App() {
                     <Navbar />
                     <main className="grow flex flex-col pt-16">
                         <Suspense fallback={<PageLoader />}>
-                            <Routes>
-                                <Route path="/" element={<HomePage />} />
-                                <Route path="/experiments" element={<ExperimentsPage />} />
-                                <Route path="/experiment/:experimentId" element={<ExperimentPage />} />
-                                <Route
-                                    path="/vaclab/topology"
-                                    element={<ComingSoonPage title="Topology" description="Interactive network topology visualization is coming soon." />}
-                                />
-                                <Route
-                                    path="/vaclab/networks"
-                                    element={<ComingSoonPage title="Networks" description="Live network explorer is coming soon." />}
-                                />
-                            </Routes>
+                            <PageTransition>
+                                <Routes>
+                                    <Route path="/" element={<HomePage />} />
+                                    <Route path="/experiments" element={<ExperimentsPage />} />
+                                    <Route path="/experiment/:experimentId" element={<ExperimentPage />} />
+                                    <Route
+                                        path="/vaclab/topology"
+                                        element={<ComingSoonPage title="Topology" description="Interactive network topology visualization is coming soon." />}
+                                    />
+                                    <Route
+                                        path="/vaclab/networks"
+                                        element={<ComingSoonPage title="Networks" description="Live network explorer is coming soon." />}
+                                    />
+                                </Routes>
+                            </PageTransition>
                         </Suspense>
                     </main>
                     <Footer />

--- a/dst_dashboard/frontend/src/components/ChartPanel.js
+++ b/dst_dashboard/frontend/src/components/ChartPanel.js
@@ -50,7 +50,8 @@ function ChartPanel({ experimentId, panelMeta, isDark }) {
     return (
         <div
             ref={ref}
-            className="card bg-base-200 border border-base-100 overflow-hidden hover:ring hover:ring-primary/30 transition-shadow"
+            className={`card bg-base-200 border border-base-100 overflow-hidden hover:ring hover:ring-primary/30 transition-all duration-500 ${inView ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
+                }`}
         >
             <div className="bg-base-100 px-5 py-4 border-b border-base-300">
                 <h3 className="font-mono text-sm uppercase tracking-widest">{panelMeta.title}</h3>

--- a/dst_dashboard/frontend/src/components/ExperimentCard.js
+++ b/dst_dashboard/frontend/src/components/ExperimentCard.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import ExperimentThumbnail from './ExperimentThumbnail';
+
+// Rendered as a grid item, so it must be h-full itself (a Grid item's default
+// stretch only reaches its direct child) and use flex-col so the footer badges
+// line up at the same baseline across cards with different description lengths.
+// showThumbnail adds a lazy-loaded preview of the experiment's first result
+// panel above the text - used on the homepage; the full Experiments list
+// stays text-only since rendering a chart per card there would be a lot of
+// extra requests for a page that's meant for fast scanning, not browsing.
+function ExperimentCard({ experiment, showThumbnail = false }) {
+    const navigate = useNavigate();
+    const goToDetail = () => navigate(`/experiment/${experiment.id}`);
+
+    return (
+        <div
+            role="link"
+            tabIndex={0}
+            onClick={goToDetail}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    goToDetail();
+                }
+            }}
+            className="card h-full flex flex-col overflow-hidden bg-base-200 border border-base-100 hover:border-secondary hover:-translate-y-1 transition-all cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+        >
+            {showThumbnail && <ExperimentThumbnail experimentId={experiment.id} />}
+            <div className="card-body p-6 flex flex-col grow">
+                <div className="grow">
+                    <div className="flex justify-between items-start gap-3">
+                        <h3 className="font-semibold leading-snug">{experiment.title}</h3>
+                        {experiment.date && (
+                            <span className="text-base-content-tertiary text-xs whitespace-nowrap">
+                                {new Date(experiment.date).toLocaleDateString('en-US', {
+                                    month: 'short',
+                                    day: 'numeric',
+                                })}
+                            </span>
+                        )}
+                    </div>
+
+                    {experiment.description && (
+                        <p className="text-base-content-secondary text-sm mt-2 line-clamp-2 font-light">
+                            {experiment.description}
+                        </p>
+                    )}
+                </div>
+
+                <div className="flex flex-wrap gap-2 pt-4 mt-4 border-t border-base-100">
+                    {experiment.github_repo && (
+                        <a
+                            href={experiment.github_repo}
+                            onClick={(e) => e.stopPropagation()}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="badge badge-neutral gap-1"
+                        >
+                            <i className="bi bi-github"></i>
+                            GitHub
+                        </a>
+                    )}
+                    {experiment.github_pr && (
+                        <a
+                            href={experiment.github_pr}
+                            onClick={(e) => e.stopPropagation()}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="badge badge-neutral gap-1"
+                        >
+                            PR
+                        </a>
+                    )}
+                    {experiment.docker_image && (
+                        <span className="badge badge-outline text-base-content-tertiary" title={experiment.docker_image}>
+                            {experiment.docker_image.split(':').pop()}
+                        </span>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default ExperimentCard;

--- a/dst_dashboard/frontend/src/components/ExperimentThumbnail.js
+++ b/dst_dashboard/frontend/src/components/ExperimentThumbnail.js
@@ -1,0 +1,108 @@
+import React, { Suspense, lazy, useEffect, useState } from 'react';
+import axios from 'axios';
+import { API_BASE_URL } from '../config';
+import { useInView } from '../hooks/useInView';
+import { buildThumbnailOption } from '../utils/chartOptions';
+import { useTheme } from '../context/ThemeContext';
+
+const ReactECharts = lazy(() => import('echarts-for-react'));
+
+const THUMB_HEIGHT = 152;
+const MAX_PANELS = 4;
+const ROTATE_INTERVAL_MS = 15000;
+
+function ThumbnailSkeleton() {
+    return (
+        <div className="animate-pulse w-full" style={{ height: THUMB_HEIGHT }}>
+            <div className="h-full w-full bg-base-300/60" />
+        </div>
+    );
+}
+
+// A quick "glance" preview of an experiment's results, rendered only once the
+// card scrolls near the viewport. Fetches up to MAX_PANELS panels once (not
+// re-fetched on re-scroll - useInView's default `once` gating), then cycles
+// through whichever came back, crossfading every few seconds so a card with
+// several panels doesn't just sit on the first one forever.
+function ExperimentThumbnail({ experimentId }) {
+    const { isDark } = useTheme();
+    const [ref, inView] = useInView();
+    const [options, setOptions] = useState([]);
+    const [index, setIndex] = useState(0);
+    const [failed, setFailed] = useState(false);
+
+    useEffect(() => {
+        if (!inView) return;
+        let cancelled = false;
+
+        axios
+            .get(`${API_BASE_URL}/experiments/${experimentId}`)
+            .then((res) => {
+                const panels = (res.data?.panels || []).slice(0, MAX_PANELS);
+                if (!panels.length) {
+                    if (!cancelled) setFailed(true);
+                    return null;
+                }
+                return Promise.all(
+                    panels.map((panel) =>
+                        axios
+                            .get(`${API_BASE_URL}/experiments/${experimentId}/panels/${panel.name}`)
+                            .then((res) => res.data?.option)
+                            .catch(() => null)
+                    )
+                );
+            })
+            .then((rawOptions) => {
+                if (cancelled || !rawOptions) return;
+                const built = rawOptions.filter(Boolean).map((raw) => buildThumbnailOption(raw, isDark));
+                if (built.length) {
+                    setOptions(built);
+                } else {
+                    setFailed(true);
+                }
+            })
+            .catch(() => {
+                if (!cancelled) setFailed(true);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [inView, experimentId, isDark]);
+
+    useEffect(() => {
+        if (options.length <= 1) return undefined;
+        const id = setInterval(() => {
+            setIndex((i) => (i + 1) % options.length);
+        }, ROTATE_INTERVAL_MS);
+        return () => clearInterval(id);
+    }, [options.length]);
+
+    const currentOption = options[index] || null;
+
+    return (
+        <div ref={ref} className="bg-base-100 border-b border-base-100 shrink-0 overflow-hidden" style={{ height: THUMB_HEIGHT }}>
+            {currentOption ? (
+                <Suspense fallback={<ThumbnailSkeleton />}>
+                    <div key={index} className="h-full w-full animate-page-in">
+                        <ReactECharts
+                            option={currentOption}
+                            style={{ height: THUMB_HEIGHT, width: '100%' }}
+                            opts={{ renderer: 'canvas' }}
+                            notMerge={true}
+                            lazyUpdate={true}
+                        />
+                    </div>
+                </Suspense>
+            ) : failed ? (
+                <div className="h-full w-full flex items-center justify-center text-base-content-tertiary">
+                    <i className="bi bi-bar-chart-line text-2xl"></i>
+                </div>
+            ) : (
+                <ThumbnailSkeleton />
+            )}
+        </div>
+    );
+}
+
+export default ExperimentThumbnail;

--- a/dst_dashboard/frontend/src/components/ExperimentThumbnail.js
+++ b/dst_dashboard/frontend/src/components/ExperimentThumbnail.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { API_BASE_URL } from '../config';
 import { useInView } from '../hooks/useInView';
 import { buildThumbnailOption } from '../utils/chartOptions';
+import { getCachedRawOptions, setCachedRawOptions } from '../utils/thumbnailCache';
 import { useTheme } from '../context/ThemeContext';
 
 const ReactECharts = lazy(() => import('echarts-for-react'));
@@ -20,54 +21,73 @@ function ThumbnailSkeleton() {
 }
 
 // A quick "glance" preview of an experiment's results, rendered only once the
-// card scrolls near the viewport. Fetches up to MAX_PANELS panels once (not
-// re-fetched on re-scroll - useInView's default `once` gating), then cycles
-// through whichever came back, crossfading every few seconds so a card with
-// several panels doesn't just sit on the first one forever.
+// card scrolls near the viewport. Some panels are tiny pre-aggregated stats;
+// others (raw per-message timeseries) can be tens of MB, and some panels can
+// simply error out server-side. So every panel (up to MAX_PANELS) is fetched
+// independently and concurrently - first paint shows whichever succeeds
+// first, regardless of position, rather than waiting on or being blocked by
+// any one specific panel. Only if every attempted panel fails does the whole
+// thumbnail fall back to the "failed" placeholder.
 function ExperimentThumbnail({ experimentId }) {
     const { isDark } = useTheme();
     const [ref, inView] = useInView();
-    const [rawOptions, setRawOptions] = useState([]);
+    const cached = getCachedRawOptions(experimentId);
+    const [rawOptions, setRawOptions] = useState(cached || []);
     const [index, setIndex] = useState(0);
+    const [visible, setVisible] = useState(true);
     const [failed, setFailed] = useState(false);
 
     useEffect(() => {
-        if (!inView) return;
-        let cancelled = false;
+        if (!inView || cached) return;
+        const controller = new AbortController();
+
+        const fetchPanelOption = (panelName) =>
+            axios
+                .get(`${API_BASE_URL}/experiments/${experimentId}/panels/${panelName}`, {
+                    signal: controller.signal,
+                })
+                .then((res) => res.data?.option)
+                .catch(() => null);
 
         axios
-            .get(`${API_BASE_URL}/experiments/${experimentId}`)
+            .get(`${API_BASE_URL}/experiments/${experimentId}`, { signal: controller.signal })
             .then((res) => {
                 const panels = (res.data?.panels || []).slice(0, MAX_PANELS);
                 if (!panels.length) {
-                    if (!cancelled) setFailed(true);
-                    return null;
-                }
-                return Promise.all(
-                    panels.map((panel) =>
-                        axios
-                            .get(`${API_BASE_URL}/experiments/${experimentId}/panels/${panel.name}`)
-                            .then((res) => res.data?.option)
-                            .catch(() => null)
-                    )
-                );
-            })
-            .then((fetched) => {
-                if (cancelled || !fetched) return;
-                const valid = fetched.filter(Boolean);
-                if (valid.length) {
-                    setRawOptions(valid);
-                } else {
                     setFailed(true);
+                    return;
                 }
+
+                const accumulated = [];
+                let settledCount = 0;
+
+                panels.forEach((panel) => {
+                    fetchPanelOption(panel.name).then((option) => {
+                        if (controller.signal.aborted) return;
+                        settledCount += 1;
+                        if (option) {
+                            accumulated.push(option);
+                            setCachedRawOptions(experimentId, [...accumulated]);
+                            setRawOptions([...accumulated]);
+                        } else if (settledCount === panels.length && accumulated.length === 0) {
+                            setFailed(true);
+                        }
+                    });
+                });
             })
             .catch(() => {
-                if (!cancelled) setFailed(true);
+                if (!controller.signal.aborted) setFailed(true);
             });
 
         return () => {
-            cancelled = true;
+            controller.abort();
         };
+        // `cached` is intentionally excluded: it's only a mount-time "was this
+        // already cached" gate. Fetching a panel populates the cache, which
+        // would flip `cached` truthy and re-trigger this effect - and its
+        // cleanup aborts the very controller the other panel fetches are
+        // still using, killing them mid-flight.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [inView, experimentId]);
 
     // Re-theming on a dark/light toggle is just recoloring already-fetched
@@ -78,12 +98,24 @@ function ExperimentThumbnail({ experimentId }) {
         [rawOptions, isDark]
     );
 
+    // Rotates by updating the *same* mounted chart's option (echarts-for-react
+    // diffs and calls setOption in place) rather than remounting it - keeps
+    // the canvas/echarts instance alive instead of re-creating it every tick.
+    // The brief opacity dip in between is a plain CSS crossfade, not a remount.
     useEffect(() => {
         if (options.length <= 1) return undefined;
-        const id = setInterval(() => {
-            setIndex((i) => (i + 1) % options.length);
+        let hideTimeout;
+        const intervalId = setInterval(() => {
+            setVisible(false);
+            hideTimeout = setTimeout(() => {
+                setIndex((i) => (i + 1) % options.length);
+                setVisible(true);
+            }, 200);
         }, ROTATE_INTERVAL_MS);
-        return () => clearInterval(id);
+        return () => {
+            clearInterval(intervalId);
+            clearTimeout(hideTimeout);
+        };
     }, [options.length]);
 
     const currentOption = options[index] || null;
@@ -92,7 +124,7 @@ function ExperimentThumbnail({ experimentId }) {
         <div ref={ref} className="bg-base-100 border-b border-base-100 shrink-0 overflow-hidden" style={{ height: THUMB_HEIGHT }}>
             {currentOption ? (
                 <Suspense fallback={<ThumbnailSkeleton />}>
-                    <div key={index} className="h-full w-full animate-page-in">
+                    <div className={`h-full w-full transition-opacity duration-200 ${visible ? 'opacity-100' : 'opacity-0'}`}>
                         <ReactECharts
                             option={currentOption}
                             style={{ height: THUMB_HEIGHT, width: '100%' }}

--- a/dst_dashboard/frontend/src/components/ExperimentThumbnail.js
+++ b/dst_dashboard/frontend/src/components/ExperimentThumbnail.js
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy, useEffect, useState } from 'react';
+import React, { Suspense, lazy, useEffect, useMemo, useState } from 'react';
 import axios from 'axios';
 import { API_BASE_URL } from '../config';
 import { useInView } from '../hooks/useInView';
@@ -27,7 +27,7 @@ function ThumbnailSkeleton() {
 function ExperimentThumbnail({ experimentId }) {
     const { isDark } = useTheme();
     const [ref, inView] = useInView();
-    const [options, setOptions] = useState([]);
+    const [rawOptions, setRawOptions] = useState([]);
     const [index, setIndex] = useState(0);
     const [failed, setFailed] = useState(false);
 
@@ -52,11 +52,11 @@ function ExperimentThumbnail({ experimentId }) {
                     )
                 );
             })
-            .then((rawOptions) => {
-                if (cancelled || !rawOptions) return;
-                const built = rawOptions.filter(Boolean).map((raw) => buildThumbnailOption(raw, isDark));
-                if (built.length) {
-                    setOptions(built);
+            .then((fetched) => {
+                if (cancelled || !fetched) return;
+                const valid = fetched.filter(Boolean);
+                if (valid.length) {
+                    setRawOptions(valid);
                 } else {
                     setFailed(true);
                 }
@@ -68,7 +68,15 @@ function ExperimentThumbnail({ experimentId }) {
         return () => {
             cancelled = true;
         };
-    }, [inView, experimentId, isDark]);
+    }, [inView, experimentId]);
+
+    // Re-theming on a dark/light toggle is just recoloring already-fetched
+    // data, so it's a cheap useMemo rather than something the fetch effect
+    // above needs to re-run for.
+    const options = useMemo(
+        () => rawOptions.map((raw) => buildThumbnailOption(raw, isDark)),
+        [rawOptions, isDark]
+    );
 
     useEffect(() => {
         if (options.length <= 1) return undefined;

--- a/dst_dashboard/frontend/src/components/ExperimentThumbnail.js
+++ b/dst_dashboard/frontend/src/components/ExperimentThumbnail.js
@@ -3,7 +3,12 @@ import axios from 'axios';
 import { API_BASE_URL } from '../config';
 import { useInView } from '../hooks/useInView';
 import { buildThumbnailOption } from '../utils/chartOptions';
-import { getCachedRawOptions, setCachedRawOptions } from '../utils/thumbnailCache';
+import {
+    getCachedPanelList,
+    getCachedPanelOption,
+    setCachedPanelList,
+    setCachedPanelOption,
+} from '../utils/thumbnailCache';
 import { useTheme } from '../context/ThemeContext';
 
 const ReactECharts = lazy(() => import('echarts-for-react'));
@@ -31,14 +36,20 @@ function ThumbnailSkeleton() {
 function ExperimentThumbnail({ experimentId }) {
     const { isDark } = useTheme();
     const [ref, inView] = useInView();
-    const cached = getCachedRawOptions(experimentId);
-    const [rawOptions, setRawOptions] = useState(cached || []);
+    const [rawOptions, setRawOptions] = useState(() => {
+        // Panels cache independently, so on remount some may already be known
+        // (instant paint, no request) while others still need fetching - see
+        // the effect below.
+        const panels = getCachedPanelList(experimentId);
+        if (!panels) return [];
+        return panels.map((panel) => getCachedPanelOption(experimentId, panel.name)).filter(Boolean);
+    });
     const [index, setIndex] = useState(0);
     const [visible, setVisible] = useState(true);
     const [failed, setFailed] = useState(false);
 
     useEffect(() => {
-        if (!inView || cached) return;
+        if (!inView) return;
         const controller = new AbortController();
 
         const fetchPanelOption = (panelName) =>
@@ -49,27 +60,59 @@ function ExperimentThumbnail({ experimentId }) {
                 .then((res) => res.data?.option)
                 .catch(() => null);
 
-        axios
-            .get(`${API_BASE_URL}/experiments/${experimentId}`, { signal: controller.signal })
-            .then((res) => {
-                const panels = (res.data?.panels || []).slice(0, MAX_PANELS);
+        const getPanelList = () => {
+            const cachedPanels = getCachedPanelList(experimentId);
+            if (cachedPanels) return Promise.resolve(cachedPanels);
+            return axios
+                .get(`${API_BASE_URL}/experiments/${experimentId}`, { signal: controller.signal })
+                .then((res) => {
+                    const panels = (res.data?.panels || []).slice(0, MAX_PANELS);
+                    setCachedPanelList(experimentId, panels);
+                    return panels;
+                });
+        };
+
+        getPanelList()
+            .then((panels) => {
+                if (controller.signal.aborted) return;
                 if (!panels.length) {
                     setFailed(true);
                     return;
                 }
 
+                // Panels are cached individually (keyed by experimentId+panelName),
+                // not as one all-or-nothing blob for the whole experiment: panels
+                // settle independently and one slow/broken panel shouldn't cost
+                // the others their cache entry. Anything already cached renders
+                // immediately below; only the rest actually go over the network.
                 const accumulated = [];
-                let settledCount = 0;
-
+                const toFetch = [];
                 panels.forEach((panel) => {
+                    const cachedOption = getCachedPanelOption(experimentId, panel.name);
+                    if (cachedOption) {
+                        accumulated.push(cachedOption);
+                    } else {
+                        toFetch.push(panel);
+                    }
+                });
+                if (accumulated.length) setRawOptions([...accumulated]);
+
+                if (!toFetch.length) {
+                    if (accumulated.length === 0) setFailed(true);
+                    return;
+                }
+
+                let settledCount = 0;
+                toFetch.forEach((panel) => {
                     fetchPanelOption(panel.name).then((option) => {
                         if (controller.signal.aborted) return;
                         settledCount += 1;
                         if (option) {
+                            setCachedPanelOption(experimentId, panel.name, option);
                             accumulated.push(option);
-                            setCachedRawOptions(experimentId, [...accumulated]);
                             setRawOptions([...accumulated]);
-                        } else if (settledCount === panels.length && accumulated.length === 0) {
+                        }
+                        if (settledCount === toFetch.length && accumulated.length === 0) {
                             setFailed(true);
                         }
                     });
@@ -82,12 +125,6 @@ function ExperimentThumbnail({ experimentId }) {
         return () => {
             controller.abort();
         };
-        // `cached` is intentionally excluded: it's only a mount-time "was this
-        // already cached" gate. Fetching a panel populates the cache, which
-        // would flip `cached` truthy and re-trigger this effect - and its
-        // cleanup aborts the very controller the other panel fetches are
-        // still using, killing them mid-flight.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [inView, experimentId]);
 
     // Re-theming on a dark/light toggle is just recoloring already-fetched

--- a/dst_dashboard/frontend/src/components/Footer.js
+++ b/dst_dashboard/frontend/src/components/Footer.js
@@ -4,7 +4,7 @@ import { API_BASE_URL } from '../config';
 
 const FOOTER_COLUMNS = [
     {
-        title: 'Product',
+        title: 'Explore',
         links: [
             { label: 'Experiments', to: '/experiments' },
             { label: 'Topology', to: '/vaclab/topology' },
@@ -15,7 +15,7 @@ const FOOTER_COLUMNS = [
         title: 'Tools',
         links: [
             { label: '10ksim', href: 'https://github.com/vacp2p/10ksim' },
-            { label: 'VacLab', href: 'https://github.com/vacp2p' },
+            { label: 'vaclab', href: 'https://github.com/vacp2p/vaclab-2' },
         ],
     },
     {
@@ -28,9 +28,9 @@ const FOOTER_COLUMNS = [
     {
         title: 'Social',
         links: [
-            { label: 'GitHub', href: 'https://github.com/vacp2p' },
-            { label: 'X / Twitter', href: 'https://twitter.com/vacp2p' },
-            { label: 'vac.dev', href: 'https://vac.dev' },
+            { label: 'GitHub', href: 'https://github.com/vacp2p', icon: 'bi-github' },
+            { label: 'Discord', href: 'https://discord.com/channels/864066763682218004/1113778766657880127', icon: 'bi-discord' },
+            { label: 'vac.dev', href: 'https://vac.dev', icon: 'bi-globe' },
         ],
     },
 ];
@@ -52,7 +52,13 @@ function Footer() {
                                             {link.label}
                                         </Link>
                                     ) : (
-                                        <a href={link.href} target="_blank" rel="noopener noreferrer" className="link link-hover">
+                                        <a
+                                            href={link.href}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="link link-hover inline-flex items-center gap-2"
+                                        >
+                                            {link.icon && <i className={`bi ${link.icon}`}></i>}
                                             {link.label}
                                         </a>
                                     )}
@@ -63,7 +69,7 @@ function Footer() {
                 ))}
             </div>
             <div className="max-w-7xl mx-auto mt-10 pt-6 border-t border-base-100 text-xs text-base-content-tertiary font-mono">
-                &copy; {new Date().getFullYear()} VacLab. DST Dashboard — Distributed Systems Testing Analytics.
+                &copy; {new Date().getFullYear()} vaclab. DST Dashboard — Distributed Systems Testing Analytics.
             </div>
         </footer>
     );

--- a/dst_dashboard/frontend/src/components/Navbar.js
+++ b/dst_dashboard/frontend/src/components/Navbar.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTheme } from '../context/ThemeContext';
 
@@ -14,12 +14,29 @@ const VACLAB_LINKS = [
 
 const ICON_LINKS = [
     { href: 'https://github.com/vacp2p/10ksim', label: '10ksim on GitHub', icon: 'bi-github' },
+    { href: 'https://discord.com/channels/864066763682218004/1113778766657880127', label: 'Join us on Discord', icon: 'bi-discord' },
 ];
+
+// Close grace period so moving the pointer from the trigger down into the
+// menu (across the visual padding gap) doesn't get read as "left the menu".
+const CLOSE_DELAY_MS = 150;
 
 function Navbar() {
     const location = useLocation();
     const [mobileOpen, setMobileOpen] = useState(false);
+    const [vaclabOpen, setVaclabOpen] = useState(false);
     const { isDark, toggleTheme } = useTheme();
+    const closeTimer = useRef(null);
+
+    useEffect(() => () => clearTimeout(closeTimer.current), []);
+
+    const openVaclab = () => {
+        clearTimeout(closeTimer.current);
+        setVaclabOpen(true);
+    };
+    const closeVaclabSoon = () => {
+        closeTimer.current = setTimeout(() => setVaclabOpen(false), CLOSE_DELAY_MS);
+    };
 
     const isActive = (to) => location.pathname === to;
     const isVaclabActive = VACLAB_LINKS.some((link) => location.pathname === link.to);
@@ -31,7 +48,7 @@ function Navbar() {
                     <span className="bg-[#f5f5ef] rounded-full p-1 flex items-center justify-center">
                         <img
                             src="https://raw.githubusercontent.com/vacp2p/vaclab-2/feat/add_lab_components/extras/vac-logo-light-no-bg.png"
-                            alt="VacLab"
+                            alt="vaclab"
                             className="h-7 w-7 object-contain"
                         />
                     </span>
@@ -51,25 +68,40 @@ function Navbar() {
                                 </Link>
                             </li>
                         ))}
-                        <li className="dropdown dropdown-hover dropdown-end">
+                        <li
+                            className="relative"
+                            onMouseEnter={openVaclab}
+                            onMouseLeave={closeVaclabSoon}
+                        >
                             <div
                                 tabIndex={0}
                                 role="button"
-                                className={`px-2 py-1 rounded transition-colors flex items-center gap-1 ${isVaclabActive ? 'text-primary' : 'text-base-content-secondary hover:text-primary'
+                                aria-expanded={vaclabOpen}
+                                onFocus={openVaclab}
+                                onBlur={closeVaclabSoon}
+                                onClick={() => setVaclabOpen((open) => !open)}
+                                className={`px-2 py-1 rounded transition-colors flex items-center gap-1 cursor-pointer select-none outline-none focus-visible:ring-2 focus-visible:ring-primary/30 ${isVaclabActive ? 'text-primary' : 'text-base-content-secondary hover:text-primary'
                                     }`}
                             >
-                                VacLab
-                                <i className="bi bi-chevron-down text-xs"></i>
+                                vaclab
+                                <i className={`bi bi-chevron-down text-xs transition-transform ${vaclabOpen ? 'rotate-180' : ''}`}></i>
                             </div>
-                            <ul tabIndex={0} className="dropdown-content menu bg-base-200 rounded-lg mt-2 w-48 p-2 shadow-lg z-40">
-                                {VACLAB_LINKS.map((link) => (
-                                    <li key={link.to}>
-                                        <Link to={link.to} className={isActive(link.to) ? 'text-primary' : ''}>
-                                            <i className={`bi ${link.icon}`}></i>
-                                            {link.label}
-                                        </Link>
-                                    </li>
-                                ))}
+                            <ul
+                                className={`absolute right-0 top-full pt-2 w-48 z-40 transition-all duration-150 ${vaclabOpen
+                                        ? 'opacity-100 translate-y-0 pointer-events-auto'
+                                        : 'opacity-0 -translate-y-1 pointer-events-none'
+                                    }`}
+                            >
+                                <div className="menu bg-base-200 rounded p-2 shadow-lg border border-base-300">
+                                    {VACLAB_LINKS.map((link) => (
+                                        <li key={link.to}>
+                                            <Link to={link.to} onClick={() => setVaclabOpen(false)} className={isActive(link.to) ? 'text-primary' : ''}>
+                                                <i className={`bi ${link.icon}`}></i>
+                                                {link.label}
+                                            </Link>
+                                        </li>
+                                    ))}
+                                </div>
                             </ul>
                         </li>
                         <li className="w-px self-stretch bg-base-300 my-1"></li>
@@ -131,7 +163,7 @@ function Navbar() {
                                 </Link>
                             </li>
                         ))}
-                        <li className="menu-title mt-2">VacLab</li>
+                        <li className="menu-title mt-2">vaclab</li>
                         {VACLAB_LINKS.map((link) => (
                             <li key={link.to}>
                                 <Link to={link.to} onClick={() => setMobileOpen(false)} className={isActive(link.to) ? 'text-primary' : ''}>

--- a/dst_dashboard/frontend/src/components/PageTransition.js
+++ b/dst_dashboard/frontend/src/components/PageTransition.js
@@ -1,0 +1,21 @@
+import React, { useLayoutEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+// Resets scroll to the top of the new page and replays a subtle fade/rise-in
+// animation on every route change, so navigating between menu items reads as
+// an intentional transition instead of an abrupt content swap.
+function PageTransition({ children }) {
+    const location = useLocation();
+
+    useLayoutEffect(() => {
+        window.scrollTo(0, 0);
+    }, [location.pathname]);
+
+    return (
+        <div key={location.pathname} className="animate-page-in">
+            {children}
+        </div>
+    );
+}
+
+export default PageTransition;

--- a/dst_dashboard/frontend/src/components/Reveal.js
+++ b/dst_dashboard/frontend/src/components/Reveal.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useInView } from '../hooks/useInView';
+
+// Fades + rises a section in as it scrolls into view, and fades it back out
+// when it scrolls back out of view - so scrolling up doesn't leave stale
+// content stuck on screen. Distinct from useInView's lazy-load use elsewhere,
+// which deliberately fires once so data isn't re-fetched on every pass.
+function Reveal({ children, className = '', delay = 0 }) {
+    const [ref, inView] = useInView({ rootMargin: '0px 0px -10% 0px', once: false });
+
+    return (
+        <div
+            ref={ref}
+            className={`transition-all duration-700 ease-out ${inView ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-6'
+                } ${className}`}
+            style={delay ? { transitionDelay: `${delay}ms` } : undefined}
+        >
+            {children}
+        </div>
+    );
+}
+
+export default Reveal;

--- a/dst_dashboard/frontend/src/hooks/useInView.js
+++ b/dst_dashboard/frontend/src/hooks/useInView.js
@@ -1,15 +1,17 @@
 import { useEffect, useRef, useState } from 'react';
 
-// Reports whether an element has scrolled into (or near) the viewport, then
-// stops observing — used to defer mounting expensive chart instances until
-// they're actually about to be seen.
-export function useInView({ rootMargin = '200px' } = {}) {
+// Reports whether an element has scrolled into (or near) the viewport.
+// By default stops observing after the first hit — used to defer mounting
+// expensive chart instances/fetches until they're actually about to be seen,
+// without re-triggering (and re-fetching) every time the user scrolls past.
+// Pass once:false for purely visual effects that should toggle both ways.
+export function useInView({ rootMargin = '200px', once = true } = {}) {
     const ref = useRef(null);
     const [inView, setInView] = useState(false);
 
     useEffect(() => {
         const node = ref.current;
-        if (!node || inView) return undefined;
+        if (!node) return undefined;
 
         if (typeof IntersectionObserver === 'undefined') {
             setInView(true);
@@ -20,7 +22,9 @@ export function useInView({ rootMargin = '200px' } = {}) {
             ([entry]) => {
                 if (entry.isIntersecting) {
                     setInView(true);
-                    observer.disconnect();
+                    if (once) observer.disconnect();
+                } else if (!once) {
+                    setInView(false);
                 }
             },
             { rootMargin }
@@ -28,7 +32,7 @@ export function useInView({ rootMargin = '200px' } = {}) {
 
         observer.observe(node);
         return () => observer.disconnect();
-    }, [inView, rootMargin]);
+    }, [rootMargin, once]);
 
     return [ref, inView];
 }

--- a/dst_dashboard/frontend/src/index.css
+++ b/dst_dashboard/frontend/src/index.css
@@ -2,6 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 
+html {
+    /* Always reserve the scrollbar gutter so navigating between a short page
+       (no scrollbar) and a tall one (scrollbar appears) doesn't shift fixed
+       elements like the navbar horizontally. */
+    overflow-y: scroll;
+}
+
 body {
     margin: 0;
     -webkit-font-smoothing: antialiased;

--- a/dst_dashboard/frontend/src/pages/ExperimentPage.js
+++ b/dst_dashboard/frontend/src/pages/ExperimentPage.js
@@ -4,6 +4,7 @@ import axios from 'axios';
 import { API_BASE_URL } from '../config';
 import { useTheme } from '../context/ThemeContext';
 import ChartPanel from '../components/ChartPanel';
+import PageLoader from '../components/PageLoader';
 
 function ExperimentPage() {
     const { experimentId } = useParams();
@@ -26,7 +27,7 @@ function ExperimentPage() {
     }, [experimentId]);
 
     if (loading) {
-        return <div className="text-center py-24 text-base-content-tertiary text-lg">Loading experiment...</div>;
+        return <PageLoader />;
     }
 
     if (error) {
@@ -42,7 +43,7 @@ function ExperimentPage() {
             <div className="bg-base-200 border-b border-base-100 px-4 lg:px-8 py-16">
                 <div className="max-w-7xl mx-auto">
                     <Link
-                        to="/"
+                        to="/experiments"
                         className="btn btn-sm btn-ghost gap-2 mb-6 -ml-2 text-base-content-secondary hover:text-primary"
                     >
                         &larr; Back to Experiments
@@ -50,7 +51,7 @@ function ExperimentPage() {
                     <div className="text-secondary font-mono text-sm uppercase tracking-widest mb-3">
                         {experiment.family}
                     </div>
-                    <h1 className="text-3xl md:text-4xl font-bold mb-4 leading-tight">{experiment.title}</h1>
+                    <h1 className="text-3xl md:text-4xl font-bold mb-4 leading-tight tracking-tight">{experiment.title}</h1>
                     {experiment.description && (
                         <p className="text-base-content-secondary text-lg font-light max-w-3xl mb-6">
                             {experiment.description}

--- a/dst_dashboard/frontend/src/pages/ExperimentsPage.js
+++ b/dst_dashboard/frontend/src/pages/ExperimentsPage.js
@@ -1,14 +1,17 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { API_BASE_URL } from '../config';
+import { flattenExperiments } from '../utils/experiments';
+import PageLoader from '../components/PageLoader';
+import Reveal from '../components/Reveal';
+import ExperimentCard from '../components/ExperimentCard';
 
 function ExperimentsPage() {
     const [familiesData, setFamiliesData] = useState(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [selectedCategory, setSelectedCategory] = useState('all');
-    const navigate = useNavigate();
+    const [query, setQuery] = useState('');
 
     useEffect(() => {
         fetchFamilies();
@@ -26,7 +29,7 @@ function ExperimentsPage() {
     };
 
     if (loading) {
-        return <div className="text-center py-24 text-base-content-tertiary text-lg">Loading experiments...</div>;
+        return <PageLoader />;
     }
 
     if (error) {
@@ -37,132 +40,101 @@ function ExperimentsPage() {
         );
     }
 
-    const allExperiments = [];
-    familiesData?.families?.forEach((family) => {
-        family.experiments?.forEach((exp) => {
-            allExperiments.push({
-                ...exp,
-                family: family.name,
-            });
-        });
-    });
+    const allExperiments = flattenExperiments(familiesData);
 
-    const filteredExperiments = selectedCategory === 'all'
+    const categoryFiltered = selectedCategory === 'all'
         ? allExperiments
         : allExperiments.filter((exp) => exp.family === selectedCategory);
 
+    const normalizedQuery = query.trim().toLowerCase();
+    const filteredExperiments = normalizedQuery
+        ? categoryFiltered.filter((exp) => exp.title?.toLowerCase().includes(normalizedQuery))
+        : categoryFiltered;
+
     return (
         <div>
-            <section className="bg-base-200 border-b border-base-100 px-4 lg:px-8 py-12">
+            <section className="bg-base-200 border-b border-base-100 px-4 lg:px-8 py-14 md:py-20">
                 <span className="text-secondary font-mono text-sm uppercase tracking-widest border-b border-secondary/40 pb-1">
-                    Data
+                    Benchmarks
                 </span>
-                <h1 className="text-3xl md:text-4xl font-bold mt-4">Experiments</h1>
-                <p className="text-base-content-secondary text-lg font-light mt-2 max-w-2xl">
-                    Browse benchmark runs by category and drill into individual experiment results.
+                <h1 className="text-4xl md:text-5xl font-bold mt-5 tracking-tight">Experiments</h1>
+                <p className="text-base-content-secondary text-lg font-light mt-3 max-w-2xl">
+                    Browse experiments by category, or search for a specific run.
                 </p>
             </section>
 
-            {/* Categories */}
-            <section className="bg-base-200 py-10 px-4 lg:px-8 border-b border-base-100">
-                <div className="max-w-7xl mx-auto">
-                    <h2 className="font-mono text-xl uppercase tracking-widest mb-6">Categories</h2>
-                    <div className="flex flex-wrap gap-3">
+            {/* Filter bar: category pills + search, in one compact row */}
+            <section className="sticky top-16 z-20 bg-base-200/95 backdrop-blur border-b border-base-100 px-4 lg:px-8 py-4">
+                <div className="max-w-7xl mx-auto flex flex-col lg:flex-row lg:items-center gap-3">
+                    <div className="flex flex-wrap gap-2" role="group" aria-label="Filter by category">
                         <button
                             type="button"
                             onClick={() => setSelectedCategory('all')}
-                            className={`px-5 py-3 rounded-lg border text-center transition-colors ${selectedCategory === 'all'
-                                    ? 'border-primary bg-base-100 text-primary'
-                                    : 'border-base-100 bg-base-100/50 hover:border-secondary'
+                            className={`px-4 py-1.5 rounded text-sm font-medium border transition-colors ${selectedCategory === 'all'
+                                    ? 'bg-primary text-primary-content border-primary'
+                                    : 'border-base-300 text-base-content-secondary hover:border-secondary hover:text-primary'
                                 }`}
                         >
-                            <div className="font-medium text-sm">All Experiments</div>
-                            <div className="font-mono text-lg">{allExperiments.length}</div>
+                            All <span className="opacity-60">{allExperiments.length}</span>
                         </button>
                         {familiesData?.families?.map((family) => (
                             <button
                                 type="button"
                                 key={family.name}
                                 onClick={() => setSelectedCategory(family.name)}
-                                className={`px-5 py-3 rounded-lg border text-center transition-colors ${selectedCategory === family.name
-                                        ? 'border-primary bg-base-100 text-primary'
-                                        : 'border-base-100 bg-base-100/50 hover:border-secondary'
+                                className={`px-4 py-1.5 rounded text-sm font-medium border transition-colors ${selectedCategory === family.name
+                                        ? 'bg-primary text-primary-content border-primary'
+                                        : 'border-base-300 text-base-content-secondary hover:border-secondary hover:text-primary'
                                     }`}
                             >
-                                <div className="font-medium text-sm">{family.name}</div>
-                                <div className="font-mono text-lg">{family.experiments?.length || 0}</div>
+                                {family.name} <span className="opacity-60">{family.experiments?.length || 0}</span>
                             </button>
                         ))}
                     </div>
+                    <label className="flex items-center gap-2 bg-base-100 border border-base-300 rounded px-4 py-1.5 w-full lg:w-64 lg:ml-auto shrink-0 focus-within:border-secondary transition-colors">
+                        <i className="bi bi-search text-base-content-tertiary text-sm"></i>
+                        <input
+                            type="text"
+                            value={query}
+                            onChange={(e) => setQuery(e.target.value)}
+                            placeholder="Search experiments"
+                            className="grow bg-transparent outline-none text-sm min-w-0"
+                            aria-label="Search experiments"
+                        />
+                        {query && (
+                            <button
+                                type="button"
+                                onClick={() => setQuery('')}
+                                aria-label="Clear search"
+                                className="text-base-content-tertiary hover:text-primary shrink-0"
+                            >
+                                <i className="bi bi-x-lg text-xs"></i>
+                            </button>
+                        )}
+                    </label>
                 </div>
             </section>
 
             {/* Experiments grid */}
             <section className="bg-base-300 py-12 px-4 lg:px-8">
                 <div className="max-w-7xl mx-auto">
-                    <h2 className="font-mono text-xl uppercase tracking-widest mb-6">
-                        {selectedCategory === 'all' ? 'All Experiments' : `${selectedCategory} Experiments`}
-                    </h2>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                        {filteredExperiments.map((experiment) => (
-                            <div
-                                key={experiment.id}
-                                onClick={() => navigate(`/experiment/${experiment.id}`)}
-                                className="card bg-base-200 border border-base-100 hover:border-secondary hover:-translate-y-1 transition-all cursor-pointer"
-                            >
-                                <div className="card-body p-6">
-                                    <div className="flex justify-between items-start gap-3">
-                                        <h3 className="font-semibold leading-snug">{experiment.title}</h3>
-                                        {experiment.date && (
-                                            <span className="text-base-content-tertiary text-xs whitespace-nowrap">
-                                                {new Date(experiment.date).toLocaleDateString('en-US', {
-                                                    month: 'short',
-                                                    day: 'numeric',
-                                                })}
-                                            </span>
-                                        )}
-                                    </div>
-
-                                    {experiment.description && (
-                                        <p className="text-base-content-secondary text-sm mt-2 line-clamp-2 font-light">
-                                            {experiment.description}
-                                        </p>
-                                    )}
-
-                                    <div className="flex flex-wrap gap-2 pt-4 mt-4 border-t border-base-100">
-                                        {experiment.github_repo && (
-                                            <a
-                                                href={experiment.github_repo}
-                                                onClick={(e) => e.stopPropagation()}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                                className="badge badge-neutral gap-1"
-                                            >
-                                                <i className="bi bi-github"></i>
-                                                GitHub
-                                            </a>
-                                        )}
-                                        {experiment.github_pr && (
-                                            <a
-                                                href={experiment.github_pr}
-                                                onClick={(e) => e.stopPropagation()}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                                className="badge badge-neutral gap-1"
-                                            >
-                                                PR
-                                            </a>
-                                        )}
-                                        {experiment.docker_image && (
-                                            <span className="badge badge-outline text-base-content-tertiary" title={experiment.docker_image}>
-                                                {experiment.docker_image.split(':').pop()}
-                                            </span>
-                                        )}
-                                    </div>
-                                </div>
-                            </div>
+                    <p className="text-base-content-tertiary text-sm mb-6">
+                        Showing {filteredExperiments.length} of {allExperiments.length} experiments
+                    </p>
+                    {filteredExperiments.length === 0 ? (
+                        <div className="text-center py-16 text-base-content-tertiary">
+                            <i className="bi bi-search text-3xl mb-3 block"></i>
+                            No experiments match your search.
+                        </div>
+                    ) : (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 items-stretch">
+                        {filteredExperiments.map((experiment, index) => (
+                            <Reveal key={experiment.id} delay={(index % 6) * 60} className="h-full">
+                                <ExperimentCard experiment={experiment} />
+                            </Reveal>
                         ))}
                     </div>
+                    )}
                 </div>
             </section>
         </div>

--- a/dst_dashboard/frontend/src/pages/HomePage.js
+++ b/dst_dashboard/frontend/src/pages/HomePage.js
@@ -2,9 +2,30 @@ import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
 import { API_BASE_URL } from '../config';
+import { flattenExperiments, sortByDateDesc } from '../utils/experiments';
+import Reveal from '../components/Reveal';
+import ExperimentCard from '../components/ExperimentCard';
+
+const FEATURED_COUNT = 6;
+
+function ExperimentCardSkeleton() {
+    return (
+        <div className="card h-full overflow-hidden bg-base-200 border border-base-100 animate-pulse">
+            <div className="h-[152px] bg-base-300/60" />
+            <div className="card-body p-6">
+                <div className="h-4 w-2/3 bg-base-300/70 rounded mb-3" />
+                <div className="h-3 w-full bg-base-300/60 rounded mb-2" />
+                <div className="h-3 w-4/5 bg-base-300/60 rounded mb-6" />
+                <div className="h-5 w-20 bg-base-300/60 rounded" />
+            </div>
+        </div>
+    );
+}
 
 function HomePage() {
     const [stats, setStats] = useState({ totalExperiments: 0, totalFamilies: 0 });
+    const [latestExperiments, setLatestExperiments] = useState([]);
+    const [loadingLatest, setLoadingLatest] = useState(true);
 
     useEffect(() => {
         axios
@@ -14,8 +35,11 @@ function HomePage() {
                     totalExperiments: res.data?.total_experiments || 0,
                     totalFamilies: res.data?.total_families || 0,
                 });
+                const all = flattenExperiments(res.data);
+                setLatestExperiments(sortByDateDesc(all).slice(0, FEATURED_COUNT));
             })
-            .catch(() => {});
+            .catch(() => {})
+            .finally(() => setLoadingLatest(false));
     }, []);
 
     return (
@@ -26,7 +50,7 @@ function HomePage() {
                     <span className="text-secondary font-mono text-sm uppercase tracking-widest border-b border-secondary/40 pb-1">
                         VacLab DST Dashboard
                     </span>
-                    <h1 className="text-4xl md:text-6xl font-bold mt-6 mb-6 leading-tight">
+                    <h1 className="text-4xl md:text-6xl font-bold mt-6 mb-6 leading-tight tracking-tight">
                         Evaluating Distributed Systems at Scale
                     </h1>
                     <p className="text-xl md:text-2xl text-base-content-secondary max-w-3xl mx-auto leading-relaxed font-light mb-10">
@@ -43,19 +67,55 @@ function HomePage() {
             </section>
 
             {/* Stats bar */}
-            <section className="bg-base-300 py-10 px-4">
+            <section className="bg-base-300 py-14 md:py-20 px-4">
                 <div className="max-w-2xl mx-auto flex flex-row justify-around text-center">
-                    <div className="flex flex-col items-center">
+                    <Reveal className="flex flex-col items-center">
                         <i className="bi bi-activity text-3xl text-primary mb-2"></i>
                         <div className="font-mono font-medium text-4xl md:text-5xl">{stats.totalExperiments}</div>
                         <div className="text-base-content-secondary text-sm mt-2">Experiments</div>
-                    </div>
+                    </Reveal>
                     <div className="border-l border-base-100" />
-                    <div className="flex flex-col items-center">
+                    <Reveal delay={120} className="flex flex-col items-center">
                         <i className="bi bi-folder2 text-3xl text-primary mb-2"></i>
                         <div className="font-mono font-medium text-4xl md:text-5xl">{stats.totalFamilies}</div>
                         <div className="text-base-content-secondary text-sm mt-2">Projects</div>
-                    </div>
+                    </Reveal>
+                </div>
+            </section>
+
+            {/* Latest experiments */}
+            <section className="bg-base-200 py-16 md:py-24 px-4 lg:px-8 border-t border-base-100">
+                <div className="max-w-7xl mx-auto">
+                    <Reveal className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 mb-10">
+                        <div>
+                            <span className="text-secondary font-mono text-sm uppercase tracking-widest border-b border-secondary/40 pb-1">
+                                Results
+                            </span>
+                            <h2 className="text-3xl md:text-4xl font-bold mt-4 tracking-tight">Latest experiments</h2>
+                        </div>
+                        <Link to="/experiments" className="btn btn-outline btn-sm gap-2 self-start sm:self-auto">
+                            View all experiments
+                            <svg width="1em" height="1em" viewBox="0 0 12 11" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M0.499979 9.66667L8.49998 1.66667L1.33331 1.66667V0L11.3333 0V10H9.66665V2.83333L1.66665 10.8333L0.499979 9.66667Z" />
+                            </svg>
+                        </Link>
+                    </Reveal>
+
+                    {loadingLatest ? (
+                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                            {Array.from({ length: 3 }).map((_, i) => (
+                                <ExperimentCardSkeleton key={i} />
+                            ))}
+                        </div>
+                    ) : latestExperiments.length > 0 ? (
+                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 items-stretch">
+                            {latestExperiments.map((experiment, index) => (
+                                <Reveal key={experiment.id} delay={(index % 3) * 80} className="h-full">
+                                    <ExperimentCard experiment={experiment} showThumbnail />
+                                </Reveal>
+                            ))}
+                        </div>
+                    ) : null}
                 </div>
             </section>
         </div>

--- a/dst_dashboard/frontend/src/utils/chartOptions.js
+++ b/dst_dashboard/frontend/src/utils/chartOptions.js
@@ -103,3 +103,31 @@ export function buildChartOption(rawOption, isDark) {
     applyChartTheme(option, isDark);
     return option;
 }
+
+function stripAxisChrome(axis) {
+    if (!axis) return axis;
+    const strip = (a) => ({
+        ...a,
+        axisLabel: { show: false },
+        axisLine: { show: false },
+        axisTick: { show: false },
+        splitLine: { show: false },
+    });
+    return Array.isArray(axis) ? axis.map(strip) : strip(axis);
+}
+
+// A small, chrome-free variant for card/thumbnail previews: same data and
+// series colors as the real chart, but no axes, legend, toolbox or tooltip -
+// just the shape of the data at a glance.
+export function buildThumbnailOption(rawOption, isDark) {
+    const option = buildChartOption(rawOption, isDark);
+    return {
+        ...option,
+        grid: { left: 4, right: 4, top: 6, bottom: 4, containLabel: false },
+        legend: { show: false },
+        toolbox: { show: false },
+        tooltip: { show: false },
+        xAxis: stripAxisChrome(option.xAxis),
+        yAxis: stripAxisChrome(option.yAxis),
+    };
+}

--- a/dst_dashboard/frontend/src/utils/chartOptions.js
+++ b/dst_dashboard/frontend/src/utils/chartOptions.js
@@ -117,8 +117,10 @@ function stripAxisChrome(axis) {
 }
 
 // A small, chrome-free variant for card/thumbnail previews: same data and
-// series colors as the real chart, but no axes, legend, toolbox or tooltip -
-// just the shape of the data at a glance.
+// series colors as the real chart, but no axes, legend, toolbox, tooltip, or
+// zoom/pan - just the shape of the data at a glance. dataZoom in particular
+// is never interacted with here but still costs real setup (gesture
+// listeners, coordinate tracking) on every mount if left enabled.
 export function buildThumbnailOption(rawOption, isDark) {
     const option = buildChartOption(rawOption, isDark);
     return {
@@ -127,6 +129,7 @@ export function buildThumbnailOption(rawOption, isDark) {
         legend: { show: false },
         toolbox: { show: false },
         tooltip: { show: false },
+        dataZoom: [],
         xAxis: stripAxisChrome(option.xAxis),
         yAxis: stripAxisChrome(option.yAxis),
     };

--- a/dst_dashboard/frontend/src/utils/experiments.js
+++ b/dst_dashboard/frontend/src/utils/experiments.js
@@ -1,0 +1,20 @@
+// Flattens the nested {families: [{name, experiments: [...]}]} response into a
+// flat list of experiments, each tagged with its family name. Shared between
+// any page that needs to list/filter/sort experiments across all families.
+export function flattenExperiments(familiesData) {
+    const all = [];
+    familiesData?.families?.forEach((family) => {
+        family.experiments?.forEach((exp) => {
+            all.push({ ...exp, family: family.name });
+        });
+    });
+    return all;
+}
+
+export function sortByDateDesc(experiments) {
+    return [...experiments].sort((a, b) => {
+        if (!a.date) return 1;
+        if (!b.date) return -1;
+        return new Date(b.date) - new Date(a.date);
+    });
+}

--- a/dst_dashboard/frontend/src/utils/thumbnailCache.js
+++ b/dst_dashboard/frontend/src/utils/thumbnailCache.js
@@ -1,0 +1,15 @@
+// Module-scoped (persists for the SPA session) cache of each experiment's
+// fetched-but-not-yet-themed panel options. HomePage fully remounts on every
+// route change (PageTransition keys the page tree by pathname), which would
+// otherwise re-fetch and rebuild every thumbnail's chart data each time the
+// user navigates back to Home. Theming is left out of the cache since it's a
+// cheap, theme-reactive derivation (see ExperimentThumbnail's useMemo).
+const cache = new Map();
+
+export function getCachedRawOptions(experimentId) {
+    return cache.get(experimentId);
+}
+
+export function setCachedRawOptions(experimentId, rawOptions) {
+    cache.set(experimentId, rawOptions);
+}

--- a/dst_dashboard/frontend/src/utils/thumbnailCache.js
+++ b/dst_dashboard/frontend/src/utils/thumbnailCache.js
@@ -1,15 +1,35 @@
-// Module-scoped (persists for the SPA session) cache of each experiment's
-// fetched-but-not-yet-themed panel options. HomePage fully remounts on every
-// route change (PageTransition keys the page tree by pathname), which would
-// otherwise re-fetch and rebuild every thumbnail's chart data each time the
-// user navigates back to Home. Theming is left out of the cache since it's a
+// Module-scoped (persists for the SPA session) cache of fetched-but-not-yet-
+// themed panel options. HomePage fully remounts on every route change
+// (PageTransition keys the page tree by pathname), which would otherwise
+// re-fetch and rebuild every thumbnail's chart data each time the user
+// navigates back to Home. Theming is left out of the cache since it's a
 // cheap, theme-reactive derivation (see ExperimentThumbnail's useMemo).
-const cache = new Map();
+//
+// Cached per-panel (keyed on `${experimentId}:${panelName}`), not per-
+// experiment: an experiment's panels are fetched independently and can
+// settle at very different times (or not at all, if one hangs/errors), so
+// bundling them into one all-or-nothing cache entry means one slow or
+// broken panel permanently prevents caching the others. Per-panel keys let
+// each panel be reused the instant it succeeds, regardless of its siblings.
+const panelOptionCache = new Map();
 
-export function getCachedRawOptions(experimentId) {
-    return cache.get(experimentId);
+// The panel list itself (name/title metadata) is cached separately so a
+// fully-cached experiment can skip the network entirely on remount, instead
+// of always paying for at least one request just to know which panels exist.
+const panelListCache = new Map();
+
+export function getCachedPanelOption(experimentId, panelName) {
+    return panelOptionCache.get(`${experimentId}:${panelName}`);
 }
 
-export function setCachedRawOptions(experimentId, rawOptions) {
-    cache.set(experimentId, rawOptions);
+export function setCachedPanelOption(experimentId, panelName, rawOption) {
+    panelOptionCache.set(`${experimentId}:${panelName}`, rawOption);
+}
+
+export function getCachedPanelList(experimentId) {
+    return panelListCache.get(experimentId);
+}
+
+export function setCachedPanelList(experimentId, panels) {
+    panelListCache.set(experimentId, panels);
 }

--- a/dst_dashboard/frontend/tailwind.config.js
+++ b/dst_dashboard/frontend/tailwind.config.js
@@ -14,6 +14,15 @@ module.exports = {
                 'base-content-secondary': 'var(--content-secondary)',
                 'base-content-tertiary': 'var(--content-tertiary)',
             },
+            keyframes: {
+                'page-in': {
+                    '0%': { opacity: '0', transform: 'translateY(10px)' },
+                    '100%': { opacity: '1', transform: 'translateY(0)' },
+                },
+            },
+            animation: {
+                'page-in': 'page-in 0.32s cubic-bezier(0.16, 1, 0.3, 1)',
+            },
         },
     },
     plugins: [require('daisyui')],
@@ -41,6 +50,10 @@ module.exports = {
                     'warning-content': '#152521',
                     error: '#e40014',
                     'error-content': '#f5f5ef',
+                    '--rounded-box': '0.375rem',
+                    '--rounded-btn': '0.25rem',
+                    '--rounded-badge': '0.25rem',
+                    '--tab-radius': '0.25rem',
                 },
             },
             {
@@ -65,6 +78,10 @@ module.exports = {
                     'warning-content': '#152521',
                     error: '#fb2c36',
                     'error-content': '#152521',
+                    '--rounded-box': '0.375rem',
+                    '--rounded-btn': '0.25rem',
+                    '--rounded-badge': '0.25rem',
+                    '--tab-radius': '0.25rem',
                 },
             },
         ],

--- a/dst_dashboard/processors/panel_processor.py
+++ b/dst_dashboard/processors/panel_processor.py
@@ -189,7 +189,7 @@ class PanelProcessor(DatasetProcessor):
                 "emphasis": {"iconStyle": {"borderColor": "#00d4ff"}},
             },
             "dataZoom": [
-                {"type": "inside", "xAxisIndex": 0, "filterMode": "none", "disabled": False}
+                {"type": "inside", "xAxisIndex": 0, "filterMode": "filter", "disabled": False}
             ],
             "grid": {"left": "10%", "right": "10%", "bottom": "15%"},
             "xAxis": {
@@ -213,6 +213,7 @@ class PanelProcessor(DatasetProcessor):
                     "type": "boxplot",
                     "data": boxplot_data,
                     "itemStyle": {"borderColor": "#00d4ff", "borderWidth": 1.5},
+                    "clip": True,
                 }
             ],
         }


### PR DESCRIPTION
## Context
This PR polishes several parts of the UI and fixes some identified issues

## Major changes
- Fixed the experiment detail page's back link to return to the Experiments list instead of Home
- Fixed page scroll position/layout jumping when navigating between pages
- Fixed the "vaclab" navbar dropdown so Network/Resources can actually be clicked on hover
- Removed the Twitter/X link, replaced with our Discord channel (navbar + footer)
- Renamed "VacLab" to "vaclab", reworded Experiments page text, renamed footer "Product" section to "Explore"
- Updated vaclab GitHub links to point to the actual repo instead of the org root
- Added a "Latest experiments" section to the homepage (6 most recent), each with an auto-rotating chart-panel preview
- Enabled scroll-triggered fade-in animations to show homepage content progressively as we scroll down
- Redesigned the Experiments page filter bar (replaced category text and added a search bar) and fixed inconsistent card heights
- Refined light/dark theme consistency (corner radius, typography)
- Replaced plain loading text with a spinner
## URLs
- Already accessible in DEV: [https://dev.dashboard.lab.vac.dev](https://dev.dashboard.lab.vac.dev)