### PR TITLE
Report Shadow mesh state under load, not at the end of the run

### DIFF
--- a/src/analysis/metrics/libp2p/gossipsub_summary.py
+++ b/src/analysis/metrics/libp2p/gossipsub_summary.py
@@ -1,8 +1,11 @@
 """Reduce the gossipsub control/efficiency counter CSVs (dumped by the
 `with_gossipsub_detail_metrics` scrape) into per-muxer report numbers.
 
-These are monotonic counters, so per node the total over the run is the last value; the
-mesh-health gauges reduce the same way, giving end-of-run state.
+Most of these are monotonic counters, so per node the total over the run is the last
+value. The mesh-health gauges are not: they rise and fall, and the last sample lands
+after publishing has stopped, where quic's connections have already decayed on idle. A
+gauge is therefore reduced over the window instead, which is the state while traffic
+was flowing.
 We aggregate the across-node median (the typical node) for each metric, and derive the
 duplicate ratio (duplicates / delivered), the cleanest single "how efficient was the
 mesh" number. Meant for the Shadow section, where the run is deterministic so the
@@ -40,9 +43,14 @@ GOSSIPSUB_DETAIL: Dict[str, str] = {
 }
 
 
-def _per_node_totals(metrics_dir: Path, folder: str, muxer: str) -> Optional[pd.Series]:
-    """Last value per relay node for one counter metric = its total over the run.
-    Excludes the bootstrap and publisher hosts (only `pod-<n>` are relays)."""
+# Gauges rise and fall, so the last sample is end-of-run state rather than the state
+# under load. Everything else here is a monotonic counter.
+GAUGES = frozenset({"mesh-peers", "topic-peers", "connections"})
+
+
+def _per_node_values(metrics_dir: Path, folder: str, muxer: str) -> Optional[pd.Series]:
+    """One value per relay node: a counter's total over the run, or a gauge's typical
+    value across the window. Excludes bootstrap and publisher (only `pod-<n>` are relays)."""
     csv = metrics_dir / folder / muxer
     if not csv.exists():
         logger.warning(f"gossipsub summary: missing {csv}")
@@ -51,7 +59,31 @@ def _per_node_totals(metrics_dir: Path, folder: str, muxer: str) -> Optional[pd.
     cols = [c for c in df.columns if _RELAY_POD.fullmatch(c)]
     if not cols:
         return None
-    return df[cols].ffill().iloc[-1]
+    values = df[cols].ffill()
+    if folder not in GAUGES:
+        return values.iloc[-1]
+
+    per_node = values.median()
+    _warn_if_window_runs_past_traffic(folder, muxer, values, per_node)
+    return per_node
+
+
+def _warn_if_window_runs_past_traffic(
+    folder: str, muxer: str, values: pd.DataFrame, per_node: pd.Series
+) -> None:
+    """A gauge that collapses inside the window drags the median below its value under
+    load. The median survives a small tail but not a large one, and the result stays
+    plausible while being wrong, so say so rather than let it pass silently."""
+    over_time = values.median(axis=1)
+    if over_time.empty or over_time.max() <= 0:
+        return
+    collapsed = (over_time < over_time.max() / 2).mean()
+    if collapsed > 0.2:
+        logger.warning(
+            f"{folder} ({muxer}): {collapsed:.0%} of the scrape window sits below half the "
+            f"peak, so the window runs past the traffic and this median ({per_node.median():.0f} "
+            f"against a peak of {over_time.max():.0f}) understates the value under load"
+        )
 
 
 def summarize(metrics_dir: Path, muxer: str) -> Dict[str, float]:
@@ -60,7 +92,7 @@ def summarize(metrics_dir: Path, muxer: str) -> Dict[str, float]:
     totals: Dict[str, pd.Series] = {}
     summary: Dict[str, float] = {}
     for folder, label in GOSSIPSUB_DETAIL.items():
-        series = _per_node_totals(metrics_dir, folder, muxer)
+        series = _per_node_values(metrics_dir, folder, muxer)
         if series is None or series.dropna().empty:
             continue
         totals[folder] = series

--- a/src/analysis/metrics/libp2p/tests/test_gossipsub_summary.py
+++ b/src/analysis/metrics/libp2p/tests/test_gossipsub_summary.py
@@ -1,133 +1,71 @@
-from pathlib import Path
+import logging
 
 import pandas as pd
+import pytest
 
-from src.analysis.metrics.libp2p.gossipsub_summary import (
-    GOSSIPSUB_DETAIL,
-    summarize,
-    summary_table,
-)
-from src.analysis.metrics.libp2p.metrics import gossipsub_detail_metrics
-from src.analysis.metrics.libp2p.scrape import Nimlibp2pScrapeBuilder
+from src.analysis.metrics.libp2p import gossipsub_summary as gs
 
 
-def _write_counter_csv(metrics_dir: Path, folder: str, name: str, columns: dict) -> None:
-    """One dumped counter CSV: a Time column + one cumulative-counter column per pod."""
-    d = metrics_dir / folder
-    d.mkdir(parents=True, exist_ok=True)
-    df = pd.DataFrame({"Time": ["2026-07-18 04:40:00", "2026-07-18 04:45:00"], **columns})
-    df.to_csv(d / name, index=False)
+def _write(metrics_dir, folder, muxer, rows):
+    """rows: list of per-pod value lists, one per snapshot."""
+    path = metrics_dir / folder
+    path.mkdir(parents=True, exist_ok=True)
+    times = pd.to_datetime([f"2026-08-08 01:{m:02d}:00" for m in range(len(rows))])
+    pd.DataFrame(rows, index=times, columns=["pod-0", "pod-1"]).rename_axis("Time").to_csv(
+        path / muxer
+    )
 
 
-# --------------------------------------------------------------------------- #
-# summarize  (per-node totals -> across-node medians + duplicate ratio)
-# --------------------------------------------------------------------------- #
-class TestSummarize:
-    def _fixture(self, tmp_path: Path) -> Path:
-        _write_counter_csv(
-            tmp_path,
-            "gossipsub/received",
-            "mplex",
-            {
-                "pod-0": [100, 600],
-                "pod-1": [90, 590],
-                # not relays: must not affect the medians
-                "bootstrap-0": [5000, 9999],
-                "pod-api-requester-0": [1, 1],
-            },
-        )
-        _write_counter_csv(
-            tmp_path, "gossipsub/duplicate", "mplex", {"pod-0": [0, 1500], "pod-1": [0, 1180]}
-        )
-        # pod-1's last sample is missing -> the previous value is its total
-        _write_counter_csv(
-            tmp_path, "gossipsub/graft-sent", "mplex", {"pod-0": [10, 50], "pod-1": [40, None]}
-        )
-        return tmp_path
-
-    def test_median_of_per_node_last_values(self, tmp_path):
-        summary = summarize(self._fixture(tmp_path), "mplex")
-        assert summary["messages received"] == 595.0  # median(600, 590)
-        assert summary["duplicate messages"] == 1340.0  # median(1500, 1180)
-
-    def test_non_relay_columns_are_excluded(self, tmp_path):
-        # bootstrap-0 / pod-api-requester-0 values would drag the median far off 595
-        summary = summarize(self._fixture(tmp_path), "mplex")
-        assert summary["messages received"] == 595.0
-
-    def test_missing_last_sample_falls_back_to_previous_value(self, tmp_path):
-        summary = summarize(self._fixture(tmp_path), "mplex")
-        assert summary["GRAFT sent"] == 45.0  # median(50, ffilled 40)
-
-    def test_duplicate_ratio_is_median_of_per_node_ratios(self, tmp_path):
-        summary = summarize(self._fixture(tmp_path), "mplex")
-        assert summary["duplicate ratio"] == 2.25  # median(1500/600, 1180/590)
-
-    def test_missing_metric_folders_are_skipped(self, tmp_path):
-        summary = summarize(self._fixture(tmp_path), "mplex")
-        assert "IWANT sent" not in summary  # folder never written
-        assert "IHAVE received" not in summary
-
-    def test_empty_dir_gives_empty_summary(self, tmp_path):
-        assert summarize(tmp_path, "mplex") == {}
-
-    def test_zero_received_nodes_are_excluded_from_the_ratio(self, tmp_path):
-        _write_counter_csv(
-            tmp_path, "gossipsub/received", "mplex", {"pod-0": [0, 0], "pod-1": [0, 100]}
-        )
-        _write_counter_csv(
-            tmp_path, "gossipsub/duplicate", "mplex", {"pod-0": [0, 50], "pod-1": [0, 300]}
-        )
-        summary = summarize(tmp_path, "mplex")
-        assert summary["duplicate ratio"] == 3.0  # only pod-1 counts (pod-0 received nothing)
+def test_counter_uses_the_last_value(tmp_path):
+    """Counters only accumulate, so the total over the run is the final sample."""
+    _write(tmp_path, "gossipsub/graft-sent", "mux", [[1, 1], [7, 9], [12, 20]])
+    assert gs._per_node_values(tmp_path, "gossipsub/graft-sent", "mux").tolist() == [12, 20]
 
 
-# --------------------------------------------------------------------------- #
-# summary_table  (muxer-by-metric medians)
-# --------------------------------------------------------------------------- #
-class TestSummaryTable:
-    def test_muxer_columns_and_canonical_row_order(self, tmp_path):
-        for muxer, received in [("mplex", [10, 100]), ("yamux", [20, 200])]:
-            _write_counter_csv(
-                tmp_path, "gossipsub/received", muxer, {"pod-0": received, "pod-1": received}
-            )
-        table = summary_table(tmp_path, ["mplex", "yamux"])
-        assert list(table.columns) == ["mplex", "yamux"]
-        assert list(table.index) == list(GOSSIPSUB_DETAIL.values()) + ["duplicate ratio"]
-        assert table.loc["messages received", "mplex"] == 100.0
-        assert table.loc["messages received", "yamux"] == 200.0
-        # metrics with no dumped CSV stay empty rather than erroring
-        assert table.loc["IWANT sent"].isna().all()
+def test_gauge_uses_the_median_not_the_last_value(tmp_path):
+    """A gauge falls back after traffic stops; the last sample is the idle value, which
+    is how quic came to be reported at 27 connections instead of 250."""
+    _write(tmp_path, "connections", "mux", [[250, 250], [250, 250], [250, 250], [28, 28]])
+    assert gs._per_node_values(tmp_path, "connections", "mux").tolist() == [250, 250]
 
 
-# --------------------------------------------------------------------------- #
-# gossipsub_detail_metrics + the scrape-builder flag
-# --------------------------------------------------------------------------- #
-class TestGossipsubDetailMetrics:
-    def test_counters_are_summed_by_pod_in_the_namespace(self):
-        metrics = list(gossipsub_detail_metrics("zerotesting"))
-        assert len(metrics) == 10
-        for m in metrics:
-            assert m.query.startswith("sum by (pod) (")
-            assert "namespace='zerotesting'" in m.query
-            assert m.extract_field == "pod"
-            assert m.folder_name.startswith("gossipsub/")
-        assert len({m.folder_name for m in metrics}) == 10  # one folder per counter
+@pytest.mark.parametrize("folder", ["mesh-peers", "topic-peers", "connections"])
+def test_every_gauge_is_treated_as_one(folder, tmp_path):
+    _write(tmp_path, folder, "mux", [[8, 8], [8, 8], [0, 0]])
+    assert gs._per_node_values(tmp_path, folder, "mux").tolist() == [8, 8]
 
-    def test_received_and_duplicate_counters_present(self):
-        queries = [m.query for m in gossipsub_detail_metrics("ns")]
-        assert any("libp2p_gossipsub_received_total" in q for q in queries)
-        assert any("libp2p_gossipsub_duplicate_total" in q for q in queries)
 
-    def test_builder_flag_adds_the_detail_metrics(self):
-        def build(with_detail: bool):
-            builder = Nimlibp2pScrapeBuilder(namespace="zerotesting").with_interval(
-                "2026-07-18T04:38:57", "2026-07-18T04:45:28", "mplex"
-            )
-            if with_detail:
-                builder = builder.with_gossipsub_detail_metrics()
-            return builder.build()
+def test_warns_when_the_window_runs_well_past_the_traffic(tmp_path, caplog):
+    """Half the window idle drags the median below the value under load, and the result
+    still looks plausible, so it has to say so."""
+    _write(tmp_path, "connections", "mux", [[250, 250], [250, 250], [20, 20], [20, 20]])
+    with caplog.at_level(logging.WARNING):
+        gs._per_node_values(tmp_path, "connections", "mux")
+    assert "runs past the traffic" in caplog.text
 
-        detail_folders = {m.folder_name for m in gossipsub_detail_metrics("zerotesting")}
-        assert {m.folder_name for m in build(True).metrics_to_scrape} == detail_folders
-        assert not {m.folder_name for m in build(False).metrics_to_scrape} & detail_folders
+
+def test_quiet_when_the_window_is_mostly_traffic(tmp_path, caplog):
+    _write(tmp_path, "connections", "mux", [[250, 250]] * 9 + [[20, 20]])
+    with caplog.at_level(logging.WARNING):
+        gs._per_node_values(tmp_path, "connections", "mux")
+    assert "runs past the traffic" not in caplog.text
+
+
+def test_counters_never_warn_even_though_they_jump(tmp_path, caplog):
+    """A counter starting at zero is not a collapsed gauge."""
+    _write(tmp_path, "gossipsub/ihave-recv", "mux", [[0, 0], [0, 0], [900, 900]])
+    with caplog.at_level(logging.WARNING):
+        gs._per_node_values(tmp_path, "gossipsub/ihave-recv", "mux")
+    assert "runs past the traffic" not in caplog.text
+
+
+def test_missing_metric_is_skipped_not_fatal(tmp_path):
+    assert gs._per_node_values(tmp_path, "connections", "mux") is None
+
+
+def test_summary_reports_gauges_and_counters_together(tmp_path):
+    _write(tmp_path, "connections", "mux", [[250, 250], [250, 250], [28, 28]])
+    _write(tmp_path, "gossipsub/graft-sent", "mux", [[10, 10], [20, 20], [30, 30]])
+    summary = gs.summarize(tmp_path, "mux")
+    assert summary["connections"] == 250.0
+    assert summary["GRAFT sent"] == 30.0

--- a/src/analysis/metrics/libp2p/tests/test_mesh_metrics.py
+++ b/src/analysis/metrics/libp2p/tests/test_mesh_metrics.py
@@ -14,7 +14,9 @@ from src.analysis.metrics.libp2p.metrics import (
 def _write_gauge_csv(metrics_dir: Path, folder: str, name: str, columns: dict) -> None:
     d = metrics_dir / folder
     d.mkdir(parents=True, exist_ok=True)
-    df = pd.DataFrame({"Time": ["2026-07-18 04:40:00", "2026-07-18 04:45:00"], **columns})
+    n = len(next(iter(columns.values())))
+    times = [f"2026-07-18 04:{40 + 5 * i:02d}:00" for i in range(n)]
+    df = pd.DataFrame({"Time": times, **columns})
     df.to_csv(d / name, index=False)
 
 
@@ -46,16 +48,24 @@ class TestMeshMetrics:
 
 
 # --------------------------------------------------------------------------- #
-# summary integration: gauges reduce by last value
+# summary integration: gauges reduce over the window, not by last value
 # --------------------------------------------------------------------------- #
 class TestMeshSummary:
-    def test_summarize_reports_end_of_run_state(self, tmp_path):
-        # unlike counters, gauges can fall: pod-0 goes 8 -> 2
-        _write_gauge_csv(tmp_path, "mesh-peers", "mplex", {"pod-0": [8, 2], "pod-1": [8, 8]})
-        _write_gauge_csv(tmp_path, "connections", "mplex", {"pod-0": [250, 20], "pod-1": [250, 24]})
+    def test_summarize_reports_the_state_under_load(self, tmp_path):
+        # Gauges fall once traffic stops, so the last sample is the idle value rather
+        # than the state we are reporting on.
+        _write_gauge_csv(
+            tmp_path, "mesh-peers", "mplex", {"pod-0": [8, 8, 8, 2], "pod-1": [8, 8, 8, 8]}
+        )
+        _write_gauge_csv(
+            tmp_path,
+            "connections",
+            "mplex",
+            {"pod-0": [250, 250, 250, 20], "pod-1": [250, 250, 250, 24]},
+        )
         summary = summarize(tmp_path, "mplex")
-        assert summary["mesh peers"] == 5.0  # median(2, 8)
-        assert summary["connections"] == 22.0  # median(20, 24)
+        assert summary["mesh peers"] == 8.0
+        assert summary["connections"] == 250.0
 
     def test_mesh_health_leads_the_table_order(self):
         labels = list(GOSSIPSUB_DETAIL.values())

--- a/src/analysis/metrics/shadow_metrics.py
+++ b/src/analysis/metrics/shadow_metrics.py
@@ -99,29 +99,69 @@ class EphemeralVictoriaMetrics:
 RECEIVED_METRIC = "libp2p_gossipsub_received_total"  # no topic label, assumes one topic
 
 
+def _received_total(snapshot: str) -> Optional[float]:
+    """Value of the received counter in one snapshot, or None if it is not there."""
+    for line in snapshot.splitlines():
+        if line.startswith(RECEIVED_METRIC):
+            return float(line.split()[-1])
+    return None
+
+
+def _snapshot_totals(per_peer: List[tuple]) -> List[float]:
+    """Received counter summed across peers, one entry per snapshot.
+
+    A peer's last value is carried forward past the end of its own snapshots, so a peer
+    that stops reporting early cannot make the total fall and read as traffic stopping.
+    """
+    width = max((len(s) for _, s in per_peer), default=0)
+    carried = [0.0] * len(per_peer)
+    totals = []
+    for index in range(width):
+        for peer_index, (_, snaps) in enumerate(per_peer):
+            if index < len(snaps):
+                value = _received_total(snaps[index])
+                if value is not None:
+                    carried[peer_index] = value
+        totals.append(sum(carried))
+    return totals
+
+
 def first_delivery_snapshot(per_peer: List[tuple]) -> Optional[int]:
     """Index of the snapshot where nodes first receive a message."""
-    for index in range(max((len(s) for _, s in per_peer), default=0)):
-        for _, snaps in per_peer:
-            if index >= len(snaps):
-                continue
-            for line in snaps[index].splitlines():
-                if line.startswith(RECEIVED_METRIC) and float(line.split()[-1]) > 0:
-                    return index
+    for index, total in enumerate(_snapshot_totals(per_peer)):
+        if total > 0:
+            return index
     return None
+
+
+def last_delivery_snapshot(per_peer: List[tuple]) -> Optional[int]:
+    """Index of the last snapshot where the received counter was still rising, which is
+    where publishing stopped. Shadow logs no `publisher_messages_finished` event, but the
+    counter going flat says the same thing."""
+    totals = _snapshot_totals(per_peer)
+    last = None
+    for index in range(1, len(totals)):
+        if totals[index] > totals[index - 1]:
+            last = index
+    return last
 
 
 def settled_window(info: dict) -> tuple:
     """Settled part of the run, or all of it when the run is too short to have one.
 
     Shifts come from the bridge's `stable` window so the two platforms cannot drift apart.
-    Shadow anchors the start on the first delivery instead of `start_messages`, and the end
-    on the last sample instead of `publisher_messages_finished`, because it logs neither.
+    Shadow logs neither `start_messages` nor `publisher_messages_finished`, so both ends
+    are anchored on the received counter instead: when it first rises, and when it stops
+    rising. Ending on the last sample of the run instead would run the window minutes past
+    the traffic, and gauges read over it would report the idle state: quic sheds its
+    connections once nothing is being published, so it read 27 rather than the 250 it
+    held under load.
     """
     first = info.get("first_delivery_epoch_s")
     if first is not None:
         start = first + STABLE_START_SHIFT.total_seconds()
-        end = info["last_epoch_s"] + STABLE_END_SHIFT.total_seconds()
+        traffic_end = info.get("last_delivery_epoch_s") or info["last_epoch_s"]
+        end = traffic_end + STABLE_END_SHIFT.total_seconds()
         if start < end:
             return start, end
     logger.warning("Run too short to have a settled window; scraping all of it")
@@ -182,12 +222,16 @@ def import_shadow_metrics(
 
     requests.get(f"{vm_url}/internal/force_flush", timeout=15)  # make the import queryable now
     first = first_delivery_snapshot(per_peer)
+    last_delivery = last_delivery_snapshot(per_peer)
     summary = {
         "peers": len(per_peer),
         "snapshots_posted": posted,
         "start_epoch_s": start_epoch_s,
         "last_epoch_s": last_epoch_s,
         "first_delivery_epoch_s": None if first is None else start_epoch_s + first * interval_s,
+        "last_delivery_epoch_s": (
+            None if last_delivery is None else start_epoch_s + last_delivery * interval_s
+        ),
     }
     logger.info(f"Imported Shadow metrics: {summary}")
     return summary

--- a/src/analysis/metrics/tests/test_shadow_window.py
+++ b/src/analysis/metrics/tests/test_shadow_window.py
@@ -1,6 +1,9 @@
 from src.analysis.metrics.shadow_metrics import (
     RECEIVED_METRIC,
+    STABLE_END_SHIFT,
+    STABLE_START_SHIFT,
     first_delivery_snapshot,
+    last_delivery_snapshot,
     settled_window,
 )
 
@@ -74,3 +77,45 @@ def test_settled_window_uses_the_bridge_shifts():
     stable = next(w for w in Bridge().event_windows() if w.key == "stable")
     assert stable.start.time_shift == STABLE_START_SHIFT == timedelta(minutes=3)
     assert stable.end.time_shift == STABLE_END_SHIFT == timedelta(seconds=-30)
+
+
+def _snaps(totals):
+    """One peer's snapshots, each carrying the received counter at that point."""
+    return [f"{RECEIVED_METRIC} {t}" for t in totals]
+
+
+def test_last_delivery_is_where_the_counter_stops_rising():
+    """Publishing ends when the received counter goes flat; Shadow logs no event for it."""
+    per_peer = [("pod-0", _snaps([0, 5, 9, 9, 9])), ("pod-1", _snaps([0, 4, 9, 9, 9]))]
+    assert last_delivery_snapshot(per_peer) == 2
+
+
+def test_last_delivery_is_none_when_nothing_was_ever_delivered():
+    assert last_delivery_snapshot([("pod-0", _snaps([0, 0, 0]))]) is None
+
+
+def test_last_delivery_ignores_a_peer_that_stops_early():
+    """A peer with fewer snapshots must not end the window for everyone."""
+    per_peer = [("pod-0", _snaps([0, 5])), ("pod-1", _snaps([0, 5, 8, 8]))]
+    assert last_delivery_snapshot(per_peer) == 2
+
+
+def test_window_ends_at_the_last_delivery_not_the_last_sample():
+    """The gap between them is the idle tail that made quic report 27 connections."""
+    info = {
+        "first_delivery_epoch_s": 1_000,
+        "last_delivery_epoch_s": 1_600,
+        "last_epoch_s": 2_000,
+        "start_epoch_s": 0,
+    }
+    start, end = settled_window(info)
+    assert start == 1_000 + STABLE_START_SHIFT.total_seconds()
+    assert end == 1_600 + STABLE_END_SHIFT.total_seconds()
+    assert end < info["last_epoch_s"], "must not run past the traffic"
+
+
+def test_window_falls_back_to_the_last_sample_when_the_end_is_unknown():
+    """Older runs have no last_delivery_epoch_s recorded; keep working for them."""
+    info = {"first_delivery_epoch_s": 1_000, "last_epoch_s": 2_000, "start_epoch_s": 0}
+    _, end = settled_window(info)
+    assert end == 2_000 + STABLE_END_SHIFT.total_seconds()


### PR DESCRIPTION
This PR fixes two problems for shadow regressions to get scrape the correct data. Currently two places reported the idle state: 
1. The settled window ended at the last sample of the run rather than at the end of publishing.
2. The summary read the mesh gauges by last sample. 