### PR TITLE
Scrape the settled window for Shadow runs

### DIFF
--- a/src/analysis/metrics/shadow_metrics.py
+++ b/src/analysis/metrics/shadow_metrics.py
@@ -95,6 +95,23 @@ class EphemeralVictoriaMetrics:
         logger.info(f"Removed ephemeral VictoriaMetrics `{self._name}`")
 
 
+STABLE_OFFSET_S = 180  # same offsets as the bridge's `stable` interval
+STABLE_TAIL_S = 30
+RECEIVED_METRIC = "libp2p_gossipsub_received_total"
+
+
+def first_delivery_snapshot(per_peer: List[tuple]) -> Optional[int]:
+    """Index of the snapshot where nodes first receive a message."""
+    for index in range(max((len(s) for _, s in per_peer), default=0)):
+        for _, snaps in per_peer:
+            if index >= len(snaps):
+                continue
+            for line in snaps[index].splitlines():
+                if line.startswith(RECEIVED_METRIC) and float(line.split()[-1]) > 0:
+                    return index
+    return None
+
+
 def import_shadow_metrics(
     *,
     hosts_dir: Path,
@@ -148,11 +165,13 @@ def import_shadow_metrics(
             posted += 1
 
     requests.get(f"{vm_url}/internal/force_flush", timeout=15)  # make the import queryable now
+    first = first_delivery_snapshot(per_peer)
     summary = {
         "peers": len(per_peer),
         "snapshots_posted": posted,
         "start_epoch_s": start_epoch_s,
         "last_epoch_s": last_epoch_s,
+        "first_delivery_epoch_s": None if first is None else start_epoch_s + first * interval_s,
     }
     logger.info(f"Imported Shadow metrics: {summary}")
     return summary
@@ -174,8 +193,17 @@ def scrape_run_metrics(
         info = import_shadow_metrics(
             hosts_dir=hosts, vm_url=vm.url, namespace=namespace, interval_s=interval_s
         )
-        start_dt = datetime.fromtimestamp(info["start_epoch_s"], tz=timezone.utc)
-        end_dt = datetime.fromtimestamp(info["last_epoch_s"], tz=timezone.utc)
+        first_delivery = info.get("first_delivery_epoch_s")
+        if first_delivery is None:
+            logger.warning("No delivery found in the Shadow metrics; scraping the whole run")
+            start_epoch, end_epoch = info["start_epoch_s"], info["last_epoch_s"]
+        else:
+            start_epoch = first_delivery + STABLE_OFFSET_S
+            end_epoch = info["last_epoch_s"] - STABLE_TAIL_S
+            if start_epoch >= end_epoch:
+                raise ValueError(f"Settled window is empty: {start_epoch} >= {end_epoch}")
+        start_dt = datetime.fromtimestamp(start_epoch, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end_epoch, tz=timezone.utc)
         config = (
             Nimlibp2pScrapeBuilder(
                 namespace=namespace,

--- a/src/analysis/metrics/shadow_metrics.py
+++ b/src/analysis/metrics/shadow_metrics.py
@@ -112,6 +112,17 @@ def first_delivery_snapshot(per_peer: List[tuple]) -> Optional[int]:
     return None
 
 
+def settled_window(info: dict) -> tuple:
+    """Settled part of the run, or all of it when the run is too short to have one."""
+    first = info.get("first_delivery_epoch_s")
+    if first is not None:
+        start, end = first + STABLE_OFFSET_S, info["last_epoch_s"] - STABLE_TAIL_S
+        if start < end:
+            return start, end
+    logger.warning("Run too short to have a settled window; scraping all of it")
+    return info["start_epoch_s"], info["last_epoch_s"]
+
+
 def import_shadow_metrics(
     *,
     hosts_dir: Path,
@@ -193,15 +204,7 @@ def scrape_run_metrics(
         info = import_shadow_metrics(
             hosts_dir=hosts, vm_url=vm.url, namespace=namespace, interval_s=interval_s
         )
-        first_delivery = info.get("first_delivery_epoch_s")
-        if first_delivery is None:
-            logger.warning("No delivery found in the Shadow metrics; scraping the whole run")
-            start_epoch, end_epoch = info["start_epoch_s"], info["last_epoch_s"]
-        else:
-            start_epoch = first_delivery + STABLE_OFFSET_S
-            end_epoch = info["last_epoch_s"] - STABLE_TAIL_S
-            if start_epoch >= end_epoch:
-                raise ValueError(f"Settled window is empty: {start_epoch} >= {end_epoch}")
+        start_epoch, end_epoch = settled_window(info)
         start_dt = datetime.fromtimestamp(start_epoch, tz=timezone.utc)
         end_dt = datetime.fromtimestamp(end_epoch, tz=timezone.utc)
         config = (

--- a/src/analysis/metrics/shadow_metrics.py
+++ b/src/analysis/metrics/shadow_metrics.py
@@ -97,7 +97,7 @@ class EphemeralVictoriaMetrics:
 
 STABLE_OFFSET_S = 180  # same offsets as the bridge's `stable` interval
 STABLE_TAIL_S = 30
-RECEIVED_METRIC = "libp2p_gossipsub_received_total"
+RECEIVED_METRIC = "libp2p_gossipsub_received_total"  # no topic label, assumes one topic
 
 
 def first_delivery_snapshot(per_peer: List[tuple]) -> Optional[int]:

--- a/src/analysis/metrics/shadow_metrics.py
+++ b/src/analysis/metrics/shadow_metrics.py
@@ -14,6 +14,7 @@ import requests
 from src.analysis.metrics.libp2p import gossipsub_summary
 from src.analysis.metrics.libp2p.scrape import Nimlibp2pScrapeBuilder
 from src.analysis.metrics.scrapper import Scrapper
+from src.deployments.libp2p.bridge import STABLE_END_SHIFT, STABLE_START_SHIFT
 
 logger = logging.getLogger(__name__)
 
@@ -95,8 +96,6 @@ class EphemeralVictoriaMetrics:
         logger.info(f"Removed ephemeral VictoriaMetrics `{self._name}`")
 
 
-STABLE_OFFSET_S = 180  # same offsets as the bridge's `stable` interval
-STABLE_TAIL_S = 30
 RECEIVED_METRIC = "libp2p_gossipsub_received_total"  # no topic label, assumes one topic
 
 
@@ -113,10 +112,16 @@ def first_delivery_snapshot(per_peer: List[tuple]) -> Optional[int]:
 
 
 def settled_window(info: dict) -> tuple:
-    """Settled part of the run, or all of it when the run is too short to have one."""
+    """Settled part of the run, or all of it when the run is too short to have one.
+
+    Shifts come from the bridge's `stable` window so the two platforms cannot drift apart.
+    Shadow anchors the start on the first delivery instead of `start_messages`, and the end
+    on the last sample instead of `publisher_messages_finished`, because it logs neither.
+    """
     first = info.get("first_delivery_epoch_s")
     if first is not None:
-        start, end = first + STABLE_OFFSET_S, info["last_epoch_s"] - STABLE_TAIL_S
+        start = first + STABLE_START_SHIFT.total_seconds()
+        end = info["last_epoch_s"] + STABLE_END_SHIFT.total_seconds()
         if start < end:
             return start, end
     logger.warning("Run too short to have a settled window; scraping all of it")

--- a/src/analysis/metrics/tests/test_shadow_window.py
+++ b/src/analysis/metrics/tests/test_shadow_window.py
@@ -1,4 +1,8 @@
-from src.analysis.metrics.shadow_metrics import RECEIVED_METRIC, first_delivery_snapshot
+from src.analysis.metrics.shadow_metrics import (
+    RECEIVED_METRIC,
+    first_delivery_snapshot,
+    settled_window,
+)
 
 
 def _snap(received: float) -> str:
@@ -32,3 +36,20 @@ def test_handles_peers_with_different_snapshot_counts():
 
 def test_no_peers_at_all():
     assert first_delivery_snapshot([]) is None
+
+
+def _info(first, start=1000, last=1180):
+    return {"start_epoch_s": start, "last_epoch_s": last, "first_delivery_epoch_s": first}
+
+
+def test_settled_window_when_the_run_is_long_enough():
+    assert settled_window(_info(1100, last=1600)) == (1280, 1570)
+
+
+def test_falls_back_when_the_default_config_is_too_short():
+    # publisher at 90s, sim stops at 180s: the settled window would end before it starts.
+    assert settled_window(_info(1090)) == (1000, 1180)
+
+
+def test_falls_back_when_nothing_was_delivered():
+    assert settled_window(_info(None)) == (1000, 1180)

--- a/src/analysis/metrics/tests/test_shadow_window.py
+++ b/src/analysis/metrics/tests/test_shadow_window.py
@@ -53,3 +53,24 @@ def test_falls_back_when_the_default_config_is_too_short():
 
 def test_falls_back_when_nothing_was_delivered():
     assert settled_window(_info(None)) == (1000, 1180)
+
+
+def test_settled_window_uses_the_bridge_shifts():
+    """The shifts are the bridge's, not a copy: a change there has to move Shadow too."""
+    from datetime import timedelta
+
+    from src.analysis.metrics.shadow_metrics import settled_window
+    from src.deployments.libp2p.bridge import STABLE_END_SHIFT, STABLE_START_SHIFT
+
+    first, last = 1_000, 10_000
+    start, end = settled_window(
+        {"first_delivery_epoch_s": first, "last_epoch_s": last, "start_epoch_s": 0}
+    )
+    assert start == first + STABLE_START_SHIFT.total_seconds()
+    assert end == last + STABLE_END_SHIFT.total_seconds()
+    # and those shifts are the ones the cluster's stable window actually uses
+    from src.deployments.libp2p.bridge import Bridge
+
+    stable = next(w for w in Bridge().event_windows() if w.key == "stable")
+    assert stable.start.time_shift == STABLE_START_SHIFT == timedelta(minutes=3)
+    assert stable.end.time_shift == STABLE_END_SHIFT == timedelta(seconds=-30)

--- a/src/analysis/metrics/tests/test_shadow_window.py
+++ b/src/analysis/metrics/tests/test_shadow_window.py
@@ -1,0 +1,34 @@
+from src.analysis.metrics.shadow_metrics import RECEIVED_METRIC, first_delivery_snapshot
+
+
+def _snap(received: float) -> str:
+    return f"# HELP process_info CPU and memory usage\nlibp2p_peers 42.0\n{RECEIVED_METRIC} {received}\n"
+
+
+def _peer(counts):
+    return ("pod-0", [_snap(c) for c in counts])
+
+
+def test_finds_the_snapshot_where_delivery_starts():
+    assert first_delivery_snapshot([_peer([0, 0, 0, 5, 9])]) == 3
+
+
+def test_takes_the_earliest_peer_to_receive():
+    peers = [
+        ("pod-0", [_snap(c) for c in [0, 0, 0, 4]]),
+        ("pod-1", [_snap(c) for c in [0, 2, 3, 4]]),
+    ]
+    assert first_delivery_snapshot(peers) == 1
+
+
+def test_none_when_nothing_is_ever_delivered():
+    assert first_delivery_snapshot([_peer([0, 0, 0])]) is None
+
+
+def test_handles_peers_with_different_snapshot_counts():
+    peers = [("pod-0", [_snap(0)]), ("pod-1", [_snap(c) for c in [0, 0, 7]])]
+    assert first_delivery_snapshot(peers) == 2
+
+
+def test_no_peers_at_all():
+    assert first_delivery_snapshot([]) is None

--- a/src/deployments/libp2p/bridge.py
+++ b/src/deployments/libp2p/bridge.py
@@ -9,6 +9,11 @@ from src.deployments.libp2p.builders.helpers import LIBP2P_CONTAINER_NAME
 
 logger = logging.getLogger(__name__)
 
+STABLE_START_SHIFT = timedelta(minutes=3)
+"""How long after the first message the mesh is treated as settled."""
+STABLE_END_SHIFT = timedelta(seconds=-30)
+"""How far before publishing ends to stop, so teardown stays out of the window."""
+
 
 class Bridge(event_window_bridge.EventWindowBridge):
     interval: Literal["complete", "stable"] = "complete"
@@ -31,9 +36,7 @@ class Bridge(event_window_bridge.EventWindowBridge):
             ),
             event_window_bridge.EventWindow(
                 key="stable",
-                start=event_window_bridge.EventBound("start_messages", timedelta(minutes=3)),
-                end=event_window_bridge.EventBound(
-                    "publisher_messages_finished", timedelta(seconds=-30)
-                ),
+                start=event_window_bridge.EventBound("start_messages", STABLE_START_SHIFT),
+                end=event_window_bridge.EventBound("publisher_messages_finished", STABLE_END_SHIFT),
             ),
         ]


### PR DESCRIPTION
Cluster runs scrape the `stable` window, but Shadow logs none of the events it keys on, so it scraped the whole run and the gauges carried mesh formation and teardown. Anchors on the received counter leaving zero instead, with the same offsets.

Replaces #371 due to an accidental close, the review discussion on #371 still applies.