### PR TITLE
Generate latency plots from the regression pipeline

### DIFF
--- a/src/analysis/plotting/latency_plotter.py
+++ b/src/analysis/plotting/latency_plotter.py
@@ -7,6 +7,7 @@ versus gossip pull sit orders of magnitude apart), so a CDF reads better than a 
 plot and this does not fit MetricsPlotter.
 """
 
+import argparse
 import logging
 from pathlib import Path
 from typing import Dict, List, Optional, Union
@@ -34,6 +35,8 @@ class LatencyPlotConfig(BaseModel):
     xlabel_name: str = "Delivery latency (ms)"
     ylabel_name: str = "Share of deliveries"
     fig_size: List[PositiveInt] = Field(default_factory=lambda: [10, 6])
+    out_dir: Optional[Path] = None
+    """Where to write the plot. Defaults to the working directory."""
 
 
 def _received_csv(run: Path) -> Path:
@@ -99,7 +102,8 @@ class LatencyPlotter(BaseModel):
         plt.ylabel(config.ylabel_name)
         plt.legend()
         plt.tight_layout()
-        out = Path(f"{config.name}.jpg")
+        out = Path(config.out_dir or ".") / f"{config.name}.jpg"
+        out.parent.mkdir(parents=True, exist_ok=True)
         plt.savefig(out)
         plt.close()
         return out
@@ -110,3 +114,58 @@ def latency_table(runs: Dict[str, Union[str, Path]], percentiles=DEFAULT_PERCENT
     return pd.DataFrame(
         {label: latency_percentiles(run, percentiles) for label, run in runs.items()}
     )
+
+
+def plot_dump_latency(dump_dir: Path, *, label: str = "run") -> Optional[Path]:
+    """CDF and percentile table for one reliability dump, written beside it.
+
+    `dump_dir` is the analysis dump folder holding `summary/received.csv`, which is
+    what both platforms produce: Shadow dumps under the run folder, cluster runs
+    under their own analysis folder. Returns None when there is no delivery data,
+    the normal case for a run whose reliability analysis produced nothing.
+    """
+    csv = dump_dir / "summary" / "received.csv"
+    if load_delays(csv).empty:
+        logger.warning(f"latency: no delivery data in {csv}")
+        return None
+
+    LatencyPlotter(
+        configs=[LatencyPlotConfig(name="latency", runs={label: csv}, out_dir=dump_dir)]
+    ).create_plots()
+    logger.info(f"Delivery latency (ms) for {label}:\n{latency_table({label: csv}).to_string()}")
+    return dump_dir / "latency.jpg"
+
+
+def main() -> None:
+    """CDF + percentile table for any set of run folders, on either platform."""
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(
+        description="Plot delivery latency as a CDF across runs and print the percentile table."
+    )
+    parser.add_argument(
+        "runs",
+        nargs="+",
+        metavar="LABEL=RUN_DIR",
+        help="Curve label and run folder, e.g. mplex=out/n1000-mplex-kad__rand_195553",
+    )
+    parser.add_argument("--name", default="latency", help="Output file stem.")
+    parser.add_argument("--out-dir", type=Path, default=None, help="Where to write the plot.")
+    args = parser.parse_args()
+
+    runs: Dict[str, Path] = {}
+    for item in args.runs:
+        label, sep, path = item.partition("=")
+        if not sep or not path:
+            parser.error(f"expected LABEL=RUN_DIR, got `{item}`")
+        if label in runs:
+            parser.error(f"duplicate label `{label}`")
+        runs[label] = Path(path)
+
+    LatencyPlotter(
+        configs=[LatencyPlotConfig(name=args.name, runs=runs, out_dir=args.out_dir)]
+    ).create_plots()
+    print(latency_table(runs).to_string())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/analysis/post_run/nimlibp2p.py
+++ b/src/analysis/post_run/nimlibp2p.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from src.analysis.mesh_analysis.analyzers.data_puller import DataPuller
+from src.analysis.mesh_analysis.analyzers.nimlibp2p_analyzer import Nimlibp2pAnalyzer
+from src.analysis.plotting.latency_plotter import plot_dump_latency
+
+if TYPE_CHECKING:
+    from src.deployments.experiments.libp2p.nimlibp2p import NimLibp2pExperiment
+
+logger = logging.getLogger(__name__)
+
+VICTORIA_LOGS_URL = "https://vlselect.lab.vac.dev/select/logsql/query"
+REQUIRED_TIME_WINDOW_KEYS = ("start_time", "end_time")
+
+
+def _require_bounded_query(stack: dict) -> None:
+    missing = [key for key in REQUIRED_TIME_WINDOW_KEYS if not stack.get(key)]
+    if missing:
+        raise ValueError(
+            "Nimlibp2p post-run analysis requires a bounded metadata stack; "
+            f"missing: {missing}. Refusing to run an unbounded VictoriaLogs query."
+        )
+
+
+def run_nimlibp2p_analysis(experiment: "NimLibp2pExperiment") -> None:
+    """Message reliability and delivery latency for a finished cluster run."""
+    if experiment.output_folder is None:
+        raise ValueError("Nimlibp2p post-run analysis requires experiment.output_folder")
+    if experiment.metadata is None:
+        raise ValueError("Nimlibp2p post-run analysis requires experiment.metadata")
+
+    cfg = experiment.config
+    stack = dict(experiment.metadata["stack"])
+    stack.update(
+        {
+            "type": "vaclab",
+            "url": VICTORIA_LOGS_URL,
+            "reader": "victoria",
+            "namespace": experiment.namespace or stack.get("namespace"),
+        }
+    )
+    _require_bounded_query(stack)
+
+    # Bootstrap nodes do not relay, so they are excluded from the delivery counts.
+    relays = [
+        pair
+        for pair in zip(stack["stateful_sets"], stack["nodes_per_statefulset"])
+        if "bootstrap" not in pair[0]
+    ]
+    dump_dir = experiment.output_folder / "analysis_data"
+
+    try:
+        (
+            Nimlibp2pAnalyzer(dump_analysis_dir=str(dump_dir))
+            .with_data_puller(DataPuller().with_kwargs(stack))
+            .with_ss_check(stack["stateful_sets"], stack["nodes_per_statefulset"])
+            .with_reliability_check(
+                stateful_sets=[name for name, _ in relays],
+                nodes_per_ss=[count for _, count in relays],
+                expected_num_peers=cfg.num_relay_nodes,
+                expected_num_messages=cfg.num_messages,
+            )
+            .run()
+        )
+    except Exception:
+        logger.exception("Nimlibp2p message analysis failed")
+    try:
+        plot_dump_latency(dump_dir, label=cfg.muxer)
+    except Exception:
+        logger.exception("Nimlibp2p latency plot failed")

--- a/src/analysis/post_run/shadow_gossipsub.py
+++ b/src/analysis/post_run/shadow_gossipsub.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from src.analysis.mesh_analysis.analyzers.data_puller import DataPuller
 from src.analysis.mesh_analysis.analyzers.nimlibp2p_analyzer import Nimlibp2pAnalyzer
 from src.analysis.metrics.shadow_metrics import scrape_run_metrics
+from src.analysis.plotting.latency_plotter import plot_dump_latency
 
 if TYPE_CHECKING:
     from src.deployments.experiments.libp2p.shadow_gossipsub import ShadowGossipsubExperiment
@@ -44,3 +45,7 @@ def run_shadow_gossipsub_analysis(experiment: "ShadowGossipsubExperiment") -> No
         )
     except Exception:
         logger.exception("Shadow message analysis failed")
+    try:
+        plot_dump_latency(run_dir / "analysis_data", label=cfg.muxer)
+    except Exception:
+        logger.exception("Shadow latency plot failed")

--- a/src/deployments/experiments/libp2p/nimlibp2p.py
+++ b/src/deployments/experiments/libp2p/nimlibp2p.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import random
 import traceback
-from typing import Literal
+from typing import ClassVar, Literal
 
 from kubernetes.client import V1Probe, V1ServicePort, V1StatefulSet, V1TCPSocketAction
 from pydantic import BaseModel, ConfigDict, NonNegativeFloat, NonNegativeInt, model_validator
@@ -179,6 +179,8 @@ async def publish(config, namespace, random_name):
 @experiment(name="nimlibp2p")
 class NimLibp2pExperiment(BaseExperiment[ExpConfig]):
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    post_run_analysis: ClassVar[str] = "src.analysis.post_run.nimlibp2p:run_nimlibp2p_analysis"
 
     def _get_metadata(self) -> dict:
         return Bridge().get_metadata(self.events_log_path)


### PR DESCRIPTION
Wires the existing LatencyPlotter into the cluster regression flow and adds a CLI so Shadow runs use the same component.