### PR TITLE
Post-run analysis for the three regression scenarios

### DIFF
--- a/src/analysis/post_run/churn.py
+++ b/src/analysis/post_run/churn.py
@@ -1,0 +1,146 @@
+"""Post-run analysis for the node-churn scenario."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple
+
+import pandas as pd
+
+from src.analysis.post_run.scenario_common import (
+    POD_COLUMN,
+    Row,
+    load_mesh_peers,
+    mesh_peers_row,
+    pct,
+    prepare,
+    write_table,
+)
+from src.deployments.core.event_log import find_events
+
+if TYPE_CHECKING:
+    from src.deployments.experiments.libp2p.nimlibp2p import NimLibp2pExperiment
+
+logger = logging.getLogger(__name__)
+
+
+def longest_run(mask: Sequence[bool]) -> Tuple[Optional[int], Optional[int], int]:
+    """Start, end and length of the longest True stretch."""
+    best = (None, None, 0)
+    start = None
+    for i, flag in enumerate(list(mask) + [False]):
+        if flag and start is None:
+            start = i
+        elif not flag and start is not None:
+            if i - start > best[2]:
+                best = (start, i - 1, i - start)
+            start = None
+    return best
+
+
+def churn_outages(df: pd.DataFrame, churned: Sequence[str]) -> pd.DataFrame:
+    """Per churned node: the outage read off its own miss run, and what it missed after it.
+
+    Pods keep serving past the scale-down and are back before the rollout finishes, so the
+    scale-down window is not a node's outage; the stretch it missed is.
+    """
+    order = df.drop_duplicates("msgId").sort_values("sent")
+    times = order["sent"].to_numpy()
+    present = (
+        df[df[POD_COLUMN].isin(set(churned))]
+        .pivot_table(index=POD_COLUMN, columns="msgId", values="ordinal", aggfunc="size")
+        .reindex(columns=order["msgId"])
+        .notna()
+    )
+
+    rows = []
+    for pod, got in present.iterrows():
+        missed = ~got.to_numpy()
+        start, end, length = longest_run(missed)
+        after = [i for i, flag in enumerate(missed) if flag and end is not None and i > end]
+        rows.append(
+            {
+                POD_COLUMN: pod,
+                "missed": int(missed.sum()),
+                "outage_messages": length,
+                "outage_s": (
+                    (times[end] - times[start]) / pd.Timedelta(seconds=1) if length else 0.0
+                ),
+                "missed_after": len(after),
+                # How long the node keeps dropping messages once its main outage has ended.
+                "recovery_tail_s": (
+                    (times[after[-1]] - times[end]) / pd.Timedelta(seconds=1) if after else 0.0
+                ),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def churn_table(
+    df: pd.DataFrame,
+    churned: Sequence[str],
+    num_messages: int,
+    num_nodes: int,
+    mesh: Optional[pd.DataFrame] = None,
+) -> List[Row]:
+    """Below 100%, with every miss inside the node's own outage."""
+    is_churned = df[POD_COLUMN].isin(set(churned))
+    survivors = num_nodes - len(set(churned))
+    per_survivor = df[~is_churned].groupby(POD_COLUMN)["msgId"].nunique()
+    out = churn_outages(df, churned)
+    ragged = int((out["missed_after"] > 0).sum())
+
+    return [
+        (
+            "delivery, whole run",
+            "below 100%, and fully explained by the churn",
+            pct(len(df), num_messages * num_nodes),
+        ),
+        (
+            "delivery, nodes that stayed up",
+            "100%",
+            f"{per_survivor.min() if len(per_survivor) else 0} to "
+            f"{per_survivor.max() if len(per_survivor) else 0} of {num_messages}, "
+            f"on {len(per_survivor)} of {survivors} nodes",
+        ),
+        (
+            "delivery, churned nodes",
+            "one contiguous gap, nothing missed either side of it",
+            f"missed {out['missed'].mean():.1f} of {num_messages} on average, "
+            f"{out['outage_messages'].mean():.1f} in one stretch",
+        ),
+        (
+            "clean recovery",
+            "no misses once the node is back",
+            f"{ragged} of {len(out)} nodes keep dropping after their outage, "
+            f"worst {out['missed_after'].max()} messages over "
+            f"{out['recovery_tail_s'].max():.0f}s",
+        ),
+        (
+            "observed outage per churned node",
+            "the configured downtime plus the drain and the rejoin dial stagger",
+            f"{out['outage_s'].median():.0f}s median, {out['outage_s'].max():.0f}s worst",
+        ),
+        mesh_peers_row(mesh, "mesh peers after rejoin", pods=churned),
+    ]
+
+
+def run_churn_analysis(experiment: "NimLibp2pExperiment") -> None:
+    dump_dir, df = prepare(experiment)
+    cfg = experiment.config
+
+    down = find_events(experiment.events_log_path, {"event": "churn_is_down"})
+    if not down:
+        raise ValueError("Churn analysis needs churn_is_down in the events log")
+
+    write_table(
+        dump_dir,
+        "churn_result",
+        churn_table(
+            df,
+            down[-1]["nodes"],
+            cfg.num_messages,
+            cfg.num_relay_nodes,
+            load_mesh_peers(experiment.output_folder),
+        ),
+    )

--- a/src/analysis/post_run/churn.py
+++ b/src/analysis/post_run/churn.py
@@ -14,6 +14,7 @@ from src.analysis.post_run.scenario_common import (
     mesh_peers_row,
     pct,
     prepare,
+    published_messages,
     write_table,
 )
 from src.deployments.core.event_log import find_events
@@ -25,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 def longest_run(mask: Sequence[bool]) -> Tuple[Optional[int], Optional[int], int]:
-    """Start, end and length of the longest True stretch."""
+    """First index, last index and length of the longest run of consecutive misses."""
     best = (None, None, 0)
     start = None
     for i, flag in enumerate(list(mask) + [False]):
@@ -41,15 +42,22 @@ def longest_run(mask: Sequence[bool]) -> Tuple[Optional[int], Optional[int], int
 def churn_outages(df: pd.DataFrame, churned: Sequence[str]) -> pd.DataFrame:
     """Per churned node: the outage read off its own miss run, and what it missed after it.
 
+    `df` is the delivery frame: one row per message received by one pod, with `sent` resolved
+    to the publish time. Deduplicating on `msgId` alone gives the publish order, since every
+    copy of a message carries the same `sent`.
+
     Pods keep serving past the scale-down and are back before the rollout finishes, so the
     scale-down window is not a node's outage; the stretch it missed is.
+
+    Rows are reindexed over every churned node, so one that received nothing is reported as
+    having missed everything rather than dropped from the table.
     """
     order = df.drop_duplicates("msgId").sort_values("sent")
     times = order["sent"].to_numpy()
     present = (
         df[df[POD_COLUMN].isin(set(churned))]
         .pivot_table(index=POD_COLUMN, columns="msgId", values="ordinal", aggfunc="size")
-        .reindex(columns=order["msgId"])
+        .reindex(index=list(churned), columns=order["msgId"])
         .notna()
     )
 
@@ -83,7 +91,8 @@ def churn_table(
     num_nodes: int,
     mesh: Optional[pd.DataFrame] = None,
 ) -> List[Row]:
-    """Below 100%, with every miss inside the node's own outage."""
+    """Expectation-vs-result rows: delivery is below 100%, and every miss sits inside the
+    churned node's own outage rather than trailing after it."""
     is_churned = df[POD_COLUMN].isin(set(churned))
     survivors = num_nodes - len(set(churned))
     per_survivor = df[~is_churned].groupby(POD_COLUMN)["msgId"].nunique()
@@ -139,7 +148,7 @@ def run_churn_analysis(experiment: "NimLibp2pExperiment") -> None:
         churn_table(
             df,
             down[-1]["nodes"],
-            cfg.num_messages,
+            published_messages(experiment),
             cfg.num_relay_nodes,
             load_mesh_peers(experiment.output_folder),
         ),

--- a/src/analysis/post_run/churn.py
+++ b/src/analysis/post_run/churn.py
@@ -40,7 +40,7 @@ def longest_run(mask: Sequence[bool]) -> Tuple[Optional[int], Optional[int], int
 
 
 def churn_outages(df: pd.DataFrame, churned: Sequence[str]) -> pd.DataFrame:
-    """Per churned node: the outage read off its own miss run, and what it missed after it.
+    """Per churned node: the outage read off its own miss run, and what it missed outside it.
 
     `df` is the delivery frame: one row per message received by one pod, with `sent` resolved
     to the publish time. Deduplicating on `msgId` alone gives the publish order, since every
@@ -74,6 +74,8 @@ def churn_outages(df: pd.DataFrame, churned: Sequence[str]) -> pd.DataFrame:
                 "outage_s": (
                     (times[end] - times[start]) / pd.Timedelta(seconds=1) if length else 0.0
                 ),
+                # Misses on either side of the outage, not just the tail after it.
+                "missed_outside": int(missed.sum()) - length,
                 "missed_after": len(after),
                 # How long the node keeps dropping messages once its main outage has ended.
                 "recovery_tail_s": (
@@ -98,6 +100,7 @@ def churn_table(
     per_survivor = df[~is_churned].groupby(POD_COLUMN)["msgId"].nunique()
     out = churn_outages(df, churned)
     ragged = int((out["missed_after"] > 0).sum())
+    scattered = int((out["missed_outside"] > 0).sum())
 
     return [
         (
@@ -116,7 +119,9 @@ def churn_table(
             "delivery, churned nodes",
             "one contiguous gap, nothing missed either side of it",
             f"missed {out['missed'].mean():.1f} of {num_messages} on average, "
-            f"{out['outage_messages'].mean():.1f} in one stretch",
+            f"{out['outage_messages'].mean():.1f} in one stretch, "
+            f"{scattered} of {len(out)} nodes missed anything outside it "
+            f"(worst {out['missed_outside'].max()})",
         ),
         (
             "clean recovery",

--- a/src/analysis/post_run/degraded.py
+++ b/src/analysis/post_run/degraded.py
@@ -1,0 +1,50 @@
+"""Post-run analysis for the degraded-network scenario."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, List, Optional
+
+import pandas as pd
+
+from src.analysis.post_run.scenario_common import (
+    Row,
+    latency_summary,
+    load_mesh_peers,
+    mesh_peers_row,
+    pct,
+    prepare,
+    write_table,
+)
+
+if TYPE_CHECKING:
+    from src.deployments.experiments.libp2p.nimlibp2p import NimLibp2pExperiment
+
+logger = logging.getLogger(__name__)
+
+
+def degraded_table(
+    df: pd.DataFrame,
+    num_messages: int,
+    num_nodes: int,
+    mesh: Optional[pd.DataFrame] = None,
+) -> List[Row]:
+    """Delivery should be complete and latency should track the injected delay."""
+    return [
+        ("delivery", "100%", pct(len(df), num_messages * num_nodes)),
+        ("median latency", "roughly mesh depth x the injected delay", latency_summary(df)),
+        ("latency tail", "bounded, no collapse", f"max {df['delayMs'].max():.0f} ms"),
+        mesh_peers_row(mesh, "mesh peers per node"),
+    ]
+
+
+def run_degraded_analysis(experiment: "NimLibp2pExperiment") -> None:
+    dump_dir, df = prepare(experiment)
+    cfg = experiment.config
+    write_table(
+        dump_dir,
+        "degraded_result",
+        degraded_table(
+            df, cfg.num_messages, cfg.num_relay_nodes, load_mesh_peers(experiment.output_folder)
+        ),
+    )

--- a/src/analysis/post_run/degraded.py
+++ b/src/analysis/post_run/degraded.py
@@ -14,6 +14,7 @@ from src.analysis.post_run.scenario_common import (
     mesh_peers_row,
     pct,
     prepare,
+    published_messages,
     write_table,
 )
 
@@ -45,6 +46,9 @@ def run_degraded_analysis(experiment: "NimLibp2pExperiment") -> None:
         dump_dir,
         "degraded_result",
         degraded_table(
-            df, cfg.num_messages, cfg.num_relay_nodes, load_mesh_peers(experiment.output_folder)
+            df,
+            published_messages(experiment),
+            cfg.num_relay_nodes,
+            load_mesh_peers(experiment.output_folder),
         ),
     )

--- a/src/analysis/post_run/partition.py
+++ b/src/analysis/post_run/partition.py
@@ -1,0 +1,91 @@
+"""Post-run analysis for the network-partition scenario."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING, List
+
+import pandas as pd
+
+from src.analysis.post_run.scenario_common import (
+    Row,
+    event_time,
+    latency_summary,
+    prepare,
+    write_table,
+)
+from src.deployments.core.event_log import find_events
+
+if TYPE_CHECKING:
+    from src.deployments.experiments.libp2p.nimlibp2p import NimLibp2pExperiment
+
+logger = logging.getLogger(__name__)
+
+
+def per_message_reach(df: pd.DataFrame, heal: datetime, split: int) -> pd.DataFrame:
+    """One row per message: reach on each side, publish time, and which phase it belongs to."""
+    side = (df["ordinal"] >= split).map({False: "a", True: "b"})
+    counts = (
+        df.assign(side=side)
+        .pivot_table(index="msgId", columns="side", values="ordinal", aggfunc="count")
+        .reindex(columns=["a", "b"])
+        .fillna(0)
+        .astype(int)
+    )
+    counts["reach"] = counts["a"] + counts["b"]
+    counts["sent"] = df.groupby("msgId")["sent"].min()
+    counts["phase"] = (counts["sent"] > heal).map({False: "split", True: "healed"})
+    return counts.sort_values("sent").reset_index()
+
+
+def partition_table(df: pd.DataFrame, heal: datetime, split: int, num_nodes: int) -> List[Row]:
+    """Contained while split, then reconverging to the whole network."""
+    per_msg = per_message_reach(df, heal, split)
+    under = per_msg[per_msg["phase"] == "split"]
+    after = per_msg[per_msg["phase"] == "healed"]
+    crossed = int(((under["a"] > 0) & (under["b"] > 0)).sum())
+    full = after[after["reach"] >= num_nodes]
+
+    # The messages before the first full-reach one are still in flight across the merge.
+    if full.empty:
+        reconverged = "no message reached the whole network after the heal"
+    else:
+        reconverged = f"{(full.iloc[0]['sent'] - heal).total_seconds():.0f}s"
+
+    contained = int((under["reach"] == under[["a", "b"]].max(axis=1)).sum())
+    return [
+        (
+            "delivery under the split, own half",
+            "100% of that half",
+            f"mean reach {under['reach'].mean():.1f} over {len(under)} messages, "
+            f"{contained} contained to one side",
+        ),
+        ("delivery under the split, far half", "0", f"{crossed} of {len(under)} messages crossed"),
+        ("time to reconverge after the heal", "under 10s on unshaped links", reconverged),
+        (
+            "delivery after reconvergence",
+            "100% of all nodes",
+            f"{len(full)} of {len(after)} messages reached all {num_nodes}",
+        ),
+        (
+            "latency across the merge",
+            "a brief tail spike, then back to baseline",
+            latency_summary(df[df["sent"] > heal]),
+        ),
+    ]
+
+
+def run_partition_analysis(experiment: "NimLibp2pExperiment") -> None:
+    dump_dir, df = prepare(experiment)
+    cfg = experiment.config
+    log = experiment.events_log_path
+
+    heal = event_time(find_events(log, {"event": "partition_heal"}))
+    if heal is None:
+        raise ValueError("Partition analysis needs partition_heal in the events log")
+
+    # The applied event records the real split; the config fraction is only a fallback.
+    applied = find_events(log, {"event": "partition_applied"})
+    split = applied[-1]["side_a"] if applied else int(cfg.num_relay_nodes * cfg.partition_fraction)
+    write_table(dump_dir, "partition_result", partition_table(df, heal, split, cfg.num_relay_nodes))

--- a/src/analysis/post_run/scenario_common.py
+++ b/src/analysis/post_run/scenario_common.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple
 import pandas as pd
 
 from src.analysis.post_run.nimlibp2p import run_nimlibp2p_analysis
+from src.deployments.core.event_log import find_events
 
 if TYPE_CHECKING:
     from src.deployments.experiments.libp2p.nimlibp2p import NimLibp2pExperiment
@@ -95,10 +96,38 @@ def event_time(events: List[dict]) -> Optional[datetime]:
     return datetime.strptime(events[-1]["timestamp"], "%Y-%m-%d %H:%M:%S")
 
 
+class NoDeliveries(Exception):
+    """The run produced no delivery data, so there is nothing to build a table from."""
+
+
+def published_messages(experiment: "NimLibp2pExperiment") -> int:
+    """How many messages actually left the publisher, per the run's own event log.
+
+    The configured count is what we meant to send; a run that failed to publish would
+    otherwise be scored against a denominator it never sent.
+    """
+    summary = find_events(experiment.events_log_path, {"event": "publish_summary"})
+    if not summary:
+        logger.warning(
+            "No publish_summary event; falling back to the configured message count, which "
+            "assumes every publish succeeded"
+        )
+        return experiment.config.num_messages
+
+    attempted = summary[-1]["attempted"]
+    failed = summary[-1].get("failed", 0)
+    if failed:
+        logger.warning(f"{failed} of {attempted} publishes failed; scoring against the rest")
+    return attempted - failed
+
+
 def prepare(experiment: "NimLibp2pExperiment") -> Tuple[Path, pd.DataFrame]:
     """Run the shared delivery analysis, then load what it dumped."""
     run_nimlibp2p_analysis(experiment)
     if experiment.output_folder is None:
         raise ValueError("Scenario analysis requires experiment.output_folder")
     dump_dir = experiment.output_folder / "analysis_data"
-    return dump_dir, load_deliveries(dump_dir)
+    df = load_deliveries(dump_dir)
+    if df.empty:
+        raise NoDeliveries(f"No deliveries in {dump_dir / 'summary' / 'received.csv'}")
+    return dump_dir, df

--- a/src/analysis/post_run/scenario_common.py
+++ b/src/analysis/post_run/scenario_common.py
@@ -1,0 +1,104 @@
+"""Shared pieces for the adverse-condition scenario analyses.
+
+Each scenario emits the expectation-versus-result table the regression rulebook lists for it.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple
+
+import pandas as pd
+
+from src.analysis.post_run.nimlibp2p import run_nimlibp2p_analysis
+
+if TYPE_CHECKING:
+    from src.deployments.experiments.libp2p.nimlibp2p import NimLibp2pExperiment
+
+logger = logging.getLogger(__name__)
+
+POD_COLUMN = "kubernetes.pod_name"
+MESH_PEERS_DIR = Path("metrics") / "mesh-peers"
+MESH_EXPECTATION = "between dLow (4) and dHigh (12), around D (6)"
+Row = Tuple[str, str, str]
+
+
+def load_deliveries(dump_dir: Path) -> pd.DataFrame:
+    """One row per delivery, with the pod's ordinal and the publish time resolved."""
+    df = pd.read_csv(dump_dir / "summary" / "received.csv")
+    df["delayMs"] = pd.to_numeric(df["delayMs"], errors="coerce")
+    df["ordinal"] = df[POD_COLUMN].str.rsplit("-", n=1).str[-1].astype(int)
+    df["sent"] = pd.to_datetime(df["sentAt"])
+    return df
+
+
+def load_mesh_peers(run_dir: Path) -> Optional[pd.DataFrame]:
+    """Scraped mesh-peer gauge as Time x pod, or None when the metrics scrape did not run."""
+    files = sorted(p for p in (run_dir / MESH_PEERS_DIR).glob("*") if p.is_file())
+    if not files:
+        return None
+    return pd.read_csv(files[0], index_col="Time", parse_dates=True)
+
+
+def mesh_peers_row(
+    mesh: Optional[pd.DataFrame], item: str, pods: Optional[Sequence[str]] = None
+) -> Row:
+    """Mesh degree at the last snapshot that reported: the final one can be past teardown."""
+    missing = (item, MESH_EXPECTATION, "no mesh-peers metrics for those pods")
+    if mesh is None or mesh.empty:
+        return (item, MESH_EXPECTATION, "no mesh-peers metrics in the run folder")
+
+    columns = list(mesh.columns) if pods is None else [p for p in pods if p in mesh.columns]
+    if not columns:
+        return missing
+    reported = mesh[columns].dropna(how="all")
+    if reported.empty:
+        return missing
+
+    final = reported.iloc[-1].dropna()
+    if final.empty:
+        return missing
+    return (
+        item,
+        MESH_EXPECTATION,
+        f"median {final.median():.0f}, range {final.min():.0f} to {final.max():.0f}",
+    )
+
+
+def pct(part: int, whole: int) -> str:
+    return f"{part} of {whole} ({100 * part / whole:.1f}%)" if whole else f"{part} of 0"
+
+
+def latency_summary(df: pd.DataFrame) -> str:
+    d = df["delayMs"].dropna()
+    if d.empty:
+        return "no deliveries"
+    return f"p50 {d.median():.0f} / p99 {d.quantile(0.99):.0f} / max {d.max():.0f} ms"
+
+
+def write_table(dump_dir: Path, name: str, rows: Sequence[Row]) -> Path:
+    """Write the table next to the other summaries and log it."""
+    out = dump_dir / "summary" / f"{name}.csv"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(rows, columns=["item", "expectation", "result"]).to_csv(out, index=False)
+    logger.info(f"{name}:")
+    for item, expectation, result in rows:
+        logger.info(f"  {item}: expected {expectation} | got {result}")
+    return out
+
+
+def event_time(events: List[dict]) -> Optional[datetime]:
+    if not events:
+        return None
+    return datetime.strptime(events[-1]["timestamp"], "%Y-%m-%d %H:%M:%S")
+
+
+def prepare(experiment: "NimLibp2pExperiment") -> Tuple[Path, pd.DataFrame]:
+    """Run the shared delivery analysis, then load what it dumped."""
+    run_nimlibp2p_analysis(experiment)
+    if experiment.output_folder is None:
+        raise ValueError("Scenario analysis requires experiment.output_folder")
+    dump_dir = experiment.output_folder / "analysis_data"
+    return dump_dir, load_deliveries(dump_dir)

--- a/src/analysis/post_run/tests/conftest.py
+++ b/src/analysis/post_run/tests/conftest.py
@@ -1,0 +1,39 @@
+from datetime import datetime, timedelta
+
+import pandas as pd
+import pytest
+
+from src.analysis.post_run.scenario_common import POD_COLUMN
+
+T0 = datetime(2026, 7, 30, 5, 15, 0)
+
+
+@pytest.fixture
+def deliveries():
+    """Build a deliveries frame from (msg_id, ordinal, seconds_after_T0, delayMs) rows."""
+
+    def build(rows):
+        return pd.DataFrame(
+            [
+                {
+                    "msgId": m,
+                    POD_COLUMN: f"pod-{o}",
+                    "ordinal": o,
+                    "sent": T0 + timedelta(seconds=s),
+                    "delayMs": d,
+                }
+                for m, o, s, d in rows
+            ]
+        )
+
+    return build
+
+
+@pytest.fixture
+def fanout():
+    """One message delivered to several pods at the same publish time."""
+
+    def build(msg, nodes, second, delay=5):
+        return [(msg, o, second, delay) for o in nodes]
+
+    return build

--- a/src/analysis/post_run/tests/test_churn.py
+++ b/src/analysis/post_run/tests/test_churn.py
@@ -44,6 +44,24 @@ def test_churn_flags_a_node_that_keeps_dropping_after_its_outage(deliveries, fan
     )
 
 
+def test_churn_flags_a_miss_on_either_side_of_the_outage(deliveries, fanout):
+    """A miss before the outage counts too: the tail alone only looks to the right of it."""
+    # pod-2 misses message 1, then 3 and 4; pod-3 misses 2 and 3, then 6.
+    df = deliveries(
+        fanout(1, [0, 1, 3], 0)
+        + fanout(2, [0, 1, 2], 30)
+        + fanout(3, [0, 1], 60)
+        + fanout(4, [0, 1, 3], 90)
+        + fanout(5, range(4), 120)
+        + fanout(6, [0, 1, 2], 150)
+    )
+    rows = dict((i, r) for i, _, r in churn_table(df, ["pod-2", "pod-3"], 6, 4))
+
+    assert "2 of 2 nodes missed anything outside it (worst 1)" in rows["delivery, churned nodes"]
+    # only pod-3 trails after its outage, so the tail on its own misses pod-2 entirely
+    assert rows["clean recovery"].startswith("1 of 2 nodes keep dropping")
+
+
 def test_churn_reads_each_nodes_outage_off_its_own_miss_run(deliveries, fanout):
     """Pods come back staggered, so the outage cannot come from a shared window."""
     df = deliveries(

--- a/src/analysis/post_run/tests/test_churn.py
+++ b/src/analysis/post_run/tests/test_churn.py
@@ -1,0 +1,64 @@
+from src.analysis.post_run.churn import churn_table, longest_run
+
+
+def test_longest_run_picks_the_biggest_stretch():
+    assert longest_run([False, True, False, True, True, True, False]) == (3, 5, 3)
+    assert longest_run([True, True, False]) == (0, 1, 2)
+    assert longest_run([False, False]) == (None, None, 0)
+    assert longest_run([True]) == (0, 0, 1)
+
+
+def test_churn_puts_every_miss_inside_one_contiguous_outage(deliveries, fanout):
+    # pods 2 and 3 miss messages 2 and 3, then are back for message 4.
+    df = deliveries(
+        fanout(1, range(4), 0)
+        + fanout(2, [0, 1], 30)
+        + fanout(3, [0, 1], 50)
+        + fanout(4, range(4), 90)
+    )
+    rows = dict((i, r) for i, _, r in churn_table(df, ["pod-2", "pod-3"], 4, 4))
+    assert "12 of 16" in rows["delivery, whole run"]
+    assert "4 to 4 of 4" in rows["delivery, nodes that stayed up"]
+    assert "missed 2.0 of 4" in rows["delivery, churned nodes"]
+    assert "2.0 in one stretch" in rows["delivery, churned nodes"]
+    assert rows["clean recovery"].startswith("0 of 2 nodes keep dropping")
+    # the outage spans the publish times of messages 2 and 3
+    assert rows["observed outage per churned node"] == "20s median, 20s worst"
+
+
+def test_churn_flags_a_node_that_keeps_dropping_after_its_outage(deliveries, fanout):
+    """The real churn failure is a ragged recovery, not one clean gap."""
+    # both share an outage over messages 2 and 3; pod-3 then drops 5 after returning for 4.
+    df = deliveries(
+        fanout(1, range(4), 0)
+        + fanout(2, [0, 1], 30)
+        + fanout(3, [0, 1], 50)
+        + fanout(4, range(4), 90)
+        + fanout(5, [0, 1, 2], 110)
+    )
+    rows = dict((i, r) for i, _, r in churn_table(df, ["pod-2", "pod-3"], 5, 4))
+    assert (
+        rows["clean recovery"]
+        == "1 of 2 nodes keep dropping after their outage, worst 1 messages over 60s"
+    )
+
+
+def test_churn_reads_each_nodes_outage_off_its_own_miss_run(deliveries, fanout):
+    """Pods come back staggered, so the outage cannot come from a shared window."""
+    df = deliveries(
+        fanout(1, range(4), 0)
+        + fanout(2, [0, 1], 30)
+        + fanout(3, [0, 1, 2], 60)
+        + fanout(4, range(4), 90)
+    )
+    rows = dict((i, r) for i, _, r in churn_table(df, ["pod-2", "pod-3"], 4, 4))
+    # pod-2 missed only message 2; pod-3 missed 2 and 3, spanning 30s
+    assert rows["observed outage per churned node"] == "15s median, 30s worst"
+    assert rows["clean recovery"].startswith("0 of 2 nodes keep dropping")
+
+
+def test_churn_handles_a_node_that_never_comes_back(deliveries, fanout):
+    df = deliveries(fanout(1, range(4), 0) + fanout(2, [0, 1], 30) + fanout(3, [0, 1], 60))
+    rows = dict((i, r) for i, _, r in churn_table(df, ["pod-2", "pod-3"], 3, 4))
+    assert "missed 2.0 of 3" in rows["delivery, churned nodes"]
+    assert rows["clean recovery"].startswith("0 of 2 nodes keep dropping")

--- a/src/analysis/post_run/tests/test_churn.py
+++ b/src/analysis/post_run/tests/test_churn.py
@@ -1,4 +1,5 @@
-from src.analysis.post_run.churn import churn_table, longest_run
+from src.analysis.post_run.churn import churn_outages, churn_table, longest_run
+from src.analysis.post_run.scenario_common import POD_COLUMN
 
 
 def test_longest_run_picks_the_biggest_stretch():
@@ -62,3 +63,21 @@ def test_churn_handles_a_node_that_never_comes_back(deliveries, fanout):
     rows = dict((i, r) for i, _, r in churn_table(df, ["pod-2", "pod-3"], 3, 4))
     assert "missed 2.0 of 3" in rows["delivery, churned nodes"]
     assert rows["clean recovery"].startswith("0 of 2 nodes keep dropping")
+
+
+def test_a_churned_node_that_received_nothing_is_still_reported(deliveries, fanout):
+    """The worst outcome must not vanish: absent from the pivot means absent from the table."""
+    df = deliveries(fanout(1, [0, 1], 0) + fanout(2, [0, 1], 30))
+    out = churn_outages(df, ["pod-2", "pod-3"])
+
+    assert list(out[POD_COLUMN]) == ["pod-2", "pod-3"]
+    assert list(out["missed"]) == [2, 2], "each missed every message"
+
+
+def test_the_recovery_denominator_covers_every_churned_node(deliveries, fanout):
+    """Dropping absent nodes shrank the denominator with the numerator, so a total
+    failure read as a clean run."""
+    df = deliveries(fanout(1, [0, 1, 2], 0) + fanout(2, [0, 1, 2], 30))
+    rows = dict((i, r) for i, _, r in churn_table(df, ["pod-2", "pod-3", "pod-4"], 2, 5))
+
+    assert rows["clean recovery"].startswith("0 of 3 nodes keep dropping")

--- a/src/analysis/post_run/tests/test_degraded.py
+++ b/src/analysis/post_run/tests/test_degraded.py
@@ -1,0 +1,20 @@
+from src.analysis.post_run.degraded import degraded_table
+
+
+def test_degraded_reports_full_delivery(deliveries, fanout):
+    df = deliveries(fanout(1, range(4), 0) + fanout(2, range(4), 1))
+    rows = dict((item, result) for item, _, result in degraded_table(df, 2, 4))
+    assert "8 of 8 (100.0%)" in rows["delivery"]
+
+
+def test_degraded_flags_a_shortfall(deliveries, fanout):
+    df = deliveries(fanout(1, range(4), 0) + fanout(2, range(3), 1))
+    rows = dict((item, result) for item, _, result in degraded_table(df, 2, 4))
+    assert "7 of 8 (87.5%)" in rows["delivery"]
+
+
+def test_degraded_reports_latency_percentiles(deliveries):
+    df = deliveries([(1, o, 0, o * 100) for o in range(1, 5)])
+    rows = dict((item, result) for item, _, result in degraded_table(df, 1, 4))
+    assert rows["median latency"] == "p50 250 / p99 397 / max 400 ms"
+    assert rows["latency tail"] == "max 400 ms"

--- a/src/analysis/post_run/tests/test_hooks_resolve.py
+++ b/src/analysis/post_run/tests/test_hooks_resolve.py
@@ -1,0 +1,21 @@
+"""The suite otherwise never imports the scenario experiments, so a broken one stays green."""
+
+import pytest
+
+from src.analysis.post_run_analysis import load_post_run_analysis
+from src.deployments.experiments.libp2p.churn import NodeChurn
+from src.deployments.experiments.libp2p.degraded import DegradedNetwork
+from src.deployments.experiments.libp2p.partition import NetworkPartition
+
+SCENARIOS = [DegradedNetwork, NodeChurn, NetworkPartition]
+
+
+@pytest.mark.parametrize("experiment", SCENARIOS, ids=lambda c: c.__name__)
+def test_scenario_declares_a_resolvable_post_run_analysis(experiment):
+    assert callable(load_post_run_analysis(experiment.post_run_analysis))
+
+
+@pytest.mark.parametrize("experiment", SCENARIOS, ids=lambda c: c.__name__)
+def test_post_run_analysis_stays_out_of_the_model_fields(experiment):
+    """A ClassVar, or it would be serialized into the run metadata and break the reload."""
+    assert "post_run_analysis" not in experiment.model_fields

--- a/src/analysis/post_run/tests/test_partition.py
+++ b/src/analysis/post_run/tests/test_partition.py
@@ -1,0 +1,43 @@
+from datetime import timedelta
+
+from src.analysis.post_run.partition import partition_table
+from src.analysis.post_run.tests.conftest import T0
+
+HEAL = T0 + timedelta(seconds=100)
+
+
+def test_partition_contained_then_reconverged(deliveries, fanout):
+    # split messages reach only side a (0,1); after the heal message 3 reaches all four.
+    df = deliveries(fanout(1, [0, 1], 10) + fanout(2, [0, 1], 20) + fanout(3, range(4), 130))
+    rows = dict((item, result) for item, _, result in partition_table(df, HEAL, 2, 4))
+    assert "0 of 2 messages crossed" in rows["delivery under the split, far half"]
+    assert "mean reach 2.0 over 2 messages" in rows["delivery under the split, own half"]
+    assert "2 contained to one side" in rows["delivery under the split, own half"]
+    assert rows["time to reconverge after the heal"] == "30s"
+    assert "1 of 1 messages reached all 4" in rows["delivery after reconvergence"]
+
+
+def test_partition_reconvergence_uses_the_earliest_full_message(deliveries, fanout):
+    """A groupby orders by msgId, so the row must be picked by publish time, not by id."""
+    # the earliest full-reach message has the largest msgId, and one message still lags.
+    df = deliveries(
+        fanout(1, [0, 1], 10)
+        + fanout(900, range(4), 110)
+        + fanout(5, [0, 1], 105)
+        + fanout(7, range(4), 200)
+    )
+    rows = dict((item, result) for item, _, result in partition_table(df, HEAL, 2, 4))
+    assert rows["time to reconverge after the heal"] == "10s"
+    assert "2 of 3 messages reached all 4" in rows["delivery after reconvergence"]
+
+
+def test_partition_reports_a_leak(deliveries, fanout):
+    df = deliveries(fanout(1, range(4), 10) + fanout(2, [0, 1], 20))
+    rows = dict((item, result) for item, _, result in partition_table(df, HEAL, 2, 4))
+    assert "1 of 2 messages crossed" in rows["delivery under the split, far half"]
+
+
+def test_partition_says_so_when_it_never_reconverges(deliveries, fanout):
+    df = deliveries(fanout(1, [0, 1], 10) + fanout(2, [0, 1], 130))
+    rows = dict((item, result) for item, _, result in partition_table(df, HEAL, 2, 4))
+    assert rows["time to reconverge after the heal"].startswith("no message reached")

--- a/src/analysis/post_run/tests/test_scenario_common.py
+++ b/src/analysis/post_run/tests/test_scenario_common.py
@@ -1,10 +1,18 @@
+import json
+import logging
+from types import SimpleNamespace
+
 import pandas as pd
+import pytest
 
 from src.analysis.post_run.scenario_common import (
     POD_COLUMN,
+    NoDeliveries,
     load_deliveries,
     load_mesh_peers,
     mesh_peers_row,
+    prepare,
+    published_messages,
     write_table,
 )
 
@@ -67,3 +75,49 @@ def test_load_deliveries_resolves_ordinal_and_publish_time(tmp_path):
     df = load_deliveries(tmp_path)
     assert df.iloc[0]["ordinal"] == 42
     assert df.iloc[0]["sent"] == pd.Timestamp("2026-07-30 03:07:19.873477632")
+
+
+class TestPublishedMessages:
+    """Delivery must be scored against what left the publisher, not what we asked for."""
+
+    def _experiment(self, tmp_path, events, configured=600):
+        log = tmp_path / "events.log"
+        log.write_text("".join(json.dumps(e) + "\n" for e in events))
+        return SimpleNamespace(events_log_path=log, config=SimpleNamespace(num_messages=configured))
+
+    def test_uses_what_the_publisher_actually_sent(self, tmp_path):
+        exp = self._experiment(
+            tmp_path, [{"event": "publish_summary", "attempted": 600, "failed": 3}]
+        )
+        assert published_messages(exp) == 597
+
+    def test_a_clean_run_matches_the_configured_count(self, tmp_path):
+        exp = self._experiment(
+            tmp_path, [{"event": "publish_summary", "attempted": 600, "failed": 0}]
+        )
+        assert published_messages(exp) == 600
+
+    def test_a_lost_publish_is_warned_about(self, tmp_path, caplog):
+        exp = self._experiment(
+            tmp_path, [{"event": "publish_summary", "attempted": 600, "failed": 3}]
+        )
+        with caplog.at_level(logging.WARNING):
+            published_messages(exp)
+        assert "3 of 600 publishes failed" in caplog.text
+
+    def test_an_older_run_without_the_event_falls_back_and_says_so(self, tmp_path, caplog):
+        exp = self._experiment(tmp_path, [{"event": "run_start"}])
+        with caplog.at_level(logging.WARNING):
+            assert published_messages(exp) == 600
+        assert "No publish_summary event" in caplog.text
+
+
+def test_prepare_refuses_a_run_with_no_deliveries(tmp_path, mocker):
+    """An empty frame used to reach the tables and raise KeyError on a missing column."""
+    mocker.patch("src.analysis.post_run.scenario_common.run_nimlibp2p_analysis")
+    mocker.patch(
+        "src.analysis.post_run.scenario_common.load_deliveries", return_value=pd.DataFrame()
+    )
+    exp = SimpleNamespace(output_folder=tmp_path, config=SimpleNamespace())
+    with pytest.raises(NoDeliveries, match="No deliveries"):
+        prepare(exp)

--- a/src/analysis/post_run/tests/test_scenario_common.py
+++ b/src/analysis/post_run/tests/test_scenario_common.py
@@ -1,0 +1,69 @@
+import pandas as pd
+
+from src.analysis.post_run.scenario_common import (
+    POD_COLUMN,
+    load_deliveries,
+    load_mesh_peers,
+    mesh_peers_row,
+    write_table,
+)
+
+
+def _mesh(rows, pods):
+    """rows: list of per-pod value lists, one per snapshot."""
+    return pd.DataFrame(
+        rows,
+        index=pd.to_datetime([f"2026-07-30 05:{15 + i}:00" for i in range(len(rows))]),
+        columns=pods,
+    )
+
+
+def test_mesh_row_reports_the_last_snapshot():
+    mesh = _mesh([[6, 6], [8, 4]], ["pod-0", "pod-1"])
+    assert mesh_peers_row(mesh, "mesh peers")[2] == "median 6, range 4 to 8"
+
+
+def test_mesh_row_skips_snapshots_taken_after_teardown():
+    mesh = _mesh([[6, 6], [8, 4], [float("nan"), float("nan")]], ["pod-0", "pod-1"])
+    assert mesh_peers_row(mesh, "mesh peers")[2] == "median 6, range 4 to 8"
+
+
+def test_mesh_row_restricts_to_the_named_pods():
+    mesh = _mesh([[1, 9]], ["pod-0", "pod-1"])
+    assert mesh_peers_row(mesh, "mesh peers", pods=["pod-1"])[2] == "median 9, range 9 to 9"
+
+
+def test_mesh_row_says_when_there_are_no_metrics():
+    assert "no mesh-peers metrics in the run folder" in mesh_peers_row(None, "mesh peers")[2]
+    mesh = _mesh([[6]], ["pod-0"])
+    assert "no mesh-peers metrics for those pods" in mesh_peers_row(mesh, "m", pods=["pod-9"])[2]
+
+
+def test_load_mesh_peers_returns_none_without_a_metrics_folder(tmp_path):
+    assert load_mesh_peers(tmp_path) is None
+
+
+def test_write_table_round_trips(tmp_path):
+    out = write_table(tmp_path, "demo", [("delivery", "100%", "8 of 8")])
+    assert out.exists()
+    back = pd.read_csv(out)
+    assert list(back.columns) == ["item", "expectation", "result"]
+    assert back.iloc[0]["result"] == "8 of 8"
+
+
+def test_load_deliveries_resolves_ordinal_and_publish_time(tmp_path):
+    summary = tmp_path / "summary"
+    summary.mkdir()
+    pd.DataFrame(
+        [
+            {
+                "msgId": 1,
+                "sentAt": "2026-07-30 03:07:19.873477632",
+                "delayMs": 7,
+                POD_COLUMN: "pod-42",
+            }
+        ]
+    ).to_csv(summary / "received.csv", index=False)
+    df = load_deliveries(tmp_path)
+    assert df.iloc[0]["ordinal"] == 42
+    assert df.iloc[0]["sent"] == pd.Timestamp("2026-07-30 03:07:19.873477632")

--- a/src/deployments/experiments/libp2p/churn.py
+++ b/src/deployments/experiments/libp2p/churn.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import List
+from typing import ClassVar, List
 
 from kubernetes.client import V1StatefulSet
 from pydantic import Field, NonNegativeInt, model_validator
@@ -47,6 +47,7 @@ class NodeChurn(NimLibp2pExperiment):
     """
 
     config: ChurnConfig
+    post_run_analysis: ClassVar[str] = "src.analysis.post_run.churn:run_churn_analysis"
 
     def _publishable_nodes(self) -> int:
         """Churned nodes return on new addresses; publishing to a stale one hangs."""

--- a/src/deployments/experiments/libp2p/degraded.py
+++ b/src/deployments/experiments/libp2p/degraded.py
@@ -1,6 +1,7 @@
 """Regression scenario: a degraded link (latency, jitter, packet loss)."""
 
 import logging
+from typing import ClassVar
 
 from pydantic import Field, NonNegativeInt
 
@@ -21,3 +22,4 @@ class DegradedNetwork(NimLibp2pExperiment):
     """Regression run over a high-latency, jittery, lossy link."""
 
     config: DegradedConfig
+    post_run_analysis: ClassVar[str] = "src.analysis.post_run.degraded:run_degraded_analysis"

--- a/src/deployments/experiments/libp2p/partition.py
+++ b/src/deployments/experiments/libp2p/partition.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 import time
-from typing import List
+from typing import ClassVar, List
 
 from kubernetes.client import (
     V1LabelSelector,
@@ -116,6 +116,7 @@ class NetworkPartition(NimLibp2pExperiment):
     """
 
     config: PartitionConfig
+    post_run_analysis: ClassVar[str] = "src.analysis.post_run.partition:run_partition_analysis"
 
     async def _wait_for_pods_to_exist(self, nodes: V1StatefulSet, timeout: int = 600) -> None:
         """Existence, not readiness: Ready already means meshed."""


### PR DESCRIPTION
Each scenario writes its own expectation-vs-result table after the run, with the rows the rulebook lists. Follows #366, which added the scenarios themselves.