### PR TITLE
Read a scrape's metric folder as well as a plain CSV path

### DIFF
--- a/src/analysis/data/data_file_handler.py
+++ b/src/analysis/data/data_file_handler.py
@@ -85,6 +85,24 @@ class DataFileHandler(DataHandler):
 
         return Ok(target_df)
 
+    def _resolve_csv_paths(self, path: Path) -> List[Path]:
+        """A DataPath's CSVs: the file itself, or the ones a scrape wrote inside the folder.
+
+        Scrapper dumps `<location>/<metric folder>/<run name>.csv`, so pointing a DataPath at
+        a scrape dump lands on the metric folder rather than a file.
+        """
+        if path.is_file():
+            return [path]
+
+        match file_utils.get_files_from_folder_path(path, self._include_files, extension="csv"):
+            case Ok(file_names):
+                if not file_names:
+                    self._report_no_csvs(path)
+                return sorted(path / name for name in file_names)
+            case Err(error):
+                logger.error(error)
+                return []
+
     def concat_dataframes_from_files(
         self,
         named_files: List[DataPath],
@@ -97,22 +115,26 @@ class DataFileHandler(DataHandler):
                 logger.error(f"{file_path} cannot be loaded.")
                 continue
 
-            logger.info(f"Reading {file_path} with {points} datapoints")
-            file_df = pd.read_csv(file_path, parse_dates=["Time"], index_col="Time", nrows=points)
-            if len(file_df) < points:
-                logger.warning(f"Not enough datapoints in {file_path}")
+            for csv_path in self._resolve_csv_paths(file_path):
+                self._append_csv(csv_path, data_file.name, group_name, points)
 
-            if self._ignore_columns:
-                columns_to_drop = [
-                    col
-                    for col in file_df.columns
-                    if any(col.startswith(prefix) for prefix in self._ignore_columns)
-                ]
-                if columns_to_drop:
-                    logger.info(f"Dropping {len(columns_to_drop)} columns: {columns_to_drop}")
-                    file_df = file_df.drop(columns=columns_to_drop)
+    def _append_csv(self, file_path: Path, name: str, group_name: str, points: int) -> None:
+        logger.info(f"Reading {file_path} with {points} datapoints")
+        file_df = pd.read_csv(file_path, parse_dates=["Time"], index_col="Time", nrows=points)
+        if len(file_df) < points:
+            logger.warning(f"Not enough datapoints in {file_path}")
 
-            file_df = file_df.reset_index(drop=True)
-            file_df["class"] = group_name
-            file_df["variable"] = data_file.name
-            self._dataframe = pd.concat([self._dataframe, file_df], ignore_index=True)
+        if self._ignore_columns:
+            columns_to_drop = [
+                col
+                for col in file_df.columns
+                if any(col.startswith(prefix) for prefix in self._ignore_columns)
+            ]
+            if columns_to_drop:
+                logger.info(f"Dropping {len(columns_to_drop)} columns: {columns_to_drop}")
+                file_df = file_df.drop(columns=columns_to_drop)
+
+        file_df = file_df.reset_index(drop=True)
+        file_df["class"] = group_name
+        file_df["variable"] = name
+        self._dataframe = pd.concat([self._dataframe, file_df], ignore_index=True)

--- a/src/analysis/data/tests/test_data_file_handler.py
+++ b/src/analysis/data/tests/test_data_file_handler.py
@@ -2,7 +2,7 @@ import logging
 
 import pandas as pd
 
-from src.analysis.data.data_file_handler import DataFileHandler
+from src.analysis.data.data_file_handler import DataFileHandler, DataPath
 
 
 def _write_csv(path, rows=3, value=1.0):
@@ -45,3 +45,50 @@ def test_an_empty_folder_still_reports(tmp_path, caplog):
     with caplog.at_level(logging.ERROR):
         assert _mean(tmp_path / "libp2p-in").empty
     assert "holds no files" in caplog.text
+
+
+def _concat(path, name="run"):
+    handler = DataFileHandler()
+    handler.concat_dataframes_from_files([DataPath(name=name, path=path)], "group", 3)
+    return handler.dataframe
+
+
+def test_reads_a_file_directly(tmp_path):
+    _write_csv(tmp_path / "libp2p-in")
+    assert len(_concat(tmp_path / "libp2p-in")) == 3
+
+
+def test_reads_a_scrape_metric_folder(tmp_path):
+    """Scrapper writes `<location>/<metric>/<run name>.csv`, so the path is a folder."""
+    _write_csv(tmp_path / "libp2p-in" / "quic.csv")
+    df = _concat(tmp_path / "libp2p-in")
+    assert len(df) == 3
+    assert df["variable"].unique().tolist() == ["run"]
+
+
+def test_reads_every_csv_in_the_folder(tmp_path):
+    _write_csv(tmp_path / "libp2p-in" / "quic.csv", value=1.0)
+    _write_csv(tmp_path / "libp2p-in" / "tcp.csv", value=2.0)
+    df = _concat(tmp_path / "libp2p-in")
+    assert len(df) == 6
+    assert sorted(df["pod-0"].unique()) == [1.0, 2.0]
+
+
+def test_missing_path_is_skipped_not_fatal(tmp_path, caplog):
+    with caplog.at_level(logging.ERROR):
+        assert _concat(tmp_path / "absent").empty
+    assert "cannot be loaded" in caplog.text
+
+
+def test_subfolders_are_not_mistaken_for_csvs(tmp_path):
+    """get_files_from_folder_path keeps files only, so a nested dir cannot be read as CSV."""
+    _write_csv(tmp_path / "libp2p-in" / "quic.csv")
+    (tmp_path / "libp2p-in" / "nested").mkdir()
+    assert len(_concat(tmp_path / "libp2p-in")) == 3
+
+
+def test_a_folder_read_reports_a_pre_suffix_scrape_too(tmp_path, caplog):
+    _write_csv(tmp_path / "libp2p-in" / "quic")
+    with caplog.at_level(logging.ERROR):
+        assert _concat(tmp_path / "libp2p-in").empty
+    assert "no .csv suffix" in caplog.text


### PR DESCRIPTION
Lets MetricsPlotter consume a Scrapper dump directly instead of needing the files copied into a different layout first.