### PR TITLE
shadow: give relays a realistic IP plan

### DIFF
--- a/src/deployments/experiments/libp2p/shadow_gossipsub.py
+++ b/src/deployments/experiments/libp2p/shadow_gossipsub.py
@@ -51,6 +51,8 @@ class ExpConfig(BaseModel):
     start_jitter_ms: NonNegativeInt = 0
     latency_ms: Optional[NonNegativeInt] = None
     bandwidth_mbit: Optional[PositiveInt] = None
+    # Peers per /24; 1 = every peer on its own subnet.
+    hosts_per_subnet: PositiveInt = 1
     # Job-pod resources, sized for ~10 peers; bump for bigger sims.
     cpu_request: str = "2"
     cpu_limit: str = "4"
@@ -98,6 +100,7 @@ class ShadowGossipsubExperiment(BaseExperiment[ExpConfig]):
             start_jitter_ms=cfg.start_jitter_ms,
             latency_ms=cfg.latency_ms,
             bandwidth_mbit=cfg.bandwidth_mbit,
+            hosts_per_subnet=cfg.hosts_per_subnet,
         )
         publisher_config = render_publisher_config(
             num_nodes=cfg.num_nodes,

--- a/src/deployments/shadow/builders.py
+++ b/src/deployments/shadow/builders.py
@@ -72,13 +72,34 @@ def _peer_env(
     return env
 
 
-def _peer_hosts(num_nodes: int, peer_env: dict, start_jitter_ms: int) -> dict:
-    """The N relay hosts (pod-0..pod-(N-1)). start_jitter_ms staggers per-pod process
+# 11.{100+s//250}.{s%250}.{10+h}; the 11.100+ base keeps clear of the addresses Shadow
+# assigns to unpinned hosts (bootstrap, publisher).
+_MAX_HOSTS_PER_SUBNET = 245
+_MAX_SUBNETS = (255 - 100) * 250 - 1
+
+
+def _peer_ip(index: int, hosts_per_subnet: int) -> str:
+    """Address for peer `index`, packing `hosts_per_subnet` peers into each /24."""
+    if not 1 <= hosts_per_subnet <= _MAX_HOSTS_PER_SUBNET:
+        raise ValueError(
+            f"hosts_per_subnet must be 1..{_MAX_HOSTS_PER_SUBNET}, got {hosts_per_subnet}"
+        )
+    subnet, host = divmod(index, hosts_per_subnet)
+    if subnet > _MAX_SUBNETS:
+        raise ValueError(f"IP plan exhausted at peer {index} (max {_MAX_SUBNETS + 1} subnets)")
+    return f"11.{100 + subnet // 250}.{subnet % 250}.{10 + host}"
+
+
+def _peer_hosts(
+    num_nodes: int, peer_env: dict, start_jitter_ms: int, hosts_per_subnet: int
+) -> dict:
+    """The N peer hosts (pod-0..pod-(N-1)). start_jitter_ms staggers per-pod process
     start so peers don't wake and dial at one simulated instant (lockstep wakes force
     simultaneous-dial collisions that never occur on real hosts)."""
     return {
         f"pod-{i}": {
             "network_node_id": 0,
+            "ip_addr": _peer_ip(i, hosts_per_subnet),
             "processes": [
                 {
                     "path": "./main",
@@ -190,6 +211,7 @@ def render_shadow_yaml(
     start_jitter_ms: int = 0,
     latency_ms: Optional[int] = None,
     bandwidth_mbit: Optional[int] = None,
+    hosts_per_subnet: int = 1,
     requester_app_path: str = _REQUESTER_APP_PATH,
 ) -> dict:
     """Build the shadow.yaml dict: N peer hosts running `./main` + a publisher host
@@ -200,7 +222,9 @@ def render_shadow_yaml(
 
     discovery selects mesh formation: "static" dials CONNECTTO peers by pod-N
     hostname; "kad-dht" adds a `bootstrap-0` anchor host that peers discover
-    through (Shadow resolves it by hostname, so no k8s Service is needed)."""
+    through (Shadow resolves it by hostname, so no k8s Service is needed).
+
+    hosts_per_subnet: 1 gives every peer its own /24; raise it to share prefixes."""
     if connect_to >= num_nodes:
         raise ValueError(f"connect_to ({connect_to}) must be smaller than num_nodes ({num_nodes}).")
 
@@ -213,7 +237,7 @@ def render_shadow_yaml(
         metrics_interval_s=metrics_interval_s,
         lsquic_tick_floor_us=lsquic_tick_floor_us,
     )
-    hosts = _peer_hosts(num_nodes, peer_env, start_jitter_ms)
+    hosts = _peer_hosts(num_nodes, peer_env, start_jitter_ms, hosts_per_subnet)
     if discovery == "kad-dht":
         hosts["bootstrap-0"] = _bootstrap_host(
             num_nodes=num_nodes,

--- a/src/deployments/shadow/tests/test_builders.py
+++ b/src/deployments/shadow/tests/test_builders.py
@@ -7,6 +7,7 @@ from src.deployments.shadow.builders import (
     _bootstrap_host,
     _peer_env,
     _peer_hosts,
+    _peer_ip,
     _publisher_host,
     build_configmap,
     build_pvc,
@@ -116,13 +117,49 @@ class TestHostBuilders:
         )
 
     def test_peer_hosts_stagger_start_time_by_jitter(self):
-        hosts = _peer_hosts(3, {"MUXER": "yamux"}, start_jitter_ms=50)
+        hosts = _peer_hosts(3, {"MUXER": "yamux"}, start_jitter_ms=50, hosts_per_subnet=1)
         assert [hosts[f"pod-{i}"]["processes"][0]["start_time"] for i in range(3)] == [
             "5000ms",
             "5050ms",
             "5100ms",
         ]
         assert all(hosts[h]["processes"][0]["expected_final_state"] == "running" for h in hosts)
+
+    def test_peer_ip_gives_each_peer_its_own_subnet_by_default(self):
+        ips = [_peer_ip(i, 1) for i in range(1000)]
+        assert len(set(ips)) == 1000
+        assert len({ip.rsplit(".", 1)[0] for ip in ips}) == 1000
+        assert ips[0] == "11.100.0.10"
+        assert ips[250] == "11.101.0.10"  # rolls into the next second octet
+
+    def test_peer_ip_packs_subnets_when_asked(self):
+        ips = [_peer_ip(i, 10) for i in range(1000)]
+        assert len({ip.rsplit(".", 1)[0] for ip in ips}) == 100  # 10 hosts per /24
+        assert ips[0] == "11.100.0.10" and ips[9] == "11.100.0.19"
+        assert ips[10] == "11.100.1.10"
+
+    def test_every_planned_octet_is_a_valid_address(self):
+        for hosts_per_subnet in (1, 10, 245):
+            for i in (0, 1, 999, 5000):
+                octets = [int(o) for o in _peer_ip(i, hosts_per_subnet).split(".")]
+                assert all(0 <= o <= 255 for o in octets), (i, hosts_per_subnet, octets)
+
+    def test_packing_beyond_a_subnet_is_rejected_not_silently_wrong(self):
+        # 250 would overflow the host octet to 11.100.0.256
+        with pytest.raises(ValueError):
+            _peer_ip(0, 250)
+        with pytest.raises(ValueError):
+            _peer_ip(0, 0)
+
+    def test_peer_ips_avoid_shadow_assigned_range(self):
+        # Shadow assigns unpinned hosts from 11.0.x
+        assert all(not _peer_ip(i, 1).startswith("11.0.") for i in range(1000))
+
+    def test_peer_hosts_pin_the_planned_addresses(self):
+        hosts = _peer_hosts(3, {"MUXER": "yamux"}, start_jitter_ms=0, hosts_per_subnet=1)
+        assert [hosts[f"pod-{i}"]["ip_addr"] for i in range(3)] == [
+            _peer_ip(i, 1) for i in range(3)
+        ]
 
     def test_bootstrap_host_lifts_connection_cap(self):
         h = _bootstrap_host(


### PR DESCRIPTION
The default shadow puts 1000 relays into 4 /24 IP addresses, which is against the nim-libp2p anti-sybil policy. This PR pins each Shadow relay to its own /24.