### PR TITLE
Allow non-primitive objects in ExpConfig CLI args

### DIFF
--- a/src/deployments/experiments/tests/base_experiment/test_cli_parse_objs.py
+++ b/src/deployments/experiments/tests/base_experiment/test_cli_parse_objs.py
@@ -371,3 +371,18 @@ class TestParserTypeWiring:
         assert flag == "--items"
         result = kwargs["type"]('["a", "b"]')
         assert result == ["a", "b"]
+
+    def test_from_str_falls_back_on_failure(self):
+        """If from_str raises an error, should fall back to constructor."""
+
+        class CustomClass:
+            @staticmethod
+            def from_str(s: str):
+                raise ValueError("intentional failure")
+
+            def __init__(self, s: str):
+                self.value = s
+
+        converter = get_from_str(CustomClass, "data")
+        result = converter("test")
+        assert result.value == "test"  # Should use constructor fallback

--- a/src/deployments/experiments/tests/base_experiment/test_cli_parse_objs.py
+++ b/src/deployments/experiments/tests/base_experiment/test_cli_parse_objs.py
@@ -6,7 +6,7 @@ import pytest
 from pydantic import BaseModel, ConfigDict, Field
 
 from src.deployments.experiments.base_experiment import BaseExperiment
-from src.deployments.utils.parser import ARG_NOT_SET, _field_to_arg, get_from_str
+from src.deployments.utils.parser import ARG_NOT_SET, _field_to_arg, _unwrap_optional, get_from_str
 
 logger = logging.getLogger(__name__)
 
@@ -386,3 +386,66 @@ class TestParserTypeWiring:
         converter = get_from_str(CustomClass, "data")
         result = converter("test")
         assert result.value == "test"  # Should use constructor fallback
+
+
+class TestUnwrapOptional:
+    """Test _unwrap_optional handles various type annotations."""
+
+    def test_unwraps_optional(self):
+        """Optional[T] should unwrap to T."""
+        result = _unwrap_optional(Optional[str])
+        assert result is str
+
+    def test_unwraps_union_pipe_syntax(self):
+        """T | None (pipe syntax) should unwrap to T."""
+        result = _unwrap_optional(str | None)
+        assert result is str
+
+    def test_unwraps_annotated(self):
+        """Annotated[T, ...] should unwrap to T."""
+        result = _unwrap_optional(Annotated[str, "meta"])
+        assert result is str
+
+    def test_unwraps_annotated_optional_nested(self):
+        """Annotated[Optional[T], ...] should unwrap to T."""
+        result = _unwrap_optional(Annotated[Optional[str], "meta"])
+        assert result is str
+
+    def test_unwraps_optional_annotated_nested(self):
+        """Optional[Annotated[T, ...]] should unwrap to T."""
+        result = _unwrap_optional(Optional[Annotated[str, "meta"]])
+        assert result is str
+
+    def test_unwraps_annotated_pipe_nested(self):
+        """Annotated[T | None, ...] should unwrap to T."""
+        result = _unwrap_optional(Annotated[str | None, "meta"])
+        assert result is str
+
+    def test_unwraps_deeply_nested(self):
+        """Annotated[Optional[Annotated[T, ...]], ...] should unwrap to T."""
+        result = _unwrap_optional(Annotated[Optional[Annotated[str, "inner"]], "outer"])
+        assert result is str
+
+    def test_unwraps_custom_class_optional(self):
+        """CustomClass | None should unwrap to CustomClass."""
+
+        class ImageConfig:
+            pass
+
+        result = _unwrap_optional(ImageConfig | None)
+        assert result is ImageConfig
+
+    def test_unwraps_annotated_custom_class(self):
+        """Annotated[CustomClass | None, ...] should unwrap to CustomClass."""
+
+        class ImageConfig:
+            pass
+
+        result = _unwrap_optional(Annotated[ImageConfig | None, "meta"])
+        assert result is ImageConfig
+
+    def test_non_wrapped_unchanged(self):
+        """Plain types should be unchanged."""
+        assert _unwrap_optional(str) is str
+        assert _unwrap_optional(int) is int
+        assert _unwrap_optional(list[str]) == list[str]

--- a/src/deployments/experiments/tests/base_experiment/test_cli_parse_objs.py
+++ b/src/deployments/experiments/tests/base_experiment/test_cli_parse_objs.py
@@ -1,6 +1,6 @@
 import argparse
 import logging
-from typing import ClassVar, Type
+from typing import Annotated, ClassVar, Optional, Type
 
 import pytest
 from pydantic import BaseModel, ConfigDict, Field
@@ -217,3 +217,157 @@ class TestParserTypeWiring:
 
             _, kwargs = _field_to_arg("field", field_info)
             assert kwargs["type"] == py_type
+
+    # Container types - should parse JSON
+    def test_list_str_parses_json(self):
+        """list[str] should parse JSON strings."""
+        field_info = type(
+            "MockFieldInfo",
+            (),
+            {
+                "annotation": list[str],
+                "description": "List field",
+                "default": ARG_NOT_SET,
+            },
+        )()
+
+        flag, kwargs = _field_to_arg("items", field_info)
+        assert flag == "--items"
+        result = kwargs["type"]('["a", "b"]')
+        assert result == ["a", "b"]
+
+    def test_list_int_parses_json(self):
+        """list[int] should parse JSON strings."""
+        field_info = type(
+            "MockFieldInfo",
+            (),
+            {
+                "annotation": list[int],
+                "description": "List of ints",
+                "default": ARG_NOT_SET,
+            },
+        )()
+
+        flag, kwargs = _field_to_arg("items", field_info)
+        assert flag == "--items"
+        result = kwargs["type"]("[1, 2, 3]")
+        assert result == [1, 2, 3]
+
+    def test_dict_str_str_parses_json(self):
+        """dict[str, str] should parse JSON strings."""
+        field_info = type(
+            "MockFieldInfo",
+            (),
+            {
+                "annotation": dict[str, str],
+                "description": "dict field",
+                "default": ARG_NOT_SET,
+            },
+        )()
+
+        flag, kwargs = _field_to_arg("metadata", field_info)
+        assert flag == "--metadata"
+        result = kwargs["type"]('{"key": "value"}')
+        assert result == {"key": "value"}
+
+    def test_set_str_parses_json(self):
+        """set[str] should parse JSON strings (returns list from JSON)."""
+        field_info = type(
+            "MockFieldInfo",
+            (),
+            {
+                "annotation": set[str],
+                "description": "set field",
+                "default": ARG_NOT_SET,
+            },
+        )()
+
+        flag, kwargs = _field_to_arg("tags", field_info)
+        assert flag == "--tags"
+        result = kwargs["type"]('["a", "b"]')
+        assert result == ["a", "b"]  # JSON gives list, Pydantic converts to set later
+
+    def test_bare_list_parses_json(self):
+        """Bare list should parse JSON strings."""
+        field_info = type(
+            "MockFieldInfo",
+            (),
+            {
+                "annotation": list,
+                "description": "Bare list",
+                "default": ARG_NOT_SET,
+            },
+        )()
+
+        flag, kwargs = _field_to_arg("items", field_info)
+        assert flag == "--items"
+        result = kwargs["type"]('["a", 1, true]')
+        assert result == ["a", 1, True]
+
+    def test_bare_dict_parses_json(self):
+        """Bare dict should parse JSON strings."""
+        field_info = type(
+            "MockFieldInfo",
+            (),
+            {
+                "annotation": dict,
+                "description": "Bare dict",
+                "default": ARG_NOT_SET,
+            },
+        )()
+
+        flag, kwargs = _field_to_arg("data", field_info)
+        assert flag == "--data"
+        result = kwargs["type"]('{"key": "value"}')
+        assert result == {"key": "value"}
+
+    # Typing constructs - should not crash
+    def test_optional_int_parses(self):
+        """Optional[int] should unwrap and parse as int."""
+        field_info = type(
+            "MockFieldInfo",
+            (),
+            {
+                "annotation": Optional[int],
+                "description": "Optional int",
+                "default": ARG_NOT_SET,
+            },
+        )()
+
+        flag, kwargs = _field_to_arg("value", field_info)
+        assert flag == "--value"
+        result = kwargs["type"]("42")
+        assert result == 42
+
+    def test_annotated_str_uses_str(self):
+        """Annotated[str, ...] should unwrap and use str."""
+        field_info = type(
+            "MockFieldInfo",
+            (),
+            {
+                "annotation": Annotated[str, "metadata"],
+                "description": "Annotated string",
+                "default": ARG_NOT_SET,
+            },
+        )()
+
+        flag, kwargs = _field_to_arg("data", field_info)
+        assert flag == "--data"
+        assert kwargs["type"] == str
+
+    def test_annotated_list_parses_json(self):
+        """Annotated[list[str], ...] should unwrap and parse JSON."""
+        field_info = type(
+            "MockFieldInfo",
+            (),
+            {
+                "annotation": Annotated[list[str], "metadata"],
+                "description": "Annotated list",
+                "default": ARG_NOT_SET,
+            },
+        )()
+
+        flag, kwargs = _field_to_arg("items", field_info)
+        assert flag == "--items"
+        result = kwargs["type"]('["a", "b"]')
+        assert result == ["a", "b"]

--- a/src/deployments/experiments/tests/base_experiment/test_cli_parse_objs.py
+++ b/src/deployments/experiments/tests/base_experiment/test_cli_parse_objs.py
@@ -1,0 +1,219 @@
+import argparse
+import logging
+from typing import ClassVar, Type
+
+import pytest
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.deployments.experiments.base_experiment import BaseExperiment
+from src.deployments.utils.parser import ARG_NOT_SET, _field_to_arg, get_from_str
+
+logger = logging.getLogger(__name__)
+
+# Tests for parsing complex objects in ExpConfigs.
+
+
+class ImageJSON(BaseModel):
+    supported_input_kinds: ClassVar[set[str]] = {"json"}
+
+    repo: str
+    tag: str
+
+
+class ImageFromStr:
+    supported_input_kinds: ClassVar[set[str]] = {"from_str"}
+
+    repo: str
+    tag: str
+
+    @staticmethod
+    def from_str(image: str):
+        repo, tag = image.split(":")
+        obj = ImageFromStr()
+        obj.repo = repo
+        obj.tag = tag
+        return obj
+
+
+class ImageDirect:
+    supported_input_kinds: ClassVar[set[str]] = {"direct"}
+
+    def __init__(self, image: str):
+        repo, tag = image.split("-")
+        self.repo = repo
+        self.tag = tag
+
+
+class ImageJSONAndFromStr(BaseModel):
+    supported_input_kinds: ClassVar[set[str]] = {"json", "from_str"}
+
+    repo: str
+    tag: str
+
+    @staticmethod
+    def from_str(image: str):
+        repo, tag = image.split(":")
+        return ImageJSONAndFromStr(repo=repo, tag=tag)
+
+
+class ImageNone:
+    supported_input_kinds: ClassVar[set[str]] = set()
+
+
+def get_exp_conf(image_type):
+    namespace = {
+        "__annotations__": {
+            "image": image_type,
+            "supported_input_kinds": ClassVar[set[str]],
+        },
+        "image": Field(description="Container image"),
+        "supported_input_kinds": getattr(image_type, "supported_input_kinds", set()),
+        "model_config": ConfigDict(use_attribute_docstrings=True, arbitrary_types_allowed=True),
+    }
+    return type(f"ExpConfig_{image_type.__name__}", (BaseModel,), namespace)
+
+
+@pytest.fixture(scope="class")
+def TestBaseExp(request):
+    config_cls = request.param
+    DynamicClass = type(f"DynamicTestExp_{config_cls.__name__}", (BaseExperiment[config_cls],), {})
+    DynamicClass.config_cls = config_cls
+    DynamicClass.name = f"TestBaseExpWith{config_cls.__name__}"
+    return DynamicClass
+
+
+class TestGetFromStr:
+    def test_json_basemodel(self):
+        converter = get_from_str(ImageJSON, "image")
+        result = converter('{"repo": "nWaku", "tag": "v0.36"}')
+        assert result.repo == "nWaku"
+        assert result.tag == "v0.36"
+
+    def test_from_str_basemodel(self):
+        converter = get_from_str(ImageFromStr, "image")
+        result = converter("nWaku:v0.36")
+        assert result.repo == "nWaku"
+        assert result.tag == "v0.36"
+
+    def test_direct_constructor(self):
+        converter = get_from_str(ImageDirect, "image")
+        result = converter("nWaku-v0.36")
+        assert result.repo == "nWaku"
+        assert result.tag == "v0.36"
+
+    def test_all_three_uses_json_first(self):
+        converter = get_from_str(ImageJSONAndFromStr, "image")
+        result = converter('{"repo": "nWaku", "tag": "v0.36"}')
+        assert result.repo == "nWaku"
+        assert result.tag == "v0.36"
+
+    def test_none_fails(self):
+        converter = get_from_str(ImageNone, "image")
+        with pytest.raises(argparse.ArgumentTypeError):
+            converter("nWaku:v0.36")
+
+
+class _HelpFormatter(argparse.HelpFormatter):
+    def __init__(self, prog):
+        super().__init__(prog, max_help_position=100, width=220)
+
+
+@pytest.mark.parametrize(
+    "TestBaseExp",
+    [
+        get_exp_conf(ImageJSONAndFromStr),
+        get_exp_conf(ImageJSON),
+        get_exp_conf(ImageFromStr),
+        get_exp_conf(ImageDirect),
+        get_exp_conf(ImageNone),
+    ],
+    indirect=True,
+)
+class TestImageInArgparse:
+    def test_help_output_contains_config_params(self, capsys, TestBaseExp: Type[BaseExperiment]):
+        parser = argparse.ArgumentParser(
+            description="Test description", formatter_class=_HelpFormatter
+        )
+        subparsers = parser.add_subparsers(dest="experiment", required=True)
+        subparser = subparsers.add_parser(TestBaseExp.__name__, help=TestBaseExp.__doc__)
+        TestBaseExp.add_config_args(subparser)
+
+        with pytest.raises(SystemExit):
+            parser.parse_args([TestBaseExp.__name__, "--help"])
+        captured = capsys.readouterr()
+
+        assert "--image" in captured.out
+        assert "Container image" in captured.out
+
+    @pytest.mark.parametrize(
+        "input_kind, input_value",
+        [
+            ("json", '{"repo": "nWaku", "tag": "v0.36"}'),
+            ("from_str", "nWaku:v0.36"),
+            ("direct", "nWaku-v0.36"),
+        ],
+    )
+    def test_cli_parsing(self, input_kind, input_value, TestBaseExp: Type[BaseExperiment]):
+        parser = argparse.ArgumentParser(description="Test parser", formatter_class=_HelpFormatter)
+        subparsers = parser.add_subparsers(dest="experiment", required=True)
+        subparser = subparsers.add_parser(TestBaseExp.name, help=TestBaseExp.__doc__)
+        TestBaseExp.add_config_args(subparser)
+
+        command = [TestBaseExp.name, "--image", input_value]
+        should_pass = input_kind in TestBaseExp.config_cls.supported_input_kinds
+        if should_pass:
+            args = parser.parse_args(command)
+            assert args.image.repo == "nWaku"
+            assert args.image.tag == "v0.36"
+        else:
+            with pytest.raises(SystemExit):
+                parser.parse_args(command)
+
+
+class TestParserTypeWiring:
+    def test_complex_type_gets_get_from_str_callable(self):
+        field_info = type(
+            "MockFieldInfo",
+            (),
+            {
+                "annotation": ImageDirect,
+                "description": "Container image",
+                "default": ARG_NOT_SET,
+            },
+        )()
+
+        flag, kwargs = _field_to_arg("image", field_info)
+        assert flag == "--image"
+        assert callable(kwargs["type"])
+        assert kwargs["metavar"] == "(ImageDirect)"
+
+    def test_bool_does_not_get_get_from_str(self):
+        field_info = type(
+            "MockFieldInfo",
+            (),
+            {
+                "annotation": bool,
+                "description": "Flag",
+                "default": False,
+            },
+        )()
+
+        flag, kwargs = _field_to_arg("flag", field_info)
+        assert flag == "--flag"
+        assert kwargs["action"] == "store_true"
+        assert "type" not in kwargs
+
+    def test_primitive_types_use_native_types(self):
+        for py_type in (int, float, str):
+            field_info = type(
+                "MockFieldInfo",
+                (),
+                {
+                    "annotation": py_type,
+                    "description": f"{py_type.__name__} field",
+                    "default": ARG_NOT_SET,
+                },
+            )()
+
+            _, kwargs = _field_to_arg("field", field_info)
+            assert kwargs["type"] == py_type

--- a/src/deployments/utils/parser.py
+++ b/src/deployments/utils/parser.py
@@ -1,6 +1,7 @@
 # Python Imports
 import argparse
 import json
+import types
 from typing import Annotated, Any, Literal, Union, get_args, get_origin
 
 from pydantic import BaseModel, ValidationError
@@ -27,20 +28,23 @@ def _annotation_display(annotation) -> str:
 
 
 def _unwrap_optional(annotation):
+    """Recursively unwrap Annotated and Optional to get the actual type."""
     origin = get_origin(annotation)
 
-    # Unwrap Annotated[T, ...] -> T
+    # Unwrap Annotated[T, ...] -> T, then recurse
     if origin is Annotated:
         args = get_args(annotation)
         if args:
-            annotation = args[0]
-            origin = get_origin(annotation)
+            return _unwrap_optional(args[0])
 
     # Unwrap Optional[T] -> T
-    if origin is Union:
+    # Optional[T] => typing.Union
+    # T | None => types.UnionType
+    if origin is Union or origin is types.UnionType:
         args = [arg for arg in get_args(annotation) if arg is not type(None)]
         if len(args) == 1:
-            return args[0]
+            return _unwrap_optional(args[0])
+
     return annotation
 
 

--- a/src/deployments/utils/parser.py
+++ b/src/deployments/utils/parser.py
@@ -1,6 +1,7 @@
 # Python Imports
 import argparse
-from typing import Any, Literal, Union, get_args, get_origin
+import json
+from typing import Annotated, Any, Literal, Union, get_args, get_origin
 
 from pydantic import BaseModel, ValidationError
 from pydantic.fields import FieldInfo
@@ -27,6 +28,15 @@ def _annotation_display(annotation) -> str:
 
 def _unwrap_optional(annotation):
     origin = get_origin(annotation)
+
+    # Unwrap Annotated[T, ...] -> T
+    if origin is Annotated:
+        args = get_args(annotation)
+        if args:
+            annotation = args[0]
+            origin = get_origin(annotation)
+
+    # Unwrap Optional[T] -> T
     if origin is Union:
         args = [arg for arg in get_args(annotation) if arg is not type(None)]
         if len(args) == 1:
@@ -36,10 +46,11 @@ def _unwrap_optional(annotation):
 
 def get_from_str(annotation: Any, field_name: str):
     def from_str(input_str: str) -> Any:
-        # Convert using model_validate_json.
         errors = []
+
+        # Convert using model_validate_json.
         try:
-            if issubclass(annotation, BaseModel):
+            if isinstance(annotation, type) and issubclass(annotation, BaseModel):
                 return annotation.model_validate_json(input_str)
         except (ValidationError, ValueError) as e:
             err = argparse.ArgumentTypeError(
@@ -49,12 +60,13 @@ def get_from_str(annotation: Any, field_name: str):
 
         # Convert using custom from_str method.
         try:
-            return annotation.from_str(input_str)
-        except AttributeError as e:
-            err = argparse.ArgumentTypeError(
-                f"No from_str method for object. Field: `{field_name}` Error: `{e}`"
-            )
-            errors.append(err)
+            if hasattr(annotation, "from_str"):
+                return annotation.from_str(input_str)
+            else:
+                err = argparse.ArgumentTypeError(
+                    f"No from_str method for object. Field: `{field_name}`"
+                )
+                errors.append(err)
         except (ValidationError, ValueError, TypeError) as e:
             err = argparse.ArgumentTypeError(
                 f"Failed to convert string with from_str. Field: `{field_name}` Error: `{e}`"
@@ -63,7 +75,14 @@ def get_from_str(annotation: Any, field_name: str):
 
         # Convert using direct instantiation.
         try:
-            return annotation(input_str)
+            # Only try direct instantiation if annotation is callable
+            if callable(annotation):
+                return annotation(input_str)
+            else:
+                err = argparse.ArgumentTypeError(
+                    f"No constructor available for annotation. Field: `{field_name}`"
+                )
+                errors.append(err)
         except (ValidationError, ValueError, TypeError) as e:
             err = argparse.ArgumentTypeError(
                 f"Failed to convert string directly. Field: `{field_name}` Error: `{e}`"
@@ -106,17 +125,23 @@ def _field_to_arg(field_name: str, field: FieldInfo) -> tuple[str, dict[str, Any
             kwargs["type"] = type(choices[0])
             kwargs["choices"] = choices
 
-    if "type" not in kwargs and annotation is not bool:
-        if origin is not None or annotation in (list, set, dict, tuple):
-            kwargs["type"] = str
-        else:
+    # Container types - parse as JSON
+    if origin in (list, set, dict, tuple) or annotation in (list, set, dict, tuple):
+        kwargs["type"] = lambda item: json.loads(item)
+
+    # Fallback for complex types (only if annotation is a class)
+    elif "type" not in kwargs and annotation is not bool:
+        if isinstance(annotation, type):
             kwargs["type"] = get_from_str(annotation, field_name)
+        # Otherwise, keep as string (typing constructs like Annotated, etc.)
+        else:
+            kwargs["type"] = str
 
     if field.description:
         kwargs["help"] = field.description
 
     type_label = _annotation_display(annotation)
-    if "type" in kwargs.keys():
+    if "type" in kwargs:
         kwargs["metavar"] = f"{type_label}"
 
     return flag, kwargs

--- a/src/deployments/utils/parser.py
+++ b/src/deployments/utils/parser.py
@@ -53,41 +53,33 @@ def get_from_str(annotation: Any, field_name: str):
             if isinstance(annotation, type) and issubclass(annotation, BaseModel):
                 return annotation.model_validate_json(input_str)
         except (ValidationError, ValueError) as e:
-            err = argparse.ArgumentTypeError(
-                f"Failed convert string with model_validate_json. Field: `{field_name}` Error: `{e}`"
+            errors.append(
+                argparse.ArgumentTypeError(
+                    f"model_validate_json failed. Field: `{field_name}` Error: `{e}`"
+                )
             )
-            errors.append(err)
 
         # Convert using custom from_str method.
-        try:
-            if hasattr(annotation, "from_str"):
-                return annotation.from_str(input_str)
-            else:
-                err = argparse.ArgumentTypeError(
-                    f"No from_str method for object. Field: `{field_name}`"
+        from_str_method = getattr(annotation, "from_str", None)
+        if from_str_method is not None:
+            try:
+                return from_str_method(input_str)
+            except Exception as e:
+                errors.append(
+                    argparse.ArgumentTypeError(
+                        f"from_str failed. Field: `{field_name}` Error: `{e}`"
+                    )
                 )
-                errors.append(err)
-        except (ValidationError, ValueError, TypeError) as e:
-            err = argparse.ArgumentTypeError(
-                f"Failed to convert string with from_str. Field: `{field_name}` Error: `{e}`"
-            )
-            errors.append(err)
 
         # Convert using direct instantiation.
-        try:
-            # Only try direct instantiation if annotation is callable
-            if callable(annotation):
+        if callable(annotation):
+            try:
                 return annotation(input_str)
-            else:
+            except Exception as e:
                 err = argparse.ArgumentTypeError(
-                    f"No constructor available for annotation. Field: `{field_name}`"
+                    f"Failed to convert string directly. Field: `{field_name}` Error: `{e}`"
                 )
                 errors.append(err)
-        except (ValidationError, ValueError, TypeError) as e:
-            err = argparse.ArgumentTypeError(
-                f"Failed to convert string directly. Field: `{field_name}` Error: `{e}`"
-            )
-            errors.append(err)
 
         if len(errors) == 1:
             raise errors[0]

--- a/src/deployments/utils/parser.py
+++ b/src/deployments/utils/parser.py
@@ -1,7 +1,8 @@
 # Python Imports
+import argparse
 from typing import Any, Literal, Union, get_args, get_origin
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from pydantic.fields import FieldInfo
 
 ARG_NOT_SET = object()
@@ -33,6 +34,49 @@ def _unwrap_optional(annotation):
     return annotation
 
 
+def get_from_str(annotation: Any, field_name: str):
+    def from_str(input_str: str) -> Any:
+        # Convert using model_validate_json.
+        errors = []
+        try:
+            if issubclass(annotation, BaseModel):
+                return annotation.model_validate_json(input_str)
+        except (ValidationError, ValueError) as e:
+            err = argparse.ArgumentTypeError(
+                f"Failed convert string with model_validate_json. Field: `{field_name}` Error: `{e}`"
+            )
+            errors.append(err)
+
+        # Convert using custom from_str method.
+        try:
+            return annotation.from_str(input_str)
+        except AttributeError as e:
+            err = argparse.ArgumentTypeError(
+                f"No from_str method for object. Field: `{field_name}` Error: `{e}`"
+            )
+            errors.append(err)
+        except (ValidationError, ValueError, TypeError) as e:
+            err = argparse.ArgumentTypeError(
+                f"Failed to convert string with from_str. Field: `{field_name}` Error: `{e}`"
+            )
+            errors.append(err)
+
+        # Convert using direct instantiation.
+        try:
+            return annotation(input_str)
+        except (ValidationError, ValueError, TypeError) as e:
+            err = argparse.ArgumentTypeError(
+                f"Failed to convert string directly. Field: `{field_name}` Error: `{e}`"
+            )
+            errors.append(err)
+
+        if len(errors) == 1:
+            raise errors[0]
+        raise argparse.ArgumentTypeError(f"Failed to convert field from str. Errors: {errors}")
+
+    return from_str
+
+
 def _field_to_arg(field_name: str, field: FieldInfo) -> tuple[str, dict[str, Any]]:
     annotation = _unwrap_optional(field.annotation)
     flag = f"--{field_name.replace('_', '-')}"
@@ -41,12 +85,11 @@ def _field_to_arg(field_name: str, field: FieldInfo) -> tuple[str, dict[str, Any
         "dest": field_name,
         "default": ARG_NOT_SET,
         "required": False,
-        "type": str,
     }
 
     if annotation is bool:
         kwargs["action"] = "store_true"
-        del kwargs["type"]
+        # For bool, "type" should not be set.
 
     if annotation in (int, float, str):
         kwargs["type"] = annotation
@@ -62,6 +105,10 @@ def _field_to_arg(field_name: str, field: FieldInfo) -> tuple[str, dict[str, Any
         if choices:
             kwargs["type"] = type(choices[0])
             kwargs["choices"] = choices
+
+    if "type" not in kwargs.keys() and annotation is not bool:
+        from_str = get_from_str(annotation, field_name)
+        kwargs["type"] = from_str
 
     if field.description:
         kwargs["help"] = field.description

--- a/src/deployments/utils/parser.py
+++ b/src/deployments/utils/parser.py
@@ -106,9 +106,11 @@ def _field_to_arg(field_name: str, field: FieldInfo) -> tuple[str, dict[str, Any
             kwargs["type"] = type(choices[0])
             kwargs["choices"] = choices
 
-    if "type" not in kwargs.keys() and annotation is not bool:
-        from_str = get_from_str(annotation, field_name)
-        kwargs["type"] = from_str
+    if "type" not in kwargs and annotation is not bool:
+        if origin is not None or annotation in (list, set, dict, tuple):
+            kwargs["type"] = str
+        else:
+            kwargs["type"] = get_from_str(annotation, field_name)
 
     if field.description:
         kwargs["help"] = field.description


### PR DESCRIPTION
Change auto generation of experiment config CLI params to allow passing in complex types.

For types that inherit from pydantic.BaseModel, allow JSON str input. 
```--image='{"repo":"pearsonwhite/nwaku","tag":"quic-b778d16"}'```

For types that have a from_str static method, use that if JSON parsing fails.
```--image="pearsonwhite/nwaku:quic-b778d16"```

Falls back on direct constructor with input str as the argument.