### PR TITLE
Degraded-network, churn and partition regression scenarios

### DIFF
--- a/src/deployments/core/builders.py
+++ b/src/deployments/core/builders.py
@@ -13,7 +13,7 @@ from kubernetes.client import (
     V1ServicePort,
     V1StatefulSet,
 )
-from pydantic import BaseModel, Field, NonNegativeInt
+from pydantic import BaseModel, Field, NonNegativeFloat, NonNegativeInt
 
 from src.deployments.core.configs.command import Command, CommandConfig, build_command
 from src.deployments.core.configs.container import ContainerConfig, Image, build_container
@@ -76,10 +76,11 @@ class StatefulSetBuilder(BaseModel):
         delay: NonNegativeInt,
         jitter: NonNegativeInt,
         rate_mbit: Optional[NonNegativeInt] = None,
+        loss_pct: Optional[NonNegativeFloat] = None,
         *,
         overwrite: bool = False,
     ) -> Self:
-        delay_container = init_container_delay(delay, jitter, rate_mbit)
+        delay_container = init_container_delay(delay, jitter, rate_mbit, loss_pct)
         self.config.stateful_set_spec.pod_template_spec_config.pod_spec_config.add_init_container(
             delay_container, overwrite=overwrite
         )

--- a/src/deployments/core/configs/helpers/utils.py
+++ b/src/deployments/core/configs/helpers/utils.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from typing import Dict, List, Literal, Optional, Tuple, Type, TypeVar, get_args
 
 from kubernetes.client import V1Capabilities, V1Container, V1SecurityContext
-from pydantic import NonNegativeInt
+from pydantic import NonNegativeFloat, NonNegativeInt
 
 # Project Imports
 from src.deployments.core.configs.command import CommandConfig
@@ -165,10 +165,13 @@ def init_container_delay(
     delay: NonNegativeInt,
     jitter: NonNegativeInt,
     rate_mbit: Optional[NonNegativeInt] = None,
+    loss_pct: Optional[NonNegativeFloat] = None,
 ):
     netem = f"delay {delay}ms"
     if jitter:
         netem += f" {jitter}ms distribution normal"
+    if loss_pct:
+        netem += f" loss {loss_pct}%"
     if rate_mbit:
         netem += f" rate {rate_mbit}mbit"
     return V1Container(

--- a/src/deployments/core/k8s_cleanup.py
+++ b/src/deployments/core/k8s_cleanup.py
@@ -33,6 +33,7 @@ def get_cleanup_resources(yamls: List[yaml.YAMLObject], types: Optional[List[str
         "Role": [],
         "RoleBinding": [],
         "ServiceAccount": [],
+        "NetworkPolicy": [],
     }
     types = (
         types
@@ -50,6 +51,7 @@ def get_cleanup_resources(yamls: List[yaml.YAMLObject], types: Optional[List[str
             "ConfigMap",
             "ServiceAccount",
             "PersistentVolumeClaim",
+            "NetworkPolicy",
         ]
     )
     for yaml in yamls:
@@ -72,6 +74,12 @@ def delete_pod(name, namespace, *, grace_period=0):
     )
 
 
+def delete_network_policy(name, namespace):
+    client.NetworkingV1Api().delete_namespaced_network_policy(
+        name=name, namespace=namespace, body=client.V1DeleteOptions()
+    )
+
+
 def cleanup_resources(
     resources: dict,
     namespace: str,
@@ -83,6 +91,7 @@ def cleanup_resources(
     """
     logger.info(f"Cleanup resources: `{resources}`")
     deletion_order = [
+        "NetworkPolicy",
         "Deployment",
         "StatefulSet",
         "DaemonSet",
@@ -142,6 +151,9 @@ def cleanup_resources(
         "RoleBinding": lambda name: client.RbacAuthorizationV1Api(
             api_client
         ).delete_namespaced_role_binding(name, namespace, body=client.V1DeleteOptions()),
+        "NetworkPolicy": lambda name: client.NetworkingV1Api(
+            api_client
+        ).delete_namespaced_network_policy(name, namespace, body=client.V1DeleteOptions()),
     }
 
     for kind in deletion_order:

--- a/src/deployments/core/k8s_cleanup.py
+++ b/src/deployments/core/k8s_cleanup.py
@@ -74,8 +74,10 @@ def delete_pod(name, namespace, *, grace_period=0):
     )
 
 
-def delete_network_policy(name, namespace):
-    client.NetworkingV1Api().delete_namespaced_network_policy(
+def delete_network_policy(
+    name: str, namespace: str, api_client: Optional[ApiClient] = None
+) -> None:
+    client.NetworkingV1Api(api_client or client.ApiClient()).delete_namespaced_network_policy(
         name=name, namespace=namespace, body=client.V1DeleteOptions()
     )
 

--- a/src/deployments/core/k8s_deploy.py
+++ b/src/deployments/core/k8s_deploy.py
@@ -42,6 +42,7 @@ def _kind_api_map(operation: str) -> Dict[str, Tuple[str, str]]:
         "RoleBinding": ("rbac", "role_binding"),
         "ConfigMap": ("core", "config_map"),
         "ServiceAccount": ("core", "service_account"),
+        "NetworkPolicy": ("networking", "network_policy"),
     }
 
     template = {}
@@ -76,6 +77,7 @@ def _kubectl_operation(
         "batch": client.BatchV1Api(api_client),
         "core": client.CoreV1Api(api_client),
         "rbac": client.RbacAuthorizationV1Api(api_client),
+        "networking": client.NetworkingV1Api(api_client),
     }
     api = api_group_map[group]
     method = getattr(api, method_name)

--- a/src/deployments/core/k8s_object.py
+++ b/src/deployments/core/k8s_object.py
@@ -9,6 +9,7 @@ from kubernetes.client import (
     V1DaemonSet,
     V1Deployment,
     V1Job,
+    V1NetworkPolicy,
     V1Pod,
     V1PodTemplateSpec,
     V1Probe,
@@ -32,6 +33,7 @@ V1Deployable = Union[
     V1CronJob,
     V1ConfigMap,
     V1ServiceAccount,
+    V1NetworkPolicy,
 ]
 
 K8sModelStr = Literal[

--- a/src/deployments/core/k8s_rollout.py
+++ b/src/deployments/core/k8s_rollout.py
@@ -2,6 +2,7 @@
 import asyncio
 import logging
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Callable, Iterable, Optional, Tuple
 
 from kubernetes import client
@@ -132,6 +133,24 @@ async def wait_for_rollout(
             raise TimeoutError(f"Timeout waiting for {kind} `{name}`.")
 
         await asyncio.sleep(polling_interval)
+
+
+def label_pods(names: Iterable[str], namespace: str, labels: dict, api_client=None) -> int:
+    """Add labels to the named pods, in parallel. Returns how many were labelled."""
+    api = client.CoreV1Api(api_client or client.ApiClient())
+    body = {"metadata": {"labels": labels}}
+
+    def patch(name: str) -> bool:
+        try:
+            api.patch_namespaced_pod(name=name, namespace=namespace, body=body)
+            return True
+        except ApiException as e:
+            logger.warning(f"Could not label pod `{name}`: {e.status}")
+            return False
+
+    names = list(names)
+    with ThreadPoolExecutor(max_workers=32) as pool:
+        return sum(pool.map(patch, names))
 
 
 def scale_statefulset(name: str, namespace: str, replicas: int, api_client=None) -> None:

--- a/src/deployments/core/k8s_rollout.py
+++ b/src/deployments/core/k8s_rollout.py
@@ -134,6 +134,14 @@ async def wait_for_rollout(
         await asyncio.sleep(polling_interval)
 
 
+def scale_statefulset(name: str, namespace: str, replicas: int, api_client=None) -> None:
+    """Set a StatefulSet's replica count. Scaling down removes the highest ordinals."""
+    api = client.AppsV1Api(api_client or client.ApiClient())
+    api.patch_namespaced_stateful_set_scale(
+        name=name, namespace=namespace, body={"spec": {"replicas": replicas}}
+    )
+
+
 def get_pods_for_statefulset(name: str, namespace: str, api_client=None) -> Iterable[V1Pod]:
     api_client = api_client or client.ApiClient()
     apps_api = client.AppsV1Api(api_client)

--- a/src/deployments/core/k8s_rollout.py
+++ b/src/deployments/core/k8s_rollout.py
@@ -7,6 +7,7 @@ from typing import Callable, Iterable, Optional, Tuple
 
 from kubernetes import client
 from kubernetes.client import (
+    ApiClient,
     ApiException,
     V1DaemonSet,
     V1Deployment,
@@ -153,12 +154,37 @@ def label_pods(names: Iterable[str], namespace: str, labels: dict, api_client=No
         return sum(pool.map(patch, names))
 
 
-def scale_statefulset(name: str, namespace: str, replicas: int, api_client=None) -> None:
-    """Set a StatefulSet's replica count. Scaling down removes the highest ordinals."""
+async def scale_statefulset(
+    name: str,
+    namespace: str,
+    replicas: int,
+    api_client: Optional[ApiClient] = None,
+    *,
+    timeout: int = 600,
+    polling_interval: int = 5,
+) -> None:
+    """Set a StatefulSet's replica count and wait for the pods to follow.
+
+    Scaling down removes the highest ordinals. The patch returns before the pods are gone,
+    so a caller that times an outage from it would start counting too early.
+    """
     api = client.AppsV1Api(api_client or client.ApiClient())
     api.patch_namespaced_stateful_set_scale(
         name=name, namespace=namespace, body={"spec": {"replicas": replicas}}
     )
+
+    deadline = time.time() + timeout
+    while True:
+        current = api.read_namespaced_stateful_set(name=name, namespace=namespace)
+        actual = getattr(current.status, "replicas", None) or 0
+        if actual == replicas:
+            logger.info(f"StatefulSet `{name}` scaled to {replicas}")
+            return
+        if time.time() > deadline:
+            raise TimeoutError(
+                f"StatefulSet `{name}` still at {actual} pods, wanted {replicas}, after {timeout}s"
+            )
+        await asyncio.sleep(polling_interval)
 
 
 def get_pods_for_statefulset(name: str, namespace: str, api_client=None) -> Iterable[V1Pod]:

--- a/src/deployments/core/tests/test_builders.py
+++ b/src/deployments/core/tests/test_builders.py
@@ -200,7 +200,7 @@ class TestStatefulSetBuilder:
         )
 
         builder.with_network_delay(100, 10)
-        mock_init_delay.assert_called_once_with(100, 10, None)
+        mock_init_delay.assert_called_once_with(100, 10, None, None)
 
     def test_with_network_delay_adds_init_container_to_pod_spec(self, mocker):
         """Should add init container to pod spec with correct delay and jitter values."""
@@ -234,7 +234,7 @@ class TestStatefulSetBuilder:
         )
 
         builder.with_network_delay(100, 10)
-        mock_init_delay.assert_called_once_with(100, 10, None)
+        mock_init_delay.assert_called_once_with(100, 10, None, None)
         init_containers = (
             builder.config.stateful_set_spec.pod_template_spec_config.pod_spec_config.init_containers
         )

--- a/src/deployments/experiments/base_experiment.py
+++ b/src/deployments/experiments/base_experiment.py
@@ -20,6 +20,7 @@ from kubernetes.client import (
     V1DaemonSet,
     V1Deployment,
     V1Job,
+    V1NetworkPolicy,
     V1Pod,
     V1PodTemplateSpec,
     V1Role,
@@ -62,6 +63,7 @@ V1Deployable = Union[
     V1RoleBinding,
     V1ConfigMap,
     V1ServiceAccount,
+    V1NetworkPolicy,
 ]
 
 

--- a/src/deployments/experiments/libp2p/churn.py
+++ b/src/deployments/experiments/libp2p/churn.py
@@ -1,0 +1,73 @@
+"""Regression scenario: a share of the nodes drop out mid-run and rejoin."""
+
+import asyncio
+import logging
+from typing import List
+
+from kubernetes.client import V1StatefulSet
+from pydantic import Field, NonNegativeInt, model_validator
+
+from src.deployments.core.k8s_rollout import scale_statefulset, wait_for_rollout
+from src.deployments.experiments.libp2p.nimlibp2p import ExpConfig, NimLibp2pExperiment
+from src.deployments.registry import experiment
+
+logger = logging.getLogger(__name__)
+
+
+class ChurnConfig(ExpConfig):
+    churn_fraction: float = Field(default=0.2, gt=0, lt=1)
+    """Share taken down, from the highest ordinals."""
+    churn_at: NonNegativeInt = 30
+    """Seconds after the first message."""
+    churn_downtime: NonNegativeInt = 60
+    churn_rejoin_timeout: NonNegativeInt = 600
+
+    @model_validator(mode="after")
+    def _check_churn_takes_nodes_down(self):
+        if int(self.num_relay_nodes * self.churn_fraction) < 1:
+            raise ValueError(
+                f"churn_fraction {self.churn_fraction} of {self.num_relay_nodes} nodes takes "
+                "none of them down, so the run would report success without any churn"
+            )
+        return self
+
+
+def churn_targets(nodes: V1StatefulSet, fraction: float) -> List[str]:
+    """Highest-ordinal pods, which is what a scale-down removes."""
+    replicas = nodes.spec.replicas
+    count = int(replicas * fraction)
+    return [f"{nodes.metadata.name}-{i}" for i in range(replicas - count, replicas)]
+
+
+@experiment(name="nimlibp2p-churn")
+class NodeChurn(NimLibp2pExperiment):
+    """Regression run where a share of the nodes drop out mid-run and rejoin.
+
+    Scale down rather than delete: a deleted pod is replaced within seconds.
+    """
+
+    config: ChurnConfig
+
+    def _publishable_nodes(self) -> int:
+        """Churned nodes return on new addresses; publishing to a stale one hangs."""
+        churned = int(self.config.num_relay_nodes * self.config.churn_fraction)
+        return self.config.num_relay_nodes - churned
+
+    async def _mid_run(self, nodes: V1StatefulSet) -> None:
+        await asyncio.sleep(self.config.churn_at)
+
+        targets = churn_targets(nodes, self.config.churn_fraction)
+        replicas = nodes.spec.replicas
+        name = nodes.metadata.name
+
+        self.log_event({"event": "churn_down", "nodes": targets})
+        logger.info(f"Taking down {len(targets)} nodes: {targets[0]}..{targets[-1]}")
+        await scale_statefulset(name, self.namespace, replicas - len(targets), self.api_client)
+        self.log_event({"event": "churn_is_down", "nodes": targets})
+
+        await asyncio.sleep(self.config.churn_downtime)
+
+        self.log_event({"event": "churn_rejoin", "nodes": targets})
+        await scale_statefulset(name, self.namespace, replicas, self.api_client)
+        await wait_for_rollout(nodes, self.api_client, timeout=self.config.churn_rejoin_timeout)
+        self.log_event({"event": "churn_rejoined", "nodes": targets})

--- a/src/deployments/experiments/libp2p/degraded.py
+++ b/src/deployments/experiments/libp2p/degraded.py
@@ -1,0 +1,23 @@
+"""Regression scenario: a degraded link (latency, jitter, packet loss)."""
+
+import logging
+
+from pydantic import Field, NonNegativeInt
+
+from src.deployments.experiments.libp2p.nimlibp2p import ExpConfig, NimLibp2pExperiment
+from src.deployments.registry import experiment
+
+logger = logging.getLogger(__name__)
+
+
+class DegradedConfig(ExpConfig):
+    network_delay: NonNegativeInt = 200
+    network_jitter: NonNegativeInt = 50
+    network_loss_pct: float = Field(default=1, ge=0, le=100)
+
+
+@experiment(name="nimlibp2p-degraded")
+class DegradedNetwork(NimLibp2pExperiment):
+    """Regression run over a high-latency, jittery, lossy link."""
+
+    config: DegradedConfig

--- a/src/deployments/experiments/libp2p/nimlibp2p.py
+++ b/src/deployments/experiments/libp2p/nimlibp2p.py
@@ -195,6 +195,10 @@ class NimLibp2pExperiment(BaseExperiment[ExpConfig]):
     async def _mid_run(self, nodes: V1StatefulSet) -> None:
         """Runs alongside the publish loop. Scenarios override this to disturb the network."""
 
+    def _publishable_nodes(self) -> int:
+        """How many of the relays the publisher may target, counted from index 0."""
+        return self.config.num_relay_nodes
+
     async def _run(self):
         self.log_event("run_start")
 
@@ -241,7 +245,7 @@ class NimLibp2pExperiment(BaseExperiment[ExpConfig]):
 
         tasks = []
         for msg_index in range(self.config.num_messages):
-            index = random.randint(0, self.config.num_relay_nodes - 1)
+            index = random.randint(0, self._publishable_nodes() - 1)
             random_name = f"{name}-{index}"
             self.log_event({"event": "publish", "node": random_name, "index": msg_index})
             tasks.append(asyncio.create_task(publish(self.config, namespace, random_name)))

--- a/src/deployments/experiments/libp2p/nimlibp2p.py
+++ b/src/deployments/experiments/libp2p/nimlibp2p.py
@@ -204,6 +204,12 @@ class NimLibp2pExperiment(BaseExperiment[ExpConfig]):
         )
         await self.deploy(deployment=publisher, wait_for_ready=True)
 
+        # Backs the StatefulSet's per-pod DNS and is what the publisher resolves nodes
+        # through, so both discovery modes need it, not just the static dial.
+        node_service = build_static_service(self.namespace)
+        self.dump_yaml(node_service, "nimp2p-service")
+        await self.deploy(deployment=node_service, exist_ok=True)
+
         # Bootstrap (kad-dht only): anchor node + headless discovery service. Deployed
         # before the nodes so the mesh can form through it once the nodes wake up.
         if self.config.discovery == "kad-dht":
@@ -214,11 +220,6 @@ class NimLibp2pExperiment(BaseExperiment[ExpConfig]):
             bootstrap = build_bootstrap_nodes(namespace=self.namespace, params=self.config)
             self.dump_yaml(bootstrap, "bootstrap")
             await self.deploy(deployment=bootstrap, wait_for_ready=True)
-        else:
-            # Static discovery resolves peers via this service, so deploy it first.
-            static_service = build_static_service(self.namespace)
-            self.dump_yaml(static_service, "static-service")
-            await self.deploy(deployment=static_service, exist_ok=True)
 
         # Nodes
         nodes = build_nodes(

--- a/src/deployments/experiments/libp2p/nimlibp2p.py
+++ b/src/deployments/experiments/libp2p/nimlibp2p.py
@@ -46,6 +46,7 @@ class ExpConfig(BaseModel):
     network_delay: NonNegativeInt = 0
     network_jitter: NonNegativeInt = 0
     network_bandwidth_mbit: NonNegativeInt = 0  # 0 = uncapped; folded into the netem qdisc
+    network_loss_pct: NonNegativeFloat = 0  # 0 = lossless; folded into the netem qdisc
     node_start_delay: NonNegativeInt = 60
     post_publish_dwell: NonNegativeInt = 90
     wait_nodes_ready: bool = True
@@ -90,11 +91,17 @@ def build_nodes(
         builder = builder.with_option(NimLibp2p.service, "nimp2p-service").with_option(
             NimLibp2p.connect_to, params.connect_to
         )
-    if params.network_delay or params.network_jitter or params.network_bandwidth_mbit:
+    if (
+        params.network_delay
+        or params.network_jitter
+        or params.network_bandwidth_mbit
+        or params.network_loss_pct
+    ):
         builder = builder.with_network_delay(
             delay=params.network_delay,
             jitter=params.network_jitter,
             rate_mbit=params.network_bandwidth_mbit or None,
+            loss_pct=params.network_loss_pct or None,
         )
 
     return builder.build()
@@ -185,6 +192,9 @@ class NimLibp2pExperiment(BaseExperiment[ExpConfig]):
     def _get_metadata(self) -> dict:
         return Bridge().get_metadata(self.events_log_path)
 
+    async def _mid_run(self, nodes: V1StatefulSet) -> None:
+        """Runs alongside the publish loop. Scenarios override this to disturb the network."""
+
     async def _run(self):
         self.log_event("run_start")
 
@@ -226,6 +236,8 @@ class NimLibp2pExperiment(BaseExperiment[ExpConfig]):
 
         self.log_event("start_messages")
 
+        mid_run = asyncio.create_task(self._mid_run(nodes))
+
         tasks = []
         for msg_index in range(self.config.num_messages):
             index = random.randint(0, self.config.num_relay_nodes - 1)
@@ -236,6 +248,8 @@ class NimLibp2pExperiment(BaseExperiment[ExpConfig]):
         await asyncio.gather(*tasks)
 
         self.log_event("publisher_messages_finished")
+
+        await mid_run
 
         await asyncio.sleep(self.config.post_publish_dwell)
         self.log_event("publisher_wait_finished")

--- a/src/deployments/experiments/libp2p/nimlibp2p.py
+++ b/src/deployments/experiments/libp2p/nimlibp2p.py
@@ -5,7 +5,7 @@ import traceback
 from typing import ClassVar, Literal
 
 from kubernetes.client import V1Probe, V1ServicePort, V1StatefulSet, V1TCPSocketAction
-from pydantic import BaseModel, ConfigDict, NonNegativeFloat, NonNegativeInt, model_validator
+from pydantic import BaseModel, ConfigDict, Field, NonNegativeFloat, NonNegativeInt, model_validator
 
 from src.deployments.core.builders import ServiceBuilder
 from src.deployments.core.configs.container import Image
@@ -46,7 +46,7 @@ class ExpConfig(BaseModel):
     network_delay: NonNegativeInt = 0
     network_jitter: NonNegativeInt = 0
     network_bandwidth_mbit: NonNegativeInt = 0  # 0 = uncapped; folded into the netem qdisc
-    network_loss_pct: NonNegativeFloat = 0  # 0 = lossless; folded into the netem qdisc
+    network_loss_pct: float = Field(default=0, ge=0, le=100)  # percent; folded into the netem qdisc
     node_start_delay: NonNegativeInt = 60
     post_publish_dwell: NonNegativeInt = 90
     wait_nodes_ready: bool = True

--- a/src/deployments/experiments/libp2p/nimlibp2p.py
+++ b/src/deployments/experiments/libp2p/nimlibp2p.py
@@ -192,6 +192,14 @@ class NimLibp2pExperiment(BaseExperiment[ExpConfig]):
     def _get_metadata(self) -> dict:
         return Bridge().get_metadata(self.events_log_path)
 
+    async def _after_nodes(self, nodes: V1StatefulSet) -> None:
+        """Runs once the nodes are up, before the cold start they form the mesh during.
+
+        Scenarios override this to shape the network the mesh will form over. Nodes hold
+        off dialling for `node_start_delay`, so anything done here lands before they
+        connect, provided that delay outlasts the deploy.
+        """
+
     async def _mid_run(self, nodes: V1StatefulSet) -> None:
         """Runs alongside the publish loop. Scenarios override this to disturb the network."""
 
@@ -234,6 +242,8 @@ class NimLibp2pExperiment(BaseExperiment[ExpConfig]):
         namespace = nodes.metadata.namespace
 
         await self.deploy(deployment=nodes, wait_for_ready=self.config.wait_nodes_ready)
+
+        await self._after_nodes(nodes)
 
         await asyncio.sleep(self.config.delay_cold_start)
 

--- a/src/deployments/experiments/libp2p/partition.py
+++ b/src/deployments/experiments/libp2p/partition.py
@@ -1,4 +1,4 @@
-"""Adverse-condition regression scenarios: degraded links, node churn, network partition."""
+"""Regression scenario: the network forms as two halves that later meet."""
 
 import asyncio
 import logging
@@ -16,89 +16,21 @@ from kubernetes.client import (
     V1ObjectMeta,
     V1StatefulSet,
 )
-from pydantic import NonNegativeFloat, NonNegativeInt
+from pydantic import Field, NonNegativeFloat, NonNegativeInt, model_validator
 
 from src.deployments.core.k8s_cleanup import delete_network_policy
-from src.deployments.core.k8s_rollout import (
-    get_pods_for_statefulset,
-    label_pods,
-    scale_statefulset,
-    wait_for_rollout,
-)
+from src.deployments.core.k8s_rollout import get_pods_for_statefulset, label_pods
 from src.deployments.experiments.libp2p.nimlibp2p import ExpConfig, NimLibp2pExperiment
 from src.deployments.registry import experiment
 
 logger = logging.getLogger(__name__)
 
-
-class DegradedConfig(ExpConfig):
-    network_delay: NonNegativeInt = 200
-    network_jitter: NonNegativeInt = 50
-    network_loss_pct: NonNegativeFloat = 1
-
-
-@experiment(name="nimlibp2p-degraded")
-class DegradedNetwork(NimLibp2pExperiment):
-    """Regression run over a high-latency, jittery, lossy link."""
-
-    config: DegradedConfig
-
-
-class ChurnConfig(ExpConfig):
-    churn_fraction: NonNegativeFloat = 0.2
-    """Share taken down, from the highest ordinals."""
-    churn_at: NonNegativeInt = 30
-    """Seconds after the first message."""
-    churn_downtime: NonNegativeInt = 60
-    churn_rejoin_timeout: NonNegativeInt = 600
-
-
-def churn_targets(nodes: V1StatefulSet, fraction: float) -> List[str]:
-    """Highest-ordinal pods, which is what a scale-down removes."""
-    replicas = nodes.spec.replicas
-    count = int(replicas * fraction)
-    return [f"{nodes.metadata.name}-{i}" for i in range(replicas - count, replicas)]
-
-
-@experiment(name="nimlibp2p-churn")
-class NodeChurn(NimLibp2pExperiment):
-    """Regression run where a share of the nodes drop out mid-run and rejoin.
-
-    Scale down rather than delete: a deleted pod is replaced within seconds.
-    """
-
-    config: ChurnConfig
-
-    def _publishable_nodes(self) -> int:
-        """Churned nodes return on new addresses; publishing to a stale one hangs."""
-        churned = int(self.config.num_relay_nodes * self.config.churn_fraction)
-        return self.config.num_relay_nodes - churned
-
-    async def _mid_run(self, nodes: V1StatefulSet) -> None:
-        await asyncio.sleep(self.config.churn_at)
-
-        targets = churn_targets(nodes, self.config.churn_fraction)
-        if not targets:
-            logger.warning(f"churn_fraction {self.config.churn_fraction} takes down no nodes")
-            return
-
-        replicas = nodes.spec.replicas
-        name = nodes.metadata.name
-        self.log_event({"event": "churn_down", "nodes": targets})
-        logger.info(f"Taking down {len(targets)} nodes: {targets[0]}..{targets[-1]}")
-        scale_statefulset(name, self.namespace, replicas - len(targets), self.api_client)
-        self.log_event({"event": "churn_is_down", "nodes": targets})
-
-        await asyncio.sleep(self.config.churn_downtime)
-
-        self.log_event({"event": "churn_rejoin", "nodes": targets})
-        scale_statefulset(name, self.namespace, replicas, self.api_client)
-        await wait_for_rollout(nodes, self.api_client, timeout=self.config.churn_rejoin_timeout)
-        self.log_event({"event": "churn_rejoined", "nodes": targets})
+SIDE_LABEL = "partition-side"
+NAMESPACE_NAME_LABEL = "kubernetes.io/metadata.name"
 
 
 class PartitionConfig(ExpConfig):
-    partition_fraction: NonNegativeFloat = 0.5
+    partition_fraction: float = Field(default=0.5, gt=0, lt=1)
     """Share of relay nodes on the first side."""
     heal_at: NonNegativeInt = 120
     """Seconds after the first message before the halves may meet."""
@@ -113,9 +45,15 @@ class PartitionConfig(ExpConfig):
     """One shared unlabelled anchor, the only way the halves learn each other's addresses.
     It cannot relay: the bootstrap role returns before GossipSub is mounted."""
 
-
-SIDE_LABEL = "partition-side"
-NAMESPACE_NAME_LABEL = "kubernetes.io/metadata.name"
+    @model_validator(mode="after")
+    def _check_both_sides_populated(self):
+        split = int(self.num_relay_nodes * self.partition_fraction)
+        if split < 1 or split >= self.num_relay_nodes:
+            raise ValueError(
+                f"partition_fraction {self.partition_fraction} of {self.num_relay_nodes} nodes "
+                f"puts {split} on one side, so the run would report success without a split"
+            )
+        return self
 
 
 def partition_sides(nodes: V1StatefulSet, fraction: float) -> tuple[List[str], List[str]]:
@@ -151,9 +89,10 @@ def _not_far_side(namespace: str, far_side: str) -> List[V1NetworkPolicyPeer]:
 def build_partition_policy(name: str, namespace: str, side: str, far_side: str) -> V1NetworkPolicy:
     """Cut `side` off from `far_side`, both directions.
 
-    Ingress alone only stops TCP; quic is UDP and goes straight through. Egress reuses the
-    ingress allow-list, or the nodes lose DNS. The label must be one we set: the CNI does
-    not enforce policies selecting on per-pod-unique labels.
+    Egress reuses the ingress allow-list rather than denying outright, or the nodes lose
+    DNS. The label must be one we set: the CNI does not enforce policies selecting on
+    per-pod-unique labels. Both directions are restricted because a partition stops traffic
+    both ways; whether ingress alone would contain quic is not settled, see PR discussion.
     """
     peers = _not_far_side(namespace, far_side)
     return V1NetworkPolicy(
@@ -194,10 +133,10 @@ class NetworkPartition(NimLibp2pExperiment):
     async def _after_nodes(self, nodes: V1StatefulSet) -> None:
         side_a, side_b = partition_sides(nodes, self.config.partition_fraction)
         if not side_a or not side_b:
-            logger.warning(
-                f"partition_fraction {self.config.partition_fraction} leaves one side empty"
+            raise ValueError(
+                f"partition_fraction {self.config.partition_fraction} leaves one side empty "
+                f"at {nodes.spec.replicas} nodes; there would be no split to measure"
             )
-            return
 
         await self._wait_for_pods_to_exist(nodes)
         labelled = label_pods(side_a, self.namespace, {SIDE_LABEL: "a"}, self.api_client)
@@ -223,5 +162,5 @@ class NetworkPartition(NimLibp2pExperiment):
 
         self.log_event("partition_heal")
         for name in ("partition-a", "partition-b"):
-            delete_network_policy(name, self.namespace)
+            delete_network_policy(name, self.namespace, self.api_client)
         self.log_event("partition_healed")

--- a/src/deployments/experiments/libp2p/regression_scenarios.py
+++ b/src/deployments/experiments/libp2p/regression_scenarios.py
@@ -19,7 +19,7 @@ from kubernetes.client import (
     V1ObjectMeta,
     V1StatefulSet,
 )
-from pydantic import NonNegativeFloat, NonNegativeInt
+from pydantic import NonNegativeFloat, NonNegativeInt, model_validator
 
 from src.deployments.core.k8s_cleanup import delete_network_policy
 from src.deployments.core.k8s_rollout import (
@@ -28,7 +28,11 @@ from src.deployments.core.k8s_rollout import (
     scale_statefulset,
     wait_for_rollout,
 )
-from src.deployments.experiments.libp2p.nimlibp2p import ExpConfig, NimLibp2pExperiment
+from src.deployments.experiments.libp2p.nimlibp2p import (
+    BOOTSTRAP_NAME,
+    ExpConfig,
+    NimLibp2pExperiment,
+)
 from src.deployments.registry import experiment
 
 logger = logging.getLogger(__name__)
@@ -130,10 +134,25 @@ class PartitionConfig(ExpConfig):
     need to get in front of, so the split is set up on existence instead."""
     delay_cold_start: NonNegativeFloat = 700
     """Long enough to cover pod creation, the start delay above, and each half meshing."""
+    bootstrap_nodes: NonNegativeInt = 2
+    """One anchor per side. A single shared anchor is itself a relaying mesh node, so it
+    bridges the split and every message reaches both halves regardless of the policies."""
+
+    @model_validator(mode="after")
+    def _check_bootstrap_per_side(self):
+        if self.bootstrap_nodes < 2:
+            raise ValueError("A partition run needs at least 2 bootstrap nodes, one per side")
+        return self
 
 
 SIDE_LABEL = "partition-side"
 NAMESPACE_NAME_LABEL = "kubernetes.io/metadata.name"
+
+
+def bootstrap_sides(count: int) -> tuple[List[str], List[str]]:
+    """Split the anchors between the two sides, alternating by ordinal."""
+    names = [f"{BOOTSTRAP_NAME}-{i}" for i in range(count)]
+    return names[0::2], names[1::2]
 
 
 def partition_sides(nodes: V1StatefulSet, fraction: float) -> tuple[List[str], List[str]]:
@@ -147,9 +166,12 @@ def build_partition_policy(name: str, namespace: str, side: str, far_side: str) 
     """Deny pods labelled `side` any ingress from pods labelled `far_side`.
 
     Applied to both sides so the split is bidirectional. Only ingress is restricted, so
-    DNS and other egress still work. Pods with no side label (publisher, bootstrap) match
-    `NotIn` and stay reachable, as do other namespaces, which keeps metrics scraping
-    alive across the split.
+    DNS and other egress still work. Unlabelled pods match `NotIn` and stay reachable from
+    both sides, as do other namespaces, which keeps the publisher working and metrics
+    scraping alive across the split. That exemption is only safe for things that do not
+    relay: every gossipsub node, anchors included, has to be on one side or the other, or
+    it carries messages over the split and delivery stays at 100% however good the
+    policies are.
 
     The side label is one we set ourselves rather than a per-pod identifier like
     `statefulset.kubernetes.io/pod-name`: the CNI does not give per-pod-unique labels a
@@ -232,6 +254,10 @@ class NetworkPartition(NimLibp2pExperiment):
             return
 
         await self._wait_for_pods_to_exist(nodes)
+        # Anchors are relaying mesh nodes too, so each side needs its own on its own side.
+        anchors_a, anchors_b = bootstrap_sides(self.config.bootstrap_nodes)
+        side_a, side_b = side_a + anchors_a, side_b + anchors_b
+
         labelled = label_pods(side_a, self.namespace, {SIDE_LABEL: "a"}, self.api_client)
         labelled += label_pods(side_b, self.namespace, {SIDE_LABEL: "b"}, self.api_client)
         self.log_event({"event": "partition_labelled", "pods": labelled})

--- a/src/deployments/experiments/libp2p/regression_scenarios.py
+++ b/src/deployments/experiments/libp2p/regression_scenarios.py
@@ -77,6 +77,17 @@ class NodeChurn(NimLibp2pExperiment):
 
     config: ChurnConfig
 
+    def _publishable_nodes(self) -> int:
+        """Keep the publisher off the churned nodes.
+
+        They come back on new addresses, and the publisher connects to the address it
+        looked up, so publishing to one that has just been replaced hangs until the
+        request times out. That is our harness tripping over the scenario rather than
+        anything about the protocol, and it starves the run of published messages.
+        """
+        churned = int(self.config.num_relay_nodes * self.config.churn_fraction)
+        return self.config.num_relay_nodes - churned
+
     async def _mid_run(self, nodes: V1StatefulSet) -> None:
         await asyncio.sleep(self.config.churn_at)
 

--- a/src/deployments/experiments/libp2p/regression_scenarios.py
+++ b/src/deployments/experiments/libp2p/regression_scenarios.py
@@ -20,8 +20,8 @@ from kubernetes.client import (
 )
 from pydantic import NonNegativeFloat, NonNegativeInt
 
-from src.deployments.core.k8s_cleanup import delete_network_policy, delete_pod
-from src.deployments.core.k8s_rollout import wait_for_rollout
+from src.deployments.core.k8s_cleanup import delete_network_policy
+from src.deployments.core.k8s_rollout import scale_statefulset, wait_for_rollout
 from src.deployments.experiments.libp2p.nimlibp2p import ExpConfig, NimLibp2pExperiment
 from src.deployments.registry import experiment
 
@@ -48,14 +48,16 @@ class DegradedNetwork(NimLibp2pExperiment):
 
 class ChurnConfig(ExpConfig):
     churn_fraction: NonNegativeFloat = 0.2
-    """Share of relay nodes killed mid-run, taken from the highest ordinals."""
+    """Share of relay nodes taken down mid-run, from the highest ordinals."""
     churn_at: NonNegativeInt = 30
-    """Seconds after the first message before killing."""
+    """Seconds after the first message before taking them down."""
+    churn_downtime: NonNegativeInt = 60
+    """Seconds to stay down before rejoining."""
     churn_rejoin_timeout: NonNegativeInt = 600
 
 
 def churn_targets(nodes: V1StatefulSet, fraction: float) -> List[str]:
-    """Highest-ordinal pod names to kill, deterministic so runs stay comparable."""
+    """Highest-ordinal pod names, which is what a scale-down removes."""
     replicas = nodes.spec.replicas
     count = int(replicas * fraction)
     return [f"{nodes.metadata.name}-{i}" for i in range(replicas - count, replicas)]
@@ -63,11 +65,13 @@ def churn_targets(nodes: V1StatefulSet, fraction: float) -> List[str]:
 
 @experiment(name="nimlibp2p-churn")
 class NodeChurn(NimLibp2pExperiment):
-    """Regression run where a share of the nodes are killed mid-run and rejoin.
+    """Regression run where a share of the nodes drop out mid-run and rejoin.
 
-    The StatefulSet recreates them, so they come back with the same names and have to
-    rediscover peers. Exercises peer management, reconnection and mesh repair
-    (prune/graft). Delivery should recover; messages published into the gap may not
+    Scaling the StatefulSet down holds them down for `churn_downtime`; deleting the
+    pods would not, because the controller replaces each one within seconds and the
+    network would only ever lose a trickle at a time. They come back with the same
+    names and have to rediscover peers, which exercises peer management, reconnection
+    and mesh repair. Delivery should recover; messages published into the gap may not
     reach the nodes that were down for it.
     """
 
@@ -78,15 +82,20 @@ class NodeChurn(NimLibp2pExperiment):
 
         targets = churn_targets(nodes, self.config.churn_fraction)
         if not targets:
-            logger.warning(f"churn_fraction {self.config.churn_fraction} kills no nodes")
+            logger.warning(f"churn_fraction {self.config.churn_fraction} takes down no nodes")
             return
 
-        self.log_event({"event": "churn_kill", "nodes": targets})
-        logger.info(f"Killing {len(targets)} nodes: {targets}")
-        for name in targets:
-            delete_pod(name, self.namespace)
-        self.log_event({"event": "churn_killed", "nodes": targets})
+        replicas = nodes.spec.replicas
+        name = nodes.metadata.name
+        self.log_event({"event": "churn_down", "nodes": targets})
+        logger.info(f"Taking down {len(targets)} nodes: {targets[0]}..{targets[-1]}")
+        scale_statefulset(name, self.namespace, replicas - len(targets), self.api_client)
+        self.log_event({"event": "churn_is_down", "nodes": targets})
 
+        await asyncio.sleep(self.config.churn_downtime)
+
+        self.log_event({"event": "churn_rejoin", "nodes": targets})
+        scale_statefulset(name, self.namespace, replicas, self.api_client)
         await wait_for_rollout(nodes, self.api_client, timeout=self.config.churn_rejoin_timeout)
         self.log_event({"event": "churn_rejoined", "nodes": targets})
 

--- a/src/deployments/experiments/libp2p/regression_scenarios.py
+++ b/src/deployments/experiments/libp2p/regression_scenarios.py
@@ -13,6 +13,7 @@ from kubernetes.client import (
     V1LabelSelector,
     V1LabelSelectorRequirement,
     V1NetworkPolicy,
+    V1NetworkPolicyEgressRule,
     V1NetworkPolicyIngressRule,
     V1NetworkPolicyPeer,
     V1NetworkPolicySpec,
@@ -149,54 +150,56 @@ def partition_sides(nodes: V1StatefulSet, fraction: float) -> tuple[List[str], L
     return names[:split], names[split:]
 
 
-def build_partition_policy(name: str, namespace: str, side: str, far_side: str) -> V1NetworkPolicy:
-    """Deny pods labelled `side` any ingress from pods labelled `far_side`.
+def _not_far_side(namespace: str, far_side: str) -> List[V1NetworkPolicyPeer]:
+    """Everything except the far side: same-namespace pods that are not on it, plus any
+    other namespace. Unlabelled pods match `NotIn`, so the publisher stays reachable, and
+    allowing other namespaces keeps DNS and metrics scraping working through the split."""
+    return [
+        V1NetworkPolicyPeer(
+            pod_selector=V1LabelSelector(
+                match_expressions=[
+                    V1LabelSelectorRequirement(key=SIDE_LABEL, operator="NotIn", values=[far_side])
+                ]
+            )
+        ),
+        V1NetworkPolicyPeer(
+            namespace_selector=V1LabelSelector(
+                match_expressions=[
+                    V1LabelSelectorRequirement(
+                        key=NAMESPACE_NAME_LABEL, operator="NotIn", values=[namespace]
+                    )
+                ]
+            )
+        ),
+    ]
 
-    Applied to both sides so the split is bidirectional. Only ingress is restricted, so
-    DNS and other egress still work. Unlabelled pods match `NotIn` and stay reachable from
-    both sides, as do other namespaces, which keeps the publisher working and metrics
-    scraping alive across the split. The exemption is only safe for things that cannot
-    relay: the publisher is an HTTP client, and the anchor answers DHT queries without
-    ever mounting GossipSub, so neither can carry a message over the split. Anything that
-    does relay has to be on one side or the other.
+
+def build_partition_policy(name: str, namespace: str, side: str, far_side: str) -> V1NetworkPolicy:
+    """Cut pods labelled `side` off from pods labelled `far_side`, both directions.
+
+    Restricting ingress alone is not enough. It stops a TCP handshake, because the reply
+    never comes back, which makes a TCP probe look reassuringly blocked. quic is UDP and
+    goes straight through: with an ingress-only policy the halves kept delivering to each
+    other in single-digit milliseconds while a TCP probe to the same pods timed out. So
+    both directions are restricted, and the two policies are applied to both sides.
+
+    Egress needs the same allow-list as ingress rather than a blanket deny, or the nodes
+    lose DNS and never resolve the bootstrap service at all.
 
     The side label is one we set ourselves rather than a per-pod identifier like
     `statefulset.kubernetes.io/pod-name`: the CNI does not give per-pod-unique labels a
     security identity, so a policy selecting on one is accepted and then never enforced.
     """
+    peers = _not_far_side(namespace, far_side)
     return V1NetworkPolicy(
         api_version="networking.k8s.io/v1",
         kind="NetworkPolicy",
         metadata=V1ObjectMeta(name=name, namespace=namespace),
         spec=V1NetworkPolicySpec(
-            policy_types=["Ingress"],
+            policy_types=["Ingress", "Egress"],
             pod_selector=V1LabelSelector(match_labels={SIDE_LABEL: side}),
-            ingress=[
-                V1NetworkPolicyIngressRule(
-                    _from=[
-                        V1NetworkPolicyPeer(
-                            pod_selector=V1LabelSelector(
-                                match_expressions=[
-                                    V1LabelSelectorRequirement(
-                                        key=SIDE_LABEL, operator="NotIn", values=[far_side]
-                                    )
-                                ]
-                            )
-                        ),
-                        V1NetworkPolicyPeer(
-                            namespace_selector=V1LabelSelector(
-                                match_expressions=[
-                                    V1LabelSelectorRequirement(
-                                        key=NAMESPACE_NAME_LABEL,
-                                        operator="NotIn",
-                                        values=[namespace],
-                                    )
-                                ]
-                            )
-                        ),
-                    ]
-                )
-            ],
+            ingress=[V1NetworkPolicyIngressRule(_from=peers)],
+            egress=[V1NetworkPolicyEgressRule(to=peers)],
         ),
     )
 

--- a/src/deployments/experiments/libp2p/regression_scenarios.py
+++ b/src/deployments/experiments/libp2p/regression_scenarios.py
@@ -1,0 +1,202 @@
+"""Adverse-condition regression scenarios: degraded links, node churn, network partition.
+
+Each one reuses the nimlibp2p regression experiment and only changes what the network
+does to it, so delivery, latency and mesh health stay comparable to a plain run.
+"""
+
+import asyncio
+import logging
+from typing import List
+
+from kubernetes.client import (
+    V1LabelSelector,
+    V1LabelSelectorRequirement,
+    V1NetworkPolicy,
+    V1NetworkPolicyIngressRule,
+    V1NetworkPolicyPeer,
+    V1NetworkPolicySpec,
+    V1ObjectMeta,
+    V1StatefulSet,
+)
+from pydantic import NonNegativeFloat, NonNegativeInt
+
+from src.deployments.core.k8s_cleanup import delete_network_policy, delete_pod
+from src.deployments.core.k8s_rollout import wait_for_rollout
+from src.deployments.experiments.libp2p.nimlibp2p import ExpConfig, NimLibp2pExperiment
+from src.deployments.registry import experiment
+
+logger = logging.getLogger(__name__)
+
+
+class DegradedConfig(ExpConfig):
+    network_delay: NonNegativeInt = 200
+    network_jitter: NonNegativeInt = 50
+    network_loss_pct: NonNegativeFloat = 1
+
+
+@experiment(name="nimlibp2p-degraded")
+class DegradedNetwork(NimLibp2pExperiment):
+    """Regression run over a high-latency, jittery, lossy link.
+
+    Exercises the timeout, retransmit and gossip-repair paths that a clean link never
+    reaches. Latency is shaped, so read delivery and mesh health rather than absolute
+    latency, and compare against another run of the same profile.
+    """
+
+    config: DegradedConfig
+
+
+class ChurnConfig(ExpConfig):
+    churn_fraction: NonNegativeFloat = 0.2
+    """Share of relay nodes killed mid-run, taken from the highest ordinals."""
+    churn_at: NonNegativeInt = 30
+    """Seconds after the first message before killing."""
+    churn_rejoin_timeout: NonNegativeInt = 600
+
+
+def churn_targets(nodes: V1StatefulSet, fraction: float) -> List[str]:
+    """Highest-ordinal pod names to kill, deterministic so runs stay comparable."""
+    replicas = nodes.spec.replicas
+    count = int(replicas * fraction)
+    return [f"{nodes.metadata.name}-{i}" for i in range(replicas - count, replicas)]
+
+
+@experiment(name="nimlibp2p-churn")
+class NodeChurn(NimLibp2pExperiment):
+    """Regression run where a share of the nodes are killed mid-run and rejoin.
+
+    The StatefulSet recreates them, so they come back with the same names and have to
+    rediscover peers. Exercises peer management, reconnection and mesh repair
+    (prune/graft). Delivery should recover; messages published into the gap may not
+    reach the nodes that were down for it.
+    """
+
+    config: ChurnConfig
+
+    async def _mid_run(self, nodes: V1StatefulSet) -> None:
+        await asyncio.sleep(self.config.churn_at)
+
+        targets = churn_targets(nodes, self.config.churn_fraction)
+        if not targets:
+            logger.warning(f"churn_fraction {self.config.churn_fraction} kills no nodes")
+            return
+
+        self.log_event({"event": "churn_kill", "nodes": targets})
+        logger.info(f"Killing {len(targets)} nodes: {targets}")
+        for name in targets:
+            delete_pod(name, self.namespace)
+        self.log_event({"event": "churn_killed", "nodes": targets})
+
+        await wait_for_rollout(nodes, self.api_client, timeout=self.config.churn_rejoin_timeout)
+        self.log_event({"event": "churn_rejoined", "nodes": targets})
+
+
+class PartitionConfig(ExpConfig):
+    partition_fraction: NonNegativeFloat = 0.5
+    """Share of relay nodes on the smaller side of the split."""
+    partition_at: NonNegativeInt = 30
+    """Seconds after the first message before splitting."""
+    partition_duration: NonNegativeInt = 60
+    """Seconds to hold the split before healing."""
+
+
+POD_NAME_LABEL = "statefulset.kubernetes.io/pod-name"
+NAMESPACE_NAME_LABEL = "kubernetes.io/metadata.name"
+
+
+def partition_sides(nodes: V1StatefulSet, fraction: float) -> tuple[List[str], List[str]]:
+    replicas = nodes.spec.replicas
+    split = int(replicas * fraction)
+    names = [f"{nodes.metadata.name}-{i}" for i in range(replicas)]
+    return names[:split], names[split:]
+
+
+def build_partition_policy(
+    name: str, namespace: str, side: List[str], far_side: List[str]
+) -> V1NetworkPolicy:
+    """Deny `side` any ingress from `far_side`, leaving every other source alone.
+
+    Applied to both sides so the split is bidirectional. Only ingress is restricted, so
+    DNS and other egress still work. Pods without the ordinal label (publisher,
+    bootstrap) match `NotIn` and stay reachable, as do other namespaces, which keeps
+    metrics scraping alive through the split.
+    """
+    return V1NetworkPolicy(
+        api_version="networking.k8s.io/v1",
+        kind="NetworkPolicy",
+        metadata=V1ObjectMeta(name=name, namespace=namespace),
+        spec=V1NetworkPolicySpec(
+            policy_types=["Ingress"],
+            pod_selector=V1LabelSelector(
+                match_expressions=[
+                    V1LabelSelectorRequirement(key=POD_NAME_LABEL, operator="In", values=side)
+                ]
+            ),
+            ingress=[
+                V1NetworkPolicyIngressRule(
+                    _from=[
+                        V1NetworkPolicyPeer(
+                            pod_selector=V1LabelSelector(
+                                match_expressions=[
+                                    V1LabelSelectorRequirement(
+                                        key=POD_NAME_LABEL, operator="NotIn", values=far_side
+                                    )
+                                ]
+                            )
+                        ),
+                        V1NetworkPolicyPeer(
+                            namespace_selector=V1LabelSelector(
+                                match_expressions=[
+                                    V1LabelSelectorRequirement(
+                                        key=NAMESPACE_NAME_LABEL,
+                                        operator="NotIn",
+                                        values=[namespace],
+                                    )
+                                ]
+                            )
+                        ),
+                    ]
+                )
+            ],
+        ),
+    )
+
+
+@experiment(name="nimlibp2p-partition")
+class NetworkPartition(NimLibp2pExperiment):
+    """Regression run split into two halves mid-run, then healed.
+
+    Tests whether the mesh reconverges and delivery recovers once the split lifts.
+    Messages published while split should only reach the publisher's own side, so
+    expect a delivery dip over the split window and full delivery after it.
+    """
+
+    config: PartitionConfig
+
+    async def _mid_run(self, nodes: V1StatefulSet) -> None:
+        await asyncio.sleep(self.config.partition_at)
+
+        side_a, side_b = partition_sides(nodes, self.config.partition_fraction)
+        if not side_a or not side_b:
+            logger.warning(
+                f"partition_fraction {self.config.partition_fraction} leaves one side empty"
+            )
+            return
+
+        policies = [
+            build_partition_policy("partition-a", self.namespace, side_a, side_b),
+            build_partition_policy("partition-b", self.namespace, side_b, side_a),
+        ]
+        for policy in policies:
+            self.dump_yaml(policy, policy.metadata.name)
+
+        self.log_event({"event": "partition_apply", "side_a": side_a, "side_b": side_b})
+        await self.deploy(deployment=policies, wait_for_ready=False)
+        self.log_event("partition_applied")
+
+        await asyncio.sleep(self.config.partition_duration)
+
+        self.log_event("partition_heal")
+        for policy in policies:
+            delete_network_policy(policy.metadata.name, self.namespace)
+        self.log_event("partition_healed")

--- a/src/deployments/experiments/libp2p/regression_scenarios.py
+++ b/src/deployments/experiments/libp2p/regression_scenarios.py
@@ -19,7 +19,7 @@ from kubernetes.client import (
     V1ObjectMeta,
     V1StatefulSet,
 )
-from pydantic import NonNegativeFloat, NonNegativeInt, model_validator
+from pydantic import NonNegativeFloat, NonNegativeInt
 
 from src.deployments.core.k8s_cleanup import delete_network_policy
 from src.deployments.core.k8s_rollout import (
@@ -28,11 +28,7 @@ from src.deployments.core.k8s_rollout import (
     scale_statefulset,
     wait_for_rollout,
 )
-from src.deployments.experiments.libp2p.nimlibp2p import (
-    BOOTSTRAP_NAME,
-    ExpConfig,
-    NimLibp2pExperiment,
-)
+from src.deployments.experiments.libp2p.nimlibp2p import ExpConfig, NimLibp2pExperiment
 from src.deployments.registry import experiment
 
 logger = logging.getLogger(__name__)
@@ -134,25 +130,16 @@ class PartitionConfig(ExpConfig):
     need to get in front of, so the split is set up on existence instead."""
     delay_cold_start: NonNegativeFloat = 700
     """Long enough to cover pod creation, the start delay above, and each half meshing."""
-    bootstrap_nodes: NonNegativeInt = 2
-    """One anchor per side. A single shared anchor is itself a relaying mesh node, so it
-    bridges the split and every message reaches both halves regardless of the policies."""
-
-    @model_validator(mode="after")
-    def _check_bootstrap_per_side(self):
-        if self.bootstrap_nodes < 2:
-            raise ValueError("A partition run needs at least 2 bootstrap nodes, one per side")
-        return self
+    bootstrap_nodes: NonNegativeInt = 1
+    """One shared anchor, left unlabelled so both halves can reach it. It is the only
+    rendezvous through which they can learn each other's addresses, and it cannot carry
+    traffic between them: the bootstrap role returns before GossipSub is mounted, so it
+    answers DHT queries and nothing else. Give each half its own anchor and neither ever
+    hears of the other, which makes a merge impossible rather than merely slow."""
 
 
 SIDE_LABEL = "partition-side"
 NAMESPACE_NAME_LABEL = "kubernetes.io/metadata.name"
-
-
-def bootstrap_sides(count: int) -> tuple[List[str], List[str]]:
-    """Split the anchors between the two sides, alternating by ordinal."""
-    names = [f"{BOOTSTRAP_NAME}-{i}" for i in range(count)]
-    return names[0::2], names[1::2]
 
 
 def partition_sides(nodes: V1StatefulSet, fraction: float) -> tuple[List[str], List[str]]:
@@ -168,10 +155,10 @@ def build_partition_policy(name: str, namespace: str, side: str, far_side: str) 
     Applied to both sides so the split is bidirectional. Only ingress is restricted, so
     DNS and other egress still work. Unlabelled pods match `NotIn` and stay reachable from
     both sides, as do other namespaces, which keeps the publisher working and metrics
-    scraping alive across the split. That exemption is only safe for things that do not
-    relay: every gossipsub node, anchors included, has to be on one side or the other, or
-    it carries messages over the split and delivery stays at 100% however good the
-    policies are.
+    scraping alive across the split. The exemption is only safe for things that cannot
+    relay: the publisher is an HTTP client, and the anchor answers DHT queries without
+    ever mounting GossipSub, so neither can carry a message over the split. Anything that
+    does relay has to be on one side or the other.
 
     The side label is one we set ourselves rather than a per-pod identifier like
     `statefulset.kubernetes.io/pod-name`: the CNI does not give per-pod-unique labels a
@@ -254,10 +241,6 @@ class NetworkPartition(NimLibp2pExperiment):
             return
 
         await self._wait_for_pods_to_exist(nodes)
-        # Anchors are relaying mesh nodes too, so each side needs its own on its own side.
-        anchors_a, anchors_b = bootstrap_sides(self.config.bootstrap_nodes)
-        side_a, side_b = side_a + anchors_a, side_b + anchors_b
-
         labelled = label_pods(side_a, self.namespace, {SIDE_LABEL: "a"}, self.api_client)
         labelled += label_pods(side_b, self.namespace, {SIDE_LABEL: "b"}, self.api_client)
         self.log_event({"event": "partition_labelled", "pods": labelled})

--- a/src/deployments/experiments/libp2p/regression_scenarios.py
+++ b/src/deployments/experiments/libp2p/regression_scenarios.py
@@ -6,6 +6,7 @@ does to it, so delivery, latency and mesh health stay comparable to a plain run.
 
 import asyncio
 import logging
+import time
 from typing import List
 
 from kubernetes.client import (
@@ -21,7 +22,12 @@ from kubernetes.client import (
 from pydantic import NonNegativeFloat, NonNegativeInt
 
 from src.deployments.core.k8s_cleanup import delete_network_policy
-from src.deployments.core.k8s_rollout import scale_statefulset, wait_for_rollout
+from src.deployments.core.k8s_rollout import (
+    get_pods_for_statefulset,
+    label_pods,
+    scale_statefulset,
+    wait_for_rollout,
+)
 from src.deployments.experiments.libp2p.nimlibp2p import ExpConfig, NimLibp2pExperiment
 from src.deployments.registry import experiment
 
@@ -113,14 +119,20 @@ class NodeChurn(NimLibp2pExperiment):
 
 class PartitionConfig(ExpConfig):
     partition_fraction: NonNegativeFloat = 0.5
-    """Share of relay nodes on the smaller side of the split."""
-    partition_at: NonNegativeInt = 30
-    """Seconds after the first message before splitting."""
-    partition_duration: NonNegativeInt = 60
-    """Seconds to hold the split before healing."""
+    """Share of relay nodes on the first side of the split."""
+    heal_at: NonNegativeInt = 120
+    """Seconds after the first message before the two halves are allowed to meet."""
+    node_start_delay: NonNegativeInt = 240
+    """Must outlast pod creation: the halves are labelled once every pod exists, and a
+    node that dialled before its label was on would sit across the split and stay there."""
+    wait_nodes_ready: bool = False
+    """Readiness here means the node already has a healthy mesh, which is exactly what we
+    need to get in front of, so the split is set up on existence instead."""
+    delay_cold_start: NonNegativeFloat = 700
+    """Long enough to cover pod creation, the start delay above, and each half meshing."""
 
 
-POD_NAME_LABEL = "statefulset.kubernetes.io/pod-name"
+SIDE_LABEL = "partition-side"
 NAMESPACE_NAME_LABEL = "kubernetes.io/metadata.name"
 
 
@@ -131,15 +143,17 @@ def partition_sides(nodes: V1StatefulSet, fraction: float) -> tuple[List[str], L
     return names[:split], names[split:]
 
 
-def build_partition_policy(
-    name: str, namespace: str, side: List[str], far_side: List[str]
-) -> V1NetworkPolicy:
-    """Deny `side` any ingress from `far_side`, leaving every other source alone.
+def build_partition_policy(name: str, namespace: str, side: str, far_side: str) -> V1NetworkPolicy:
+    """Deny pods labelled `side` any ingress from pods labelled `far_side`.
 
     Applied to both sides so the split is bidirectional. Only ingress is restricted, so
-    DNS and other egress still work. Pods without the ordinal label (publisher,
-    bootstrap) match `NotIn` and stay reachable, as do other namespaces, which keeps
-    metrics scraping alive through the split.
+    DNS and other egress still work. Pods with no side label (publisher, bootstrap) match
+    `NotIn` and stay reachable, as do other namespaces, which keeps metrics scraping
+    alive across the split.
+
+    The side label is one we set ourselves rather than a per-pod identifier like
+    `statefulset.kubernetes.io/pod-name`: the CNI does not give per-pod-unique labels a
+    security identity, so a policy selecting on one is accepted and then never enforced.
     """
     return V1NetworkPolicy(
         api_version="networking.k8s.io/v1",
@@ -147,11 +161,7 @@ def build_partition_policy(
         metadata=V1ObjectMeta(name=name, namespace=namespace),
         spec=V1NetworkPolicySpec(
             policy_types=["Ingress"],
-            pod_selector=V1LabelSelector(
-                match_expressions=[
-                    V1LabelSelectorRequirement(key=POD_NAME_LABEL, operator="In", values=side)
-                ]
-            ),
+            pod_selector=V1LabelSelector(match_labels={SIDE_LABEL: side}),
             ingress=[
                 V1NetworkPolicyIngressRule(
                     _from=[
@@ -159,7 +169,7 @@ def build_partition_policy(
                             pod_selector=V1LabelSelector(
                                 match_expressions=[
                                     V1LabelSelectorRequirement(
-                                        key=POD_NAME_LABEL, operator="NotIn", values=far_side
+                                        key=SIDE_LABEL, operator="NotIn", values=[far_side]
                                     )
                                 ]
                             )
@@ -184,18 +194,36 @@ def build_partition_policy(
 
 @experiment(name="nimlibp2p-partition")
 class NetworkPartition(NimLibp2pExperiment):
-    """Regression run split into two halves mid-run, then healed.
+    """Regression run where the network forms as two halves that later meet.
 
-    Tests whether the mesh reconverges and delivery recovers once the split lifts.
-    Messages published while split should only reach the publisher's own side, so
-    expect a delivery dip over the split window and full delivery after it.
+    The split is in place before the nodes dial, so each half discovers and meshes only
+    within itself, and the two are allowed to meet part way through publishing. What it
+    measures is convergence: how fast the halves merge and whether delivery returns to
+    everyone once they do.
+
+    It is deliberately not a cut of a live mesh. A policy only decides whether a
+    connection may be opened, so adding one to an already-meshed network leaves every
+    existing link running and changes nothing (measured: delivery, latency and peer
+    counts all unmoved). Cutting live connections needs packet-level drops instead.
     """
 
     config: PartitionConfig
 
-    async def _mid_run(self, nodes: V1StatefulSet) -> None:
-        await asyncio.sleep(self.config.partition_at)
+    async def _wait_for_pods_to_exist(self, nodes: V1StatefulSet, timeout: int = 600) -> None:
+        """Existence, not readiness: a node is only Ready once it has a healthy mesh, and
+        the split has to be in place well before that."""
+        name, wanted = nodes.metadata.name, nodes.spec.replicas
+        deadline = time.monotonic() + timeout
+        while True:
+            found = len(list(get_pods_for_statefulset(name, self.namespace, self.api_client)))
+            if found >= wanted:
+                logger.info(f"All {wanted} pods exist; labelling the split")
+                return
+            if time.monotonic() > deadline:
+                raise TimeoutError(f"Only {found}/{wanted} pods exist after {timeout}s")
+            await asyncio.sleep(5)
 
+    async def _after_nodes(self, nodes: V1StatefulSet) -> None:
         side_a, side_b = partition_sides(nodes, self.config.partition_fraction)
         if not side_a or not side_b:
             logger.warning(
@@ -203,20 +231,29 @@ class NetworkPartition(NimLibp2pExperiment):
             )
             return
 
+        await self._wait_for_pods_to_exist(nodes)
+        labelled = label_pods(side_a, self.namespace, {SIDE_LABEL: "a"}, self.api_client)
+        labelled += label_pods(side_b, self.namespace, {SIDE_LABEL: "b"}, self.api_client)
+        self.log_event({"event": "partition_labelled", "pods": labelled})
+        if labelled != len(side_a) + len(side_b):
+            raise RuntimeError(
+                f"Labelled {labelled} of {len(side_a) + len(side_b)} pods; an unlabelled pod "
+                "is not covered by the split and would bridge the two halves."
+            )
+
         policies = [
-            build_partition_policy("partition-a", self.namespace, side_a, side_b),
-            build_partition_policy("partition-b", self.namespace, side_b, side_a),
+            build_partition_policy("partition-a", self.namespace, "a", "b"),
+            build_partition_policy("partition-b", self.namespace, "b", "a"),
         ]
         for policy in policies:
             self.dump_yaml(policy, policy.metadata.name)
-
-        self.log_event({"event": "partition_apply", "side_a": side_a, "side_b": side_b})
         await self.deploy(deployment=policies, wait_for_ready=False)
-        self.log_event("partition_applied")
+        self.log_event({"event": "partition_applied", "side_a": len(side_a), "side_b": len(side_b)})
 
-        await asyncio.sleep(self.config.partition_duration)
+    async def _mid_run(self, nodes: V1StatefulSet) -> None:
+        await asyncio.sleep(self.config.heal_at)
 
         self.log_event("partition_heal")
-        for policy in policies:
-            delete_network_policy(policy.metadata.name, self.namespace)
+        for name in ("partition-a", "partition-b"):
+            delete_network_policy(name, self.namespace)
         self.log_event("partition_healed")

--- a/src/deployments/experiments/libp2p/regression_scenarios.py
+++ b/src/deployments/experiments/libp2p/regression_scenarios.py
@@ -130,7 +130,13 @@ class PartitionConfig(ExpConfig):
     """Readiness here means the node already has a healthy mesh, which is exactly what we
     need to get in front of, so the split is set up on existence instead."""
     delay_cold_start: NonNegativeFloat = 700
-    """Long enough to cover pod creation, the start delay above, and each half meshing."""
+    """Long enough to cover pod creation, the start delay above, and each half meshing.
+
+    Meshing inside a half is slow: the shared anchor hands out far-side addresses too, so
+    roughly half of every DHT lookup is spent on peers that cannot be dialled. At 30 nodes
+    a half was still on one or two peers after four minutes of dialling and only reached a
+    healthy mesh after seven, so do not trim this to the point where publishing starts
+    before both halves have converged."""
     bootstrap_nodes: NonNegativeInt = 1
     """One shared anchor, left unlabelled so both halves can reach it. It is the only
     rendezvous through which they can learn each other's addresses, and it cannot carry

--- a/src/deployments/experiments/libp2p/regression_scenarios.py
+++ b/src/deployments/experiments/libp2p/regression_scenarios.py
@@ -1,8 +1,4 @@
-"""Adverse-condition regression scenarios: degraded links, node churn, network partition.
-
-Each one reuses the nimlibp2p regression experiment and only changes what the network
-does to it, so delivery, latency and mesh health stay comparable to a plain run.
-"""
+"""Adverse-condition regression scenarios: degraded links, node churn, network partition."""
 
 import asyncio
 import logging
@@ -43,28 +39,22 @@ class DegradedConfig(ExpConfig):
 
 @experiment(name="nimlibp2p-degraded")
 class DegradedNetwork(NimLibp2pExperiment):
-    """Regression run over a high-latency, jittery, lossy link.
-
-    Exercises the timeout, retransmit and gossip-repair paths that a clean link never
-    reaches. Latency is shaped, so read delivery and mesh health rather than absolute
-    latency, and compare against another run of the same profile.
-    """
+    """Regression run over a high-latency, jittery, lossy link."""
 
     config: DegradedConfig
 
 
 class ChurnConfig(ExpConfig):
     churn_fraction: NonNegativeFloat = 0.2
-    """Share of relay nodes taken down mid-run, from the highest ordinals."""
+    """Share taken down, from the highest ordinals."""
     churn_at: NonNegativeInt = 30
-    """Seconds after the first message before taking them down."""
+    """Seconds after the first message."""
     churn_downtime: NonNegativeInt = 60
-    """Seconds to stay down before rejoining."""
     churn_rejoin_timeout: NonNegativeInt = 600
 
 
 def churn_targets(nodes: V1StatefulSet, fraction: float) -> List[str]:
-    """Highest-ordinal pod names, which is what a scale-down removes."""
+    """Highest-ordinal pods, which is what a scale-down removes."""
     replicas = nodes.spec.replicas
     count = int(replicas * fraction)
     return [f"{nodes.metadata.name}-{i}" for i in range(replicas - count, replicas)]
@@ -74,24 +64,13 @@ def churn_targets(nodes: V1StatefulSet, fraction: float) -> List[str]:
 class NodeChurn(NimLibp2pExperiment):
     """Regression run where a share of the nodes drop out mid-run and rejoin.
 
-    Scaling the StatefulSet down holds them down for `churn_downtime`; deleting the
-    pods would not, because the controller replaces each one within seconds and the
-    network would only ever lose a trickle at a time. They come back with the same
-    names and have to rediscover peers, which exercises peer management, reconnection
-    and mesh repair. Delivery should recover; messages published into the gap may not
-    reach the nodes that were down for it.
+    Scale down rather than delete: a deleted pod is replaced within seconds.
     """
 
     config: ChurnConfig
 
     def _publishable_nodes(self) -> int:
-        """Keep the publisher off the churned nodes.
-
-        They come back on new addresses, and the publisher connects to the address it
-        looked up, so publishing to one that has just been replaced hangs until the
-        request times out. That is our harness tripping over the scenario rather than
-        anything about the protocol, and it starves the run of published messages.
-        """
+        """Churned nodes return on new addresses; publishing to a stale one hangs."""
         churned = int(self.config.num_relay_nodes * self.config.churn_fraction)
         return self.config.num_relay_nodes - churned
 
@@ -120,29 +99,19 @@ class NodeChurn(NimLibp2pExperiment):
 
 class PartitionConfig(ExpConfig):
     partition_fraction: NonNegativeFloat = 0.5
-    """Share of relay nodes on the first side of the split."""
+    """Share of relay nodes on the first side."""
     heal_at: NonNegativeInt = 120
-    """Seconds after the first message before the two halves are allowed to meet."""
+    """Seconds after the first message before the halves may meet."""
     node_start_delay: NonNegativeInt = 240
-    """Must outlast pod creation: the halves are labelled once every pod exists, and a
-    node that dialled before its label was on would sit across the split and stay there."""
+    """Must outlast pod creation, or a node dials before its side label is on."""
     wait_nodes_ready: bool = False
-    """Readiness here means the node already has a healthy mesh, which is exactly what we
-    need to get in front of, so the split is set up on existence instead."""
+    """Ready means already meshed, which the split has to precede."""
     delay_cold_start: NonNegativeFloat = 700
-    """Long enough to cover pod creation, the start delay above, and each half meshing.
-
-    Meshing inside a half is slow: the shared anchor hands out far-side addresses too, so
-    roughly half of every DHT lookup is spent on peers that cannot be dialled. At 30 nodes
-    a half was still on one or two peers after four minutes of dialling and only reached a
-    healthy mesh after seven, so do not trim this to the point where publishing starts
-    before both halves have converged."""
+    """Must cover each half meshing, slow behind a split: 7 min at 30 nodes. Publishing
+    before both halves converge invalidates the run."""
     bootstrap_nodes: NonNegativeInt = 1
-    """One shared anchor, left unlabelled so both halves can reach it. It is the only
-    rendezvous through which they can learn each other's addresses, and it cannot carry
-    traffic between them: the bootstrap role returns before GossipSub is mounted, so it
-    answers DHT queries and nothing else. Give each half its own anchor and neither ever
-    hears of the other, which makes a merge impossible rather than merely slow."""
+    """One shared unlabelled anchor, the only way the halves learn each other's addresses.
+    It cannot relay: the bootstrap role returns before GossipSub is mounted."""
 
 
 SIDE_LABEL = "partition-side"
@@ -157,9 +126,8 @@ def partition_sides(nodes: V1StatefulSet, fraction: float) -> tuple[List[str], L
 
 
 def _not_far_side(namespace: str, far_side: str) -> List[V1NetworkPolicyPeer]:
-    """Everything except the far side: same-namespace pods that are not on it, plus any
-    other namespace. Unlabelled pods match `NotIn`, so the publisher stays reachable, and
-    allowing other namespaces keeps DNS and metrics scraping working through the split."""
+    """Unlabelled pods match `NotIn` so the publisher stays reachable; other namespaces
+    keep DNS and metrics working."""
     return [
         V1NetworkPolicyPeer(
             pod_selector=V1LabelSelector(
@@ -181,20 +149,11 @@ def _not_far_side(namespace: str, far_side: str) -> List[V1NetworkPolicyPeer]:
 
 
 def build_partition_policy(name: str, namespace: str, side: str, far_side: str) -> V1NetworkPolicy:
-    """Cut pods labelled `side` off from pods labelled `far_side`, both directions.
+    """Cut `side` off from `far_side`, both directions.
 
-    Restricting ingress alone is not enough. It stops a TCP handshake, because the reply
-    never comes back, which makes a TCP probe look reassuringly blocked. quic is UDP and
-    goes straight through: with an ingress-only policy the halves kept delivering to each
-    other in single-digit milliseconds while a TCP probe to the same pods timed out. So
-    both directions are restricted, and the two policies are applied to both sides.
-
-    Egress needs the same allow-list as ingress rather than a blanket deny, or the nodes
-    lose DNS and never resolve the bootstrap service at all.
-
-    The side label is one we set ourselves rather than a per-pod identifier like
-    `statefulset.kubernetes.io/pod-name`: the CNI does not give per-pod-unique labels a
-    security identity, so a policy selecting on one is accepted and then never enforced.
+    Ingress alone only stops TCP; quic is UDP and goes straight through. Egress reuses the
+    ingress allow-list, or the nodes lose DNS. The label must be one we set: the CNI does
+    not enforce policies selecting on per-pod-unique labels.
     """
     peers = _not_far_side(namespace, far_side)
     return V1NetworkPolicy(
@@ -214,22 +173,13 @@ def build_partition_policy(name: str, namespace: str, side: str, far_side: str) 
 class NetworkPartition(NimLibp2pExperiment):
     """Regression run where the network forms as two halves that later meet.
 
-    The split is in place before the nodes dial, so each half discovers and meshes only
-    within itself, and the two are allowed to meet part way through publishing. What it
-    measures is convergence: how fast the halves merge and whether delivery returns to
-    everyone once they do.
-
-    It is deliberately not a cut of a live mesh. A policy only decides whether a
-    connection may be opened, so adding one to an already-meshed network leaves every
-    existing link running and changes nothing (measured: delivery, latency and peer
-    counts all unmoved). Cutting live connections needs packet-level drops instead.
+    Measures convergence, not a live cut: a policy only gates opening a connection.
     """
 
     config: PartitionConfig
 
     async def _wait_for_pods_to_exist(self, nodes: V1StatefulSet, timeout: int = 600) -> None:
-        """Existence, not readiness: a node is only Ready once it has a healthy mesh, and
-        the split has to be in place well before that."""
+        """Existence, not readiness: Ready already means meshed."""
         name, wanted = nodes.metadata.name, nodes.spec.replicas
         deadline = time.monotonic() + timeout
         while True:

--- a/src/deployments/experiments/libp2p/shadow_gossipsub.py
+++ b/src/deployments/experiments/libp2p/shadow_gossipsub.py
@@ -48,6 +48,7 @@ class ExpConfig(BaseModel):
     start_jitter_ms: NonNegativeInt = 0
     latency_ms: Optional[NonNegativeInt] = None
     bandwidth_mbit: Optional[PositiveInt] = None
+    loss_pct: NonNegativeFloat = 0
     # Peers per /24; 1 = every peer on its own subnet.
     hosts_per_subnet: PositiveInt = 1
     # Job-pod resources, sized for ~10 peers; bump for bigger sims.
@@ -100,6 +101,7 @@ class ShadowGossipsubExperiment(BaseExperiment[ExpConfig]):
             start_jitter_ms=cfg.start_jitter_ms,
             latency_ms=cfg.latency_ms,
             bandwidth_mbit=cfg.bandwidth_mbit,
+            loss_pct=cfg.loss_pct,
             hosts_per_subnet=cfg.hosts_per_subnet,
         )
         publisher_config = render_publisher_config(

--- a/src/deployments/shadow/builders.py
+++ b/src/deployments/shadow/builders.py
@@ -172,7 +172,7 @@ _SWITCH_BANDWIDTH_MBIT = 1000
 _SWITCH_LATENCY_MS = 0
 
 
-def _wan_gml(latency_ms: int, bandwidth_mbit: int) -> LiteralScalarString:
+def _wan_gml(latency_ms: int, bandwidth_mbit: int, loss_pct: float = 0.0) -> LiteralScalarString:
     """A one-node GML graph with a self-loop, so every host (all on network_node_id 0)
     sees `latency_ms` one-way delay and `bandwidth_mbit` up/down. Shadow's GML parser
     wants multi-line GML (one attribute per line); return it as a YAML literal block so
@@ -188,6 +188,7 @@ def _wan_gml(latency_ms: int, bandwidth_mbit: int) -> LiteralScalarString:
     source 0
     target 0
     latency "{latency_ms} ms"
+    packet_loss {loss_pct / 100}
   ]
 ]
 """
@@ -211,6 +212,7 @@ def render_shadow_yaml(
     start_jitter_ms: int = 0,
     latency_ms: Optional[int] = None,
     bandwidth_mbit: Optional[int] = None,
+    loss_pct: float = 0.0,
     hosts_per_subnet: int = 1,
     requester_app_path: str = _REQUESTER_APP_PATH,
 ) -> dict:
@@ -248,18 +250,21 @@ def render_shadow_yaml(
         )
     hosts["publisher"] = _publisher_host(publisher_start_s, requester_app_path)
 
-    if latency_ms is None and bandwidth_mbit is None:
+    if latency_ms is None and bandwidth_mbit is None and not loss_pct:
         graph = {"type": "1_gbit_switch"}
     else:
         if latency_ms is not None and latency_ms < 0:
             raise ValueError(f"latency_ms must be >= 0, got {latency_ms}")
         if bandwidth_mbit is not None and bandwidth_mbit <= 0:
             raise ValueError(f"bandwidth_mbit must be > 0, got {bandwidth_mbit}")
+        if not 0 <= loss_pct <= 100:
+            raise ValueError(f"loss_pct must be 0..100, got {loss_pct}")
         graph = {
             "type": "gml",
             "inline": _wan_gml(
                 _SWITCH_LATENCY_MS if latency_ms is None else latency_ms,
                 _SWITCH_BANDWIDTH_MBIT if bandwidth_mbit is None else bandwidth_mbit,
+                loss_pct,
             ),
         }
 


### PR DESCRIPTION
Three adverse-condition variants of the nimlibp2p regression run: shaped links (netem gains a loss knob), killing a share of nodes mid-run, and splitting the network in two then healing it. 

All 3 scenarios are tested at scale.