### PR TITLE
Regression analysis: plot delivery latency as a CDF

### DIFF
--- a/src/analysis/plotting/latency_plotter.py
+++ b/src/analysis/plotting/latency_plotter.py
@@ -1,0 +1,112 @@
+"""Plot message delivery latency as a CDF, one curve per run.
+
+Latency is not a scraped metric: it comes from the delay stamped on each
+`Received message` log line, which the reliability analysis dumps to
+`analysis_data/summary/received.csv`. The tail is the interesting part (mesh push
+versus gossip pull sit orders of magnitude apart), so a CDF reads better than a box
+plot and this does not fit MetricsPlotter.
+"""
+
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+from pydantic import BaseModel, Field, PositiveInt
+
+logger = logging.getLogger(__name__)
+sns.set_theme()
+
+DELAY_COLUMN = "delayMs"
+SUMMARY_RECEIVED = Path("analysis_data") / "summary" / "received.csv"
+DEFAULT_PERCENTILES = (50, 95, 99)
+
+
+class LatencyPlotConfig(BaseModel):
+    name: str = "latency"
+    runs: Dict[str, Path] = Field(default_factory=dict)
+    """Curve label -> run folder (or the received.csv itself)."""
+    percentiles: List[PositiveInt] = Field(default_factory=lambda: list(DEFAULT_PERCENTILES))
+    log_x: bool = True
+    """Log x: delivery latency spans milliseconds to seconds when a mesh degrades."""
+    xlabel_name: str = "Delivery latency (ms)"
+    ylabel_name: str = "Share of deliveries"
+    fig_size: List[PositiveInt] = Field(default_factory=lambda: [10, 6])
+
+
+def _received_csv(run: Path) -> Path:
+    return run if run.suffix == ".csv" else run / SUMMARY_RECEIVED
+
+
+def load_delays(run: Union[str, Path]) -> pd.Series:
+    """Delivery delays (ms) for one run, from the reliability analysis dump."""
+    csv = _received_csv(Path(run))
+    if not csv.exists():
+        logger.warning(f"latency: missing {csv}")
+        return pd.Series(dtype="float64")
+    delays = pd.read_csv(csv, usecols=[DELAY_COLUMN])[DELAY_COLUMN]
+    return pd.to_numeric(delays, errors="coerce").dropna()
+
+
+def latency_percentiles(run: Union[str, Path], percentiles=DEFAULT_PERCENTILES) -> Dict[str, float]:
+    """Percentile table for the report, plus the delivery count behind it."""
+    delays = load_delays(run)
+    if delays.empty:
+        return {}
+    summary = {f"p{p}": round(float(delays.quantile(p / 100)), 1) for p in percentiles}
+    summary["max"] = round(float(delays.max()), 1)
+    summary["deliveries"] = int(delays.size)
+    return summary
+
+
+class LatencyPlotter(BaseModel):
+    configs: List[LatencyPlotConfig]
+
+    def create_plots(self) -> None:
+        for config in self.configs:
+            logger.info(f'Plotting "{config.name}"')
+            self._create_plot(config)
+            logger.info(f'Plot "{config.name}" finished')
+
+    def _create_plot(self, config: LatencyPlotConfig) -> Optional[Path]:
+        plt.figure(figsize=tuple(config.fig_size))
+        plotted = False
+        for label, run in config.runs.items():
+            delays = load_delays(run)
+            if delays.empty:
+                continue
+            ordered = delays.sort_values()
+            # step: a CDF is a step function, and interpolating hides heartbeat plateaus
+            plt.step(
+                ordered,
+                (ordered.rank(method="first") / ordered.size),
+                where="post",
+                label=f"{label} (n={ordered.size})",
+            )
+            plotted = True
+
+        if not plotted:
+            logger.warning(f'No latency data for "{config.name}"')
+            plt.close()
+            return None
+
+        if config.log_x:
+            plt.xscale("log")
+        plt.ylim(0, 1)
+        plt.xlabel(config.xlabel_name)
+        plt.ylabel(config.ylabel_name)
+        plt.legend()
+        plt.tight_layout()
+        out = Path(f"{config.name}.jpg")
+        plt.savefig(out)
+        plt.close()
+        return out
+
+
+def latency_table(runs: Dict[str, Union[str, Path]], percentiles=DEFAULT_PERCENTILES):
+    """Run-by-percentile table, the small latency table the report carries."""
+    return pd.DataFrame(
+        {label: latency_percentiles(run, percentiles) for label, run in runs.items()}
+    )

--- a/src/analysis/plotting/tests/test_latency_plotter.py
+++ b/src/analysis/plotting/tests/test_latency_plotter.py
@@ -3,8 +3,6 @@ from pathlib import Path
 import pandas as pd
 
 from src.analysis.plotting.latency_plotter import (
-    LatencyPlotConfig,
-    LatencyPlotter,
     latency_percentiles,
     latency_table,
     load_delays,
@@ -64,29 +62,3 @@ class TestPercentiles:
         assert list(table.columns) == ["v2.1.0", "v2.2.0"]
         assert table.loc["p50", "v2.1.0"] == 2.0
         assert table.loc["p50", "v2.2.0"] == 200.0
-
-
-class TestLatencyPlotter:
-    def test_writes_one_figure_per_config(self, tmp_path, monkeypatch):
-        monkeypatch.chdir(tmp_path)
-        a = _write_received(tmp_path / "a", [1, 2, 3])
-        b = _write_received(tmp_path / "b", [10, 20, 30])
-        LatencyPlotter(
-            configs=[LatencyPlotConfig(name="xver_latency", runs={"v2.1.0": a, "v2.2.0": b})]
-        ).create_plots()
-        assert (tmp_path / "xver_latency.jpg").exists()
-
-    def test_runs_without_data_are_skipped_not_fatal(self, tmp_path, monkeypatch):
-        monkeypatch.chdir(tmp_path)
-        good = _write_received(tmp_path / "good", [1, 2])
-        cfg = LatencyPlotConfig(
-            name="partial", runs={"has data": good, "missing": tmp_path / "nope"}
-        )
-        LatencyPlotter(configs=[cfg]).create_plots()
-        assert (tmp_path / "partial.jpg").exists()
-
-    def test_no_data_at_all_writes_nothing(self, tmp_path, monkeypatch):
-        monkeypatch.chdir(tmp_path)
-        cfg = LatencyPlotConfig(name="empty", runs={"missing": tmp_path / "nope"})
-        LatencyPlotter(configs=[cfg]).create_plots()
-        assert not (tmp_path / "empty.jpg").exists()

--- a/src/analysis/plotting/tests/test_latency_plotter.py
+++ b/src/analysis/plotting/tests/test_latency_plotter.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+
+import pandas as pd
+
+from src.analysis.plotting.latency_plotter import (
+    LatencyPlotConfig,
+    LatencyPlotter,
+    latency_percentiles,
+    latency_table,
+    load_delays,
+)
+
+
+def _write_received(run: Path, delays, pods=None) -> Path:
+    d = run / "analysis_data" / "summary"
+    d.mkdir(parents=True, exist_ok=True)
+    pods = pods or [f"pod-{i}" for i in range(len(delays))]
+    pd.DataFrame(
+        {
+            "msgId": range(len(delays)),
+            "timestamp": ["2026-07-18 04:40:00"] * len(delays),
+            "sentAt": ["2026-07-18 04:40:00"] * len(delays),
+            "delayMs": delays,
+            "kubernetes.pod_name": pods,
+        }
+    ).to_csv(d / "received.csv", index=False)
+    return run
+
+
+class TestLoadDelays:
+    def test_reads_the_analysis_dump(self, tmp_path):
+        _write_received(tmp_path, [10, 20, 30])
+        assert list(load_delays(tmp_path)) == [10, 20, 30]
+
+    def test_accepts_the_csv_directly(self, tmp_path):
+        _write_received(tmp_path, [5, 15])
+        csv = tmp_path / "analysis_data" / "summary" / "received.csv"
+        assert list(load_delays(csv)) == [5, 15]
+
+    def test_missing_run_is_empty_not_an_error(self, tmp_path):
+        assert load_delays(tmp_path / "nope").empty
+
+    def test_unparseable_delays_are_dropped(self, tmp_path):
+        _write_received(tmp_path, [10, "n/a", 30])
+        assert list(load_delays(tmp_path)) == [10.0, 30.0]
+
+
+class TestPercentiles:
+    def test_percentiles_and_count(self, tmp_path):
+        _write_received(tmp_path, list(range(1, 101)))  # 1..100
+        summary = latency_percentiles(tmp_path)
+        assert summary["p50"] == 50.5
+        assert summary["p99"] == 99.0  # 99.01, reported to one decimal
+        assert summary["max"] == 100.0
+        assert summary["deliveries"] == 100
+
+    def test_empty_run_gives_empty_summary(self, tmp_path):
+        assert latency_percentiles(tmp_path / "nope") == {}
+
+    def test_table_puts_runs_in_columns(self, tmp_path):
+        fast = _write_received(tmp_path / "fast", [1, 2, 3])
+        slow = _write_received(tmp_path / "slow", [100, 200, 300])
+        table = latency_table({"v2.1.0": fast, "v2.2.0": slow})
+        assert list(table.columns) == ["v2.1.0", "v2.2.0"]
+        assert table.loc["p50", "v2.1.0"] == 2.0
+        assert table.loc["p50", "v2.2.0"] == 200.0
+
+
+class TestLatencyPlotter:
+    def test_writes_one_figure_per_config(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        a = _write_received(tmp_path / "a", [1, 2, 3])
+        b = _write_received(tmp_path / "b", [10, 20, 30])
+        LatencyPlotter(
+            configs=[LatencyPlotConfig(name="xver_latency", runs={"v2.1.0": a, "v2.2.0": b})]
+        ).create_plots()
+        assert (tmp_path / "xver_latency.jpg").exists()
+
+    def test_runs_without_data_are_skipped_not_fatal(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        good = _write_received(tmp_path / "good", [1, 2])
+        cfg = LatencyPlotConfig(
+            name="partial", runs={"has data": good, "missing": tmp_path / "nope"}
+        )
+        LatencyPlotter(configs=[cfg]).create_plots()
+        assert (tmp_path / "partial.jpg").exists()
+
+    def test_no_data_at_all_writes_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = LatencyPlotConfig(name="empty", runs={"missing": tmp_path / "nope"})
+        LatencyPlotter(configs=[cfg]).create_plots()
+        assert not (tmp_path / "empty.jpg").exists()


### PR DESCRIPTION
Reads the delays the reliability analysis already dumps to `analysis_data/summary/received.csv` and draws a CDF per run, plus a percentile table for the report. 