### PR TITLE
Fix broken imports  and add tests for all imports

### DIFF
--- a/src/deployments/deployment/waku/experiments/jswaku/jswaku.py
+++ b/src/deployments/deployment/waku/experiments/jswaku/jswaku.py
@@ -17,11 +17,8 @@ from pydantic import BaseModel, ConfigDict
 from ruamel import yaml
 
 # Project Imports
-from src.deployments.core.base_bridge import (
-    format_metadata_timestamps,
-    get_valid_shifted_times,
-    parse_events_log,
-)
+from src.deployments.core.base_bridge import format_metadata_timestamps, parse_events_log
+from src.deployments.core.metadata_times import apply_time_shifts
 from src.deployments.core.pod_interaction import exec_command_in_pod
 from src.deployments.experiments.base_experiment import BaseExperiment
 from src.deployments.pod_api_requester.builder import PodApiRequesterBuilder
@@ -235,10 +232,9 @@ class JsWakuNodes(BaseExperiment[EmptyConfig]):
 
         # Get timedeltas for each path. dict of {path : timedelta}.
         deltatime_map = {obj[1][0]: obj[1][1] for obj in events_list}
-        shifted = get_valid_shifted_times(deltatime_map, metadata)
-        metadata.update(shifted)
+        metadata = apply_time_shifts(deltatime_map, metadata)
 
-        metadata = format_metadata_timestamps(metadata)
+        metadata = format_metadata_timestamps(metadata, format="vquery")
 
         # Add links.
         links_map = {

--- a/src/tests/test_imports.py
+++ b/src/tests/test_imports.py
@@ -1,0 +1,34 @@
+"""Every module under src/ must import.
+
+The linters parse files without executing them, so they catch a syntax error but not a
+broken import, and pytest only imports what a test reaches. A module nothing imports is
+never executed at all, which is how a rename in one file left another importing a name
+that no longer existed and still went green.
+"""
+
+import importlib
+from pathlib import Path
+from typing import List
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[1]
+
+
+def _module_names() -> List[str]:
+    root = SRC.parent
+    names = []
+    for path in sorted(SRC.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        parts = list(path.relative_to(root).with_suffix("").parts)
+        if parts[-1] == "__init__":
+            parts = parts[:-1]
+        if parts:
+            names.append(".".join(parts))
+    return names
+
+
+@pytest.mark.parametrize("module", _module_names())
+def test_module_imports(module: str) -> None:
+    importlib.import_module(module)


### PR DESCRIPTION
`deployment.py` currently fails on master because `jswaku.py` still imports `get_valid_shifted_times`, which #367 removed. Fixes that and adds a test importing every module under `src/`, which the linters cannot catch since they never execute imports.