### PR TITLE
Stop dropping deliveries whose measured delay is negative

### DIFF
--- a/src/analysis/mesh_analysis/readers/tracers/nimlibp2p_tracer.py
+++ b/src/analysis/mesh_analysis/readers/tracers/nimlibp2p_tracer.py
@@ -64,8 +64,30 @@ class Nimlibp2pTracer(MessageTracer):
         df["sentAt"] = pd.to_datetime(df["sentAt"], unit="ns")
         df["timestamp"] = df["timestamp"].astype(np.uint64)
         df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ns")
+        self._warn_about_negative_delays(df)
 
         return df
+
+    @staticmethod
+    def _warn_about_negative_delays(df: pd.DataFrame) -> int:
+        """Report deliveries whose measured delay is negative. Returns how many.
+
+        delayMs is the receiver's clock minus the sender's, read on two machines, so it
+        goes negative when the receiver's host clock trails the sender's by more than the
+        transit time. The delivery is real; the latency is not measurable on that pair.
+        """
+        delays = pd.to_numeric(df["delayMs"], errors="coerce")
+        negative = delays < 0
+        count = int(negative.sum())
+        if not count:
+            return 0
+
+        logger.warning(
+            f"{count} of {len(df)} deliveries ({count / len(df):.2%}) have a negative measured "
+            f"delay, down to {delays[negative].min()}ms: the receiving hosts' clocks trail the "
+            f"senders'. The deliveries are counted, but their latency is not trustworthy."
+        )
+        return count
 
     def _trace_sent_in_logs(self, parsed_logs: List) -> pd.DataFrame:
         columns = ["msgId", "timestamp"]

--- a/src/analysis/mesh_analysis/readers/tracers/nimlibp2p_tracer.py
+++ b/src/analysis/mesh_analysis/readers/tracers/nimlibp2p_tracer.py
@@ -27,7 +27,10 @@ class Nimlibp2pTracer(MessageTracer):
                 "received",
                 trace_pairs=[
                     TracePair(
-                        regex=r"Received message.*?msgId=([\w*]+).*?sentAt=([\w*]+).*?current=([\w*]+).*?delayMs=([\w*]+)",
+                        # delayMs goes negative when the sender's clock is ahead of the
+                        # receiver's, so the sign has to be part of the match: `\w` alone
+                        # drops those deliveries and under-reports delivery.
+                        regex=r"Received message.*?msgId=([\w*]+).*?sentAt=([\w*]+).*?current=([\w*]+).*?delayMs=(-?[\w*]+)",
                         convert=self._trace_received_in_logs,
                     ),
                 ],

--- a/src/analysis/mesh_analysis/readers/tracers/tests/test_nimlibp2p_tracer.py
+++ b/src/analysis/mesh_analysis/readers/tracers/tests/test_nimlibp2p_tracer.py
@@ -1,3 +1,4 @@
+import logging
 import re
 
 from src.analysis.mesh_analysis.readers.tracers.nimlibp2p_tracer import Nimlibp2pTracer
@@ -40,3 +41,30 @@ def test_negative_delay_survives_conversion():
     )
     assert len(df) == 1
     assert df.iloc[0]["delayMs"] == "-1"
+
+
+class TestNegativeDelayWarning:
+    """Negative delays are kept, but they are not silent: the clocks were skewed."""
+
+    def _rows(self, delays):
+        return [
+            [str(i), "1754000000000000000", "1754000000100000000", d] for i, d in enumerate(delays)
+        ]
+
+    def test_a_negative_delay_is_warned_about(self, caplog):
+        tracer = Nimlibp2pTracer().with_extra_fields([])
+        with caplog.at_level(logging.WARNING):
+            tracer._trace_received_in_logs(self._rows(["10", "-3", "7", "-11"]))
+        assert "2 of 4 deliveries (50.00%)" in caplog.text
+        assert "-11ms" in caplog.text
+
+    def test_clean_timing_does_not_warn(self, caplog):
+        tracer = Nimlibp2pTracer().with_extra_fields([])
+        with caplog.at_level(logging.WARNING):
+            tracer._trace_received_in_logs(self._rows(["10", "7"]))
+        assert not caplog.records
+
+    def test_the_deliveries_are_still_kept(self):
+        tracer = Nimlibp2pTracer().with_extra_fields([])
+        df = tracer._trace_received_in_logs(self._rows(["10", "-3"]))
+        assert len(df) == 2

--- a/src/analysis/mesh_analysis/readers/tracers/tests/test_nimlibp2p_tracer.py
+++ b/src/analysis/mesh_analysis/readers/tracers/tests/test_nimlibp2p_tracer.py
@@ -1,0 +1,42 @@
+import re
+
+from src.analysis.mesh_analysis.readers.tracers.nimlibp2p_tracer import Nimlibp2pTracer
+
+POSITIVE = (
+    "INF 2026-08-05 01:15:19.582+00:00 Received message   tid=1 "
+    "msgId=13647046878266911 sentAt=1785892519584947712 current=1785892519585947712 delayMs=1"
+)
+NEGATIVE = (
+    "INF 2026-08-05 01:15:19.582+00:00 Received message   tid=1 "
+    "msgId=2759438560592407784 sentAt=1785892519584947712 current=1785892519583493632 delayMs=-1"
+)
+
+
+def _received_regex():
+    tracer = Nimlibp2pTracer().with_received_pattern_group()
+    (group,) = [p for p in tracer.patterns if p.name == "received"]
+    (pair,) = group.trace_pairs
+    return re.compile(pair.regex)
+
+
+def test_received_line_is_parsed():
+    m = _received_regex().search(POSITIVE)
+    assert m.groups() == ("13647046878266911", "1785892519584947712", "1785892519585947712", "1")
+
+
+def test_negative_delay_is_parsed():
+    """A sender clock ahead of the receiver's yields delayMs=-N; dropping those under-reports
+    delivery, and it lands on whichever hosts are skewed."""
+    m = _received_regex().search(NEGATIVE)
+    assert m is not None, "negative delayMs must still match, or the delivery is lost"
+    assert m.group(1) == "2759438560592407784"
+    assert m.group(4) == "-1"
+
+
+def test_negative_delay_survives_conversion():
+    tracer = Nimlibp2pTracer().with_received_pattern_group()
+    df = tracer._trace_received_in_logs(
+        [("2759438560592407784", "1785892519584947712", "1785892519583493632", "-1")]
+    )
+    assert len(df) == 1
+    assert df.iloc[0]["delayMs"] == "-1"


### PR DESCRIPTION
Sometimes the delivery delay is shown as -1 or -2, because of the clock skew between the servers. 

`delayMs` was matched with `[\w*]+`, which excludes the minus sign, so deliveries recorded with a negative delay were silently discarded. Affects nimlibp2p and gossipsub-priority-queues, cluster and Shadow, since both use `Nimlibp2pTracer`.