### PR TITLE
Fail a Shadow run whose simulated clock has stopped

### DIFF
--- a/src/deployments/shadow/liveness.py
+++ b/src/deployments/shadow/liveness.py
@@ -42,8 +42,10 @@ class StallWatch:
             self._last_change_at = now
 
         if sim_time is None:
-            # Shadow builds the network before the clock starts, so allow a longer grace.
-            if now - self._last_change_at > self.startup_grace_s:
+            # Only a signal before the clock has ever been seen, since Shadow builds the
+            # network first. After that, no reading means an unreadable log, not a stall,
+            # so leave the stall clock where it was.
+            if self._last_sim is None and now - self._last_change_at > self.startup_grace_s:
                 raise RuntimeError(
                     f"Shadow reported no simulated time in {self.startup_grace_s}s; "
                     "the run is stuck before the simulation started"

--- a/src/deployments/shadow/liveness.py
+++ b/src/deployments/shadow/liveness.py
@@ -1,0 +1,62 @@
+"""Detect a Shadow run whose simulated clock has stopped.
+
+Shadow prints progress and we leave `progress: True` on, but nothing reads it, so a
+livelocked run is indistinguishable from a slow one until the job timeout fires hours
+later. Watching simulated time turns that into a fast, specific failure.
+"""
+
+import logging
+import re
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# "Progress: 49% - simulated: 00:09:52.847/00:20:00, realtime: 00:57:00, ..."
+_PROGRESS = re.compile(r"Progress:.*?simulated:\s*(\d+):(\d{2}):(\d{2}(?:\.\d+)?)")
+# Fallback: every worker line carries the simulated time as its third field.
+_WORKER = re.compile(r"^[\d:.]+\s+\[\d+:[^\]]+\]\s+(\d+):(\d{2}):(\d{2}(?:\.\d+)?)", re.MULTILINE)
+
+
+def simulated_time_s(log_text: str) -> Optional[float]:
+    """Latest simulated time in the log, or None if it has not started yet."""
+    for pattern in (_PROGRESS, _WORKER):
+        matches = pattern.findall(log_text)
+        if matches:
+            h, m, s = matches[-1]
+            return int(h) * 3600 + int(m) * 60 + float(s)
+    return None
+
+
+class StallWatch:
+    """Raises once simulated time has failed to advance for `stall_timeout_s`."""
+
+    def __init__(self, *, stall_timeout_s: int = 600, startup_grace_s: int = 900):
+        self.stall_timeout_s = stall_timeout_s
+        self.startup_grace_s = startup_grace_s
+        self._last_sim: Optional[float] = None
+        self._last_change_at: Optional[float] = None
+
+    def check(self, sim_time: Optional[float], now: float) -> None:
+        """Feed the current simulated time and wall-clock reading."""
+        if self._last_change_at is None:
+            self._last_change_at = now
+
+        if sim_time is None:
+            # Shadow builds the network before the clock starts, so allow a longer grace.
+            if now - self._last_change_at > self.startup_grace_s:
+                raise RuntimeError(
+                    f"Shadow reported no simulated time in {self.startup_grace_s}s; "
+                    "the run is stuck before the simulation started"
+                )
+            return
+
+        if self._last_sim is None or sim_time > self._last_sim:
+            self._last_sim, self._last_change_at = sim_time, now
+            return
+
+        stalled = now - self._last_change_at
+        if stalled > self.stall_timeout_s:
+            raise RuntimeError(
+                f"Shadow simulated time stuck at {sim_time:.3f}s for {stalled:.0f}s; "
+                "the run is livelocked, not slow"
+            )

--- a/src/deployments/shadow/runtime.py
+++ b/src/deployments/shadow/runtime.py
@@ -12,6 +12,7 @@ from kubernetes.client.rest import ApiException
 
 from src.deployments.core.k8s_kubeconfig import get_config_file
 from src.deployments.shadow.builders import _RUN_MOUNT, build_log_reader_pod
+from src.deployments.shadow.liveness import StallWatch, simulated_time_s
 
 logger = logging.getLogger(__name__)
 
@@ -31,10 +32,19 @@ async def wait_for_job_complete(
     job_name: str,
     timeout_s: int = 1800,
     poll_interval_s: int = 5,
+    stall_timeout_s: int = 1200,
+    liveness_interval_s: int = 60,
 ) -> JobState:
-    """Poll the Job until it reports Complete or Failed; raise TimeoutError otherwise."""
+    """Poll the Job until it reports Complete or Failed; raise TimeoutError otherwise.
+
+    Also fails fast when Shadow's simulated clock stops advancing, which otherwise looks
+    exactly like a slow run until the job timeout.
+    """
     batch = BatchV1Api(api_client)
+    core = CoreV1Api(api_client)
+    watch = StallWatch(stall_timeout_s=stall_timeout_s)
     elapsed = 0
+    next_liveness = 0
     while elapsed < timeout_s:
         job = batch.read_namespaced_job_status(name=job_name, namespace=namespace)
         for condition in job.status.conditions or []:
@@ -42,12 +52,36 @@ async def wait_for_job_complete(
                 return "complete"
             if condition.type == "Failed" and condition.status == "True":
                 return "failed"
+        # Job status needs a tight poll; the simulated clock does not, and reading the
+        # pod log every few seconds for hours is a lot of API traffic for no extra signal.
+        if elapsed >= next_liveness:
+            watch.check(_job_simulated_time(core, namespace, job_name), time.monotonic())
+            next_liveness = elapsed + liveness_interval_s
         await asyncio.sleep(poll_interval_s)
         elapsed += poll_interval_s
     raise TimeoutError(
         f"Job `{namespace}/{job_name}` did not complete within {timeout_s}s "
         f"(last conditions: {job.status.conditions})"
     )
+
+
+def _job_simulated_time(core: CoreV1Api, namespace: str, job_name: str) -> Optional[float]:
+    """Simulated time from the job pod's recent output, or None if not readable yet."""
+    try:
+        pods = core.list_namespaced_pod(
+            namespace=namespace, label_selector=f"job-name={job_name}"
+        ).items
+        if not pods:
+            return None
+        name = sorted(pods, key=lambda p: p.metadata.creation_timestamp)[-1].metadata.name
+        return simulated_time_s(
+            core.read_namespaced_pod_log(name=name, namespace=namespace, tail_lines=200)
+        )
+    except Exception as e:
+        # A liveness probe must never be the thing that kills a healthy run, so any
+        # read failure reads as "unknown" and the stall clock keeps its last value.
+        logger.debug(f"Could not read shadow log for liveness check: {e}")
+        return None
 
 
 def _find_job_pod(api_client: ApiClient, namespace: str, job_name: str) -> str:

--- a/src/deployments/shadow/tests/test_liveness.py
+++ b/src/deployments/shadow/tests/test_liveness.py
@@ -71,6 +71,24 @@ def test_unreadable_logs_do_not_trip_it_once_running():
     watch.check(501.0, 60.0)
 
 
+def test_an_extended_read_outage_does_not_kill_a_running_sim():
+    """An API outage longer than the startup grace is still not a startup failure."""
+    watch = StallWatch(stall_timeout_s=100, startup_grace_s=300)
+    watch.check(500.0, 0.0)
+    watch.check(None, 400.0)
+    watch.check(None, 900.0)
+    watch.check(501.0, 950.0)
+
+
+def test_a_stall_is_still_caught_after_a_read_outage():
+    """Unreadable samples must not forgive a stall either: the clock keeps its value."""
+    watch = StallWatch(stall_timeout_s=100, startup_grace_s=300)
+    watch.check(500.0, 0.0)
+    watch.check(None, 400.0)
+    with pytest.raises(RuntimeError, match="livelocked, not slow"):
+        watch.check(500.0, 500.0)
+
+
 def test_default_timeout_tolerates_the_observed_progress_rate():
     """The 50KB quic cell emits a progress line about every two minutes, so the default
     allowance has to sit well above that or a healthy heavy run gets killed."""

--- a/src/deployments/shadow/tests/test_liveness.py
+++ b/src/deployments/shadow/tests/test_liveness.py
@@ -1,0 +1,81 @@
+import pytest
+
+from src.deployments.shadow.liveness import StallWatch, simulated_time_s
+
+PROGRESS = (
+    "Progress: 49% — simulated: 00:09:52.847/00:20:00, realtime: 00:57:00, processes failed: 0"
+)
+WORKER = (
+    "00:57:50.361079 [114:shadow-worker] 00:10:06.976000000 [WARN] "
+    "[pod-31:11.100.31.10] [regular_file.c:393] [regularfile_op] something"
+)
+
+
+def test_reads_the_progress_line():
+    assert simulated_time_s(PROGRESS) == pytest.approx(592.847)
+
+
+def test_falls_back_to_worker_lines_when_progress_is_off():
+    assert simulated_time_s(WORKER) == pytest.approx(606.976)
+
+
+def test_prefers_the_progress_line_over_worker_lines():
+    assert simulated_time_s(f"{WORKER}\n{PROGRESS}") == pytest.approx(592.847)
+
+
+def test_takes_the_latest_of_several():
+    later = PROGRESS.replace("00:09:52.847", "00:11:00.000")
+    assert simulated_time_s(f"{PROGRESS}\n{later}") == pytest.approx(660.0)
+
+
+def test_none_before_the_clock_starts():
+    assert simulated_time_s("shadow starting up\nparsing config\n") is None
+
+
+def test_advancing_time_never_raises():
+    watch = StallWatch(stall_timeout_s=100)
+    for i in range(20):
+        watch.check(float(i), i * 60.0)
+
+
+def test_stalled_time_raises_once_past_the_timeout():
+    watch = StallWatch(stall_timeout_s=100)
+    watch.check(500.0, 0.0)
+    watch.check(500.0, 99.0)  # still inside the allowance
+    with pytest.raises(RuntimeError, match="livelocked, not slow"):
+        watch.check(500.0, 101.0)
+
+
+def test_recovery_resets_the_clock():
+    """A slow but advancing run must not trip the check."""
+    watch = StallWatch(stall_timeout_s=100)
+    watch.check(500.0, 0.0)
+    watch.check(500.0, 90.0)
+    watch.check(501.0, 95.0)  # advanced, so the allowance restarts
+    watch.check(501.0, 180.0)
+
+
+def test_never_starting_raises_after_the_grace_period():
+    watch = StallWatch(stall_timeout_s=100, startup_grace_s=300)
+    watch.check(None, 0.0)
+    watch.check(None, 299.0)
+    with pytest.raises(RuntimeError, match="no simulated time"):
+        watch.check(None, 301.0)
+
+
+def test_unreadable_logs_do_not_trip_it_once_running():
+    """A transient log-read failure returns None; that must not look like a stall."""
+    watch = StallWatch(stall_timeout_s=100, startup_grace_s=300)
+    watch.check(500.0, 0.0)
+    watch.check(None, 50.0)
+    watch.check(501.0, 60.0)
+
+
+def test_default_timeout_tolerates_the_observed_progress_rate():
+    """The 50KB quic cell emits a progress line about every two minutes, so the default
+    allowance has to sit well above that or a healthy heavy run gets killed."""
+    from src.deployments.shadow.runtime import wait_for_job_complete
+
+    default = wait_for_job_complete.__kwdefaults__["stall_timeout_s"]
+    assert default >= 600, "a livelock should still be caught well inside the job timeout"
+    assert default >= 6 * 120, "must survive several progress intervals on the slowest cell"


### PR DESCRIPTION
A livelocked Shadow run is currently indistinguishable from a slow one until the job timeout. `wait_for_job_complete` now watches simulated time and fails fast when it stops advancing.