### PR TITLE
Include scenario runs in nim-libp2p regression scraping

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -10,23 +10,22 @@ from src.analysis.metrics.libp2p.scrape import Nimlibp2pScrapeBuilder
 from src.analysis.metrics.scrapper import Scrapper
 from src.analysis.plotting.config import PlotConfigBuilder
 from src.analysis.plotting.metrics_plotter import MetricsPlotter
+from src.analysis.utils.experiment_classes import subclass_names
 from src.analysis.utils.file_utils import extract_exps, get_folders
 from src.analysis.utils.log_utils import init_logger
+from src.deployments.experiments.libp2p.nimlibp2p import NimLibp2pExperiment
 
 logger = logging.getLogger(__name__)
 
 
 def get_nimlibp2p_exps(folder: Union[str, Path]) -> Iterable[dict]:
-    experiment_class = "NimLibp2pExperiment"
+    # Subclasses too, or the adverse-condition scenarios are skipped and never scraped.
+    accepted = subclass_names(NimLibp2pExperiment)
 
     def filter_by_class(exp) -> bool:
-        if exp["experiment"]["class"] != experiment_class:
-            return False
-        return True
+        return exp["experiment"]["class"] in accepted
 
-    filters = []
-    if experiment_class:
-        filters.append(filter_by_class)
+    filters = [filter_by_class]
 
     paths = [folder / path for path in get_folders(Path(folder), "metadata.json")]
     for exp in extract_exps(paths, filters):

--- a/src/analysis/utils/experiment_classes.py
+++ b/src/analysis/utils/experiment_classes.py
@@ -1,0 +1,43 @@
+"""Which experiment classes a metadata filter should accept.
+
+Run metadata records the class by bare name, so filtering on one name silently skips
+every subclass. The scenarios subclass NimLibp2pExperiment, which is how the metrics
+scrape came to ignore them entirely. Deriving the set from the registry keeps new
+subclasses included without anyone remembering to update a list.
+
+Matching is by class name rather than the dotted `_type` in the dump, because `_type`
+records the module a run was launched from and goes stale when a module is renamed.
+"""
+
+import logging
+from functools import lru_cache
+from pathlib import Path
+from typing import FrozenSet, Type, Union
+
+from src.deployments.registry import registry
+
+logger = logging.getLogger(__name__)
+
+# Anchored to this file, not the working directory: registry.scan resolves a relative
+# path against the cwd and rglob on a missing directory finds nothing without erroring,
+# so a relative default would silently accept only the base class from anywhere else.
+EXPERIMENTS_FOLDER = Path(__file__).resolve().parents[3] / "src" / "deployments" / "experiments"
+
+
+@lru_cache(maxsize=None)
+def subclass_names(base: Type, *, folder: Union[str, Path] = EXPERIMENTS_FOLDER) -> FrozenSet[str]:
+    """Names of every registered experiment class that is `base` or a subclass of it."""
+    folder = Path(folder)
+    if not folder.is_dir():
+        raise FileNotFoundError(f"Experiments folder not found for class scan: `{folder}`")
+    # Always scan: importing one experiment module populates the registry, so a
+    # "scan only if empty" guard leaves every other subclass unregistered.
+    registry.scan(str(folder), mode="skip")
+    names = {
+        info.cls.__name__
+        for info in registry.items()
+        if isinstance(info.cls, type) and issubclass(info.cls, base)
+    }
+    names.add(base.__name__)
+    logger.debug(f"Accepting experiment classes for {base.__name__}: {sorted(names)}")
+    return frozenset(names)

--- a/src/analysis/utils/tests/test_experiment_classes.py
+++ b/src/analysis/utils/tests/test_experiment_classes.py
@@ -1,0 +1,93 @@
+import json
+
+import pytest
+
+from src.analysis.utils.experiment_classes import subclass_names
+from src.deployments.experiments.libp2p.churn import NodeChurn
+from src.deployments.experiments.libp2p.degraded import DegradedNetwork
+from src.deployments.experiments.libp2p.nimlibp2p import NimLibp2pExperiment
+from src.deployments.experiments.libp2p.partition import NetworkPartition
+
+
+def test_includes_the_base_class_itself():
+    assert NimLibp2pExperiment.__name__ in subclass_names(NimLibp2pExperiment)
+
+
+@pytest.mark.parametrize("scenario", [DegradedNetwork, NodeChurn, NetworkPartition])
+def test_includes_every_scenario_subclass(scenario):
+    """These were skipped by an exact name match, so their metrics were never scraped."""
+    assert scenario.__name__ in subclass_names(NimLibp2pExperiment)
+
+
+def test_excludes_unrelated_experiments():
+    names = subclass_names(NimLibp2pExperiment)
+    assert "WakuExperiment" not in names
+    assert "ShadowGossipsubExperiment" not in names
+
+
+def test_scrape_picks_up_a_scenario_run(tmp_path):
+    """End to end: a churn run folder must survive the scrape's class filter."""
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[4]))  # scrape.py sits at the root
+    from scrape import get_nimlibp2p_exps
+
+    run = tmp_path / "churn-run"
+    run.mkdir()
+    (run / "metadata.json").write_text(
+        json.dumps(
+            {
+                "experiment": {
+                    "class": "NodeChurn",
+                    "dump": {"_type": "src.deployments.experiments.libp2p.churn.NodeChurn"},
+                },
+                "stack": {"start_time": "2026-08-05T01:00:07", "end_time": "2026-08-05T01:28:06"},
+                "metadata": {"namespace": "zerotesting"},
+            }
+        )
+    )
+    found = list(get_nimlibp2p_exps(tmp_path))
+    assert len(found) == 1
+    assert found[0]["experiment"]["class"] == "NodeChurn"
+
+
+def test_finds_subclasses_without_importing_them_first(tmp_path):
+    """Importing one experiment populates the registry, so a scan-if-empty guard would
+    leave the rest unregistered. Run in a clean interpreter to catch that."""
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[4]
+    code = (
+        "from src.analysis.utils.experiment_classes import subclass_names\n"
+        "from src.deployments.experiments.libp2p.nimlibp2p import NimLibp2pExperiment\n"
+        "names = subclass_names(NimLibp2pExperiment)\n"
+        "assert {'NodeChurn', 'NetworkPartition', 'DegradedNetwork'} <= names, sorted(names)\n"
+        "print('ok')\n"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        env={"PYTHONPATH": str(root), "PATH": "/usr/bin:/bin"},
+    )
+    assert out.returncode == 0, out.stderr[-400:]
+
+
+def test_works_from_any_working_directory(tmp_path, monkeypatch):
+    """registry.scan resolves a relative path against the cwd and rglob on a missing
+    directory finds nothing silently, so a relative default would quietly accept only
+    the base class when scrape.py is run from elsewhere."""
+    subclass_names.cache_clear()
+    monkeypatch.chdir(tmp_path)
+    names = subclass_names(NimLibp2pExperiment)
+    assert {"NodeChurn", "NetworkPartition", "DegradedNetwork"} <= names
+
+
+def test_a_missing_folder_is_an_error_not_an_empty_result():
+    subclass_names.cache_clear()
+    with pytest.raises(FileNotFoundError):
+        subclass_names(NimLibp2pExperiment, folder="/nonexistent/experiments")


### PR DESCRIPTION
`get_nimlibp2p_exps` exact-matched the class name, so the three adverse-condition scenarios were filtered out and never scraped. Derives the accepted names from the registry by subclass instead.

Related to: #158 