### PR TITLE
k8s: optional bandwidth cap on the network-delay init container

### DIFF
--- a/src/deployments/core/builders.py
+++ b/src/deployments/core/builders.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional, Self, Tuple, Union
+from typing import List, Optional, Self, Tuple
 
 from kubernetes.client import (
     V1Container,
@@ -73,8 +73,8 @@ class StatefulSetBuilder(BaseModel):
 
     def with_network_delay(
         self,
-        delay: Union[str, NonNegativeInt],
-        jitter: Union[str, NonNegativeInt],
+        delay: NonNegativeInt,
+        jitter: NonNegativeInt,
         rate_mbit: Optional[NonNegativeInt] = None,
         *,
         overwrite: bool = False,

--- a/src/deployments/core/builders.py
+++ b/src/deployments/core/builders.py
@@ -75,10 +75,11 @@ class StatefulSetBuilder(BaseModel):
         self,
         delay: Union[str, NonNegativeInt],
         jitter: Union[str, NonNegativeInt],
+        rate_mbit: Optional[NonNegativeInt] = None,
         *,
         overwrite: bool = False,
     ) -> Self:
-        delay_container = init_container_delay(delay, jitter)
+        delay_container = init_container_delay(delay, jitter, rate_mbit)
         self.config.stateful_set_spec.pod_template_spec_config.pod_spec_config.add_init_container(
             delay_container, overwrite=overwrite
         )

--- a/src/deployments/core/configs/helpers/utils.py
+++ b/src/deployments/core/configs/helpers/utils.py
@@ -1,6 +1,6 @@
 # Python Imports
 from copy import deepcopy
-from typing import Dict, List, Literal, Optional, Tuple, Type, TypeVar, Union, get_args
+from typing import Dict, List, Literal, Optional, Tuple, Type, TypeVar, get_args
 
 from kubernetes.client import V1Capabilities, V1Container, V1SecurityContext
 from pydantic import NonNegativeInt
@@ -162,16 +162,13 @@ def convert_to_container_config(
 
 
 def init_container_delay(
-    delay: Union[str, NonNegativeInt],
-    jitter: Union[str, NonNegativeInt],
+    delay: NonNegativeInt,
+    jitter: NonNegativeInt,
     rate_mbit: Optional[NonNegativeInt] = None,
 ):
-    netem = f"delay {str(delay)}ms"
-    # netem's `distribution` needs a non-zero jitter; a fixed delay omits it.
-    if str(jitter) not in ("0", "0ms", ""):
-        netem += f" {str(jitter)}ms distribution normal"
-    # Fold the bandwidth cap into the same netem qdisc; a separate tbf root qdisc
-    # would collide with this one on eth0.
+    netem = f"delay {delay}ms"
+    if jitter:
+        netem += f" {jitter}ms distribution normal"
     if rate_mbit:
         netem += f" rate {rate_mbit}mbit"
     return V1Container(

--- a/src/deployments/core/configs/helpers/utils.py
+++ b/src/deployments/core/configs/helpers/utils.py
@@ -164,15 +164,22 @@ def convert_to_container_config(
 def init_container_delay(
     delay: Union[str, NonNegativeInt],
     jitter: Union[str, NonNegativeInt],
+    rate_mbit: Optional[NonNegativeInt] = None,
 ):
+    netem = f"delay {str(delay)}ms"
+    # netem's `distribution` needs a non-zero jitter; a fixed delay omits it.
+    if str(jitter) not in ("0", "0ms", ""):
+        netem += f" {str(jitter)}ms distribution normal"
+    # Fold the bandwidth cap into the same netem qdisc; a separate tbf root qdisc
+    # would collide with this one on eth0.
+    if rate_mbit:
+        netem += f" rate {rate_mbit}mbit"
     return V1Container(
         name="slowyourroll",
         image="soutullostatus/tc-container:1",
         image_pull_policy="IfNotPresent",
         security_context=V1SecurityContext(capabilities=V1Capabilities(add=["NET_ADMIN"])),
-        command=[
-            f"tc qdisc add dev eth0 root netem delay {str(delay)}ms {str(jitter)}ms distribution normal",
-        ],
+        command=[f"tc qdisc add dev eth0 root netem {netem}"],
     )
 
 

--- a/src/deployments/core/tests/test_builders.py
+++ b/src/deployments/core/tests/test_builders.py
@@ -28,6 +28,7 @@ from src.deployments.core.builders import (
     default_readiness_probe_health,
 )
 from src.deployments.core.configs.container import ContainerConfig, Image
+from src.deployments.core.configs.helpers.utils import init_container_delay
 from src.deployments.core.dependency_decorator import depends_on
 
 # --------------------------------------------------------------------------- #
@@ -199,7 +200,7 @@ class TestStatefulSetBuilder:
         )
 
         builder.with_network_delay("100ms", "10ms")
-        mock_init_delay.assert_called_once_with("100ms", "10ms")
+        mock_init_delay.assert_called_once_with("100ms", "10ms", None)
 
     def test_with_network_delay_adds_init_container_to_pod_spec(self, mocker):
         """Should add init container to pod spec with correct delay and jitter values."""
@@ -233,7 +234,7 @@ class TestStatefulSetBuilder:
         )
 
         builder.with_network_delay("100ms", "10ms")
-        mock_init_delay.assert_called_once_with("100ms", "10ms")
+        mock_init_delay.assert_called_once_with("100ms", "10ms", None)
         init_containers = (
             builder.config.stateful_set_spec.pod_template_spec_config.pod_spec_config.init_containers
         )
@@ -254,6 +255,16 @@ class TestStatefulSetBuilder:
         )
         result = builder.with_network_delay("100ms", "10ms")
         assert isinstance(result, StatefulSetBuilder)
+
+    def test_init_container_delay_folds_rate_into_netem(self):
+        """delay + a bandwidth cap share one netem qdisc (a separate tbf root would collide)."""
+        assert init_container_delay(50, 0, 50).command == [
+            "tc qdisc add dev eth0 root netem delay 50ms rate 50mbit"
+        ]
+        # existing delay+jitter output is unchanged
+        assert init_container_delay(100, 10).command == [
+            "tc qdisc add dev eth0 root netem delay 100ms 10ms distribution normal"
+        ]
 
     def test_with_bandwidth_limit_calls_helper(self, mocker):
         """Should call init_container_bandwidth_limit."""

--- a/src/deployments/core/tests/test_builders.py
+++ b/src/deployments/core/tests/test_builders.py
@@ -199,8 +199,8 @@ class TestStatefulSetBuilder:
             return_value=delay_container,
         )
 
-        builder.with_network_delay("100ms", "10ms")
-        mock_init_delay.assert_called_once_with("100ms", "10ms", None)
+        builder.with_network_delay(100, 10)
+        mock_init_delay.assert_called_once_with(100, 10, None)
 
     def test_with_network_delay_adds_init_container_to_pod_spec(self, mocker):
         """Should add init container to pod spec with correct delay and jitter values."""
@@ -233,8 +233,8 @@ class TestStatefulSetBuilder:
             return_value=delay_container,
         )
 
-        builder.with_network_delay("100ms", "10ms")
-        mock_init_delay.assert_called_once_with("100ms", "10ms", None)
+        builder.with_network_delay(100, 10)
+        mock_init_delay.assert_called_once_with(100, 10, None)
         init_containers = (
             builder.config.stateful_set_spec.pod_template_spec_config.pod_spec_config.init_containers
         )
@@ -253,7 +253,7 @@ class TestStatefulSetBuilder:
         mocker.patch(
             "src.deployments.core.builders.init_container_delay", return_value=delay_container
         )
-        result = builder.with_network_delay("100ms", "10ms")
+        result = builder.with_network_delay(100, 10)
         assert isinstance(result, StatefulSetBuilder)
 
     def test_init_container_delay_folds_rate_into_netem(self):
@@ -261,7 +261,6 @@ class TestStatefulSetBuilder:
         assert init_container_delay(50, 0, 50).command == [
             "tc qdisc add dev eth0 root netem delay 50ms rate 50mbit"
         ]
-        # existing delay+jitter output is unchanged
         assert init_container_delay(100, 10).command == [
             "tc qdisc add dev eth0 root netem delay 100ms 10ms distribution normal"
         ]
@@ -357,7 +356,7 @@ class TestStatefulSetBuilder:
             return_value=bandwidth_container,
         )
 
-        builder.with_network_delay("100ms", "10ms").with_bandwidth_limit(
+        builder.with_network_delay(100, 10).with_bandwidth_limit(
             ingress_rate="1mbit", egress_rate="500kbit"
         )
         init_containers = (

--- a/src/deployments/experiments/libp2p/nimlibp2p.py
+++ b/src/deployments/experiments/libp2p/nimlibp2p.py
@@ -45,6 +45,7 @@ class ExpConfig(BaseModel):
     bootstrap_nodes: NonNegativeInt = 1
     network_delay: NonNegativeInt = 0
     network_jitter: NonNegativeInt = 0
+    network_bandwidth_mbit: NonNegativeInt = 0  # 0 = uncapped; folded into the netem qdisc
     node_start_delay: NonNegativeInt = 60
     wait_nodes_ready: bool = True
 
@@ -88,9 +89,11 @@ def build_nodes(
         builder = builder.with_option(NimLibp2p.service, "nimp2p-service").with_option(
             NimLibp2p.connect_to, params.connect_to
         )
-    if params.network_delay or params.network_jitter:
+    if params.network_delay or params.network_jitter or params.network_bandwidth_mbit:
         builder = builder.with_network_delay(
-            delay=params.network_delay, jitter=params.network_jitter
+            delay=params.network_delay,
+            jitter=params.network_jitter,
+            rate_mbit=params.network_bandwidth_mbit or None,
         )
 
     return builder.build()


### PR DESCRIPTION
Adds a `network_bandwidth_mbit` knob to the nimlibp2p experiment. Off by default (0 = uncapped), so existing runs are unchanged.