### PR TITLE
Shape every run with the WAN profile by default

### DIFF
--- a/src/deployments/experiments/libp2p/nimlibp2p.py
+++ b/src/deployments/experiments/libp2p/nimlibp2p.py
@@ -45,9 +45,8 @@ class ExpConfig(BaseModel):
     bootstrap_nodes: NonNegativeInt = 1
     network_delay: NonNegativeInt = WAN_LATENCY_MS
     network_jitter: NonNegativeInt = 0
-    network_bandwidth_mbit: NonNegativeInt = (
-        WAN_BANDWIDTH_MBIT  # 0 = uncapped; folded into the netem qdisc
-    )
+    network_bandwidth_mbit: NonNegativeInt = WAN_BANDWIDTH_MBIT
+    """Link rate, folded into the netem qdisc; 0 leaves it uncapped."""
     network_loss_pct: float = Field(default=0, ge=0, le=100)  # percent; folded into the netem qdisc
     node_start_delay: NonNegativeInt = 60
     post_publish_dwell: NonNegativeInt = 90

--- a/src/deployments/experiments/libp2p/nimlibp2p.py
+++ b/src/deployments/experiments/libp2p/nimlibp2p.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, NonNegativeFloat, NonNegative
 from src.deployments.core.builders import ServiceBuilder
 from src.deployments.core.configs.container import Image
 from src.deployments.experiments.base_experiment import BaseExperiment
-from src.deployments.libp2p.bridge import Bridge
+from src.deployments.libp2p.bridge import WAN_BANDWIDTH_MBIT, WAN_LATENCY_MS, Bridge
 from src.deployments.libp2p.builders.builders import Libp2pStatefulSetBuilder
 from src.deployments.libp2p.builders.builders import Option as NimLibp2p
 from src.deployments.libp2p.builders.helpers import readiness_probe_metrics
@@ -43,9 +43,11 @@ class ExpConfig(BaseModel):
     connect_to: NonNegativeInt = 10
     """Number of nodes to try to connect to for each node when starting up"""
     bootstrap_nodes: NonNegativeInt = 1
-    network_delay: NonNegativeInt = 0
+    network_delay: NonNegativeInt = WAN_LATENCY_MS
     network_jitter: NonNegativeInt = 0
-    network_bandwidth_mbit: NonNegativeInt = 0  # 0 = uncapped; folded into the netem qdisc
+    network_bandwidth_mbit: NonNegativeInt = (
+        WAN_BANDWIDTH_MBIT  # 0 = uncapped; folded into the netem qdisc
+    )
     network_loss_pct: float = Field(default=0, ge=0, le=100)  # percent; folded into the netem qdisc
     node_start_delay: NonNegativeInt = 60
     post_publish_dwell: NonNegativeInt = 90

--- a/src/deployments/experiments/libp2p/shadow_gossipsub.py
+++ b/src/deployments/experiments/libp2p/shadow_gossipsub.py
@@ -6,6 +6,7 @@ from typing import ClassVar, Literal, Optional
 from pydantic import BaseModel, ConfigDict, NonNegativeFloat, NonNegativeInt, PositiveInt
 
 from src.deployments.experiments.base_experiment import BaseExperiment
+from src.deployments.libp2p.bridge import WAN_BANDWIDTH_MBIT, WAN_LATENCY_MS
 from src.deployments.registry import experiment
 from src.deployments.shadow.builders import (
     build_configmap,
@@ -46,8 +47,8 @@ class ExpConfig(BaseModel):
     lsquic_tick_floor_us: NonNegativeInt = 0
     # Per-pod process start stagger (pod-i starts at 5000 + i*jitter ms); 0 = lockstep.
     start_jitter_ms: NonNegativeInt = 0
-    latency_ms: Optional[NonNegativeInt] = None
-    bandwidth_mbit: Optional[PositiveInt] = None
+    latency_ms: Optional[NonNegativeInt] = WAN_LATENCY_MS
+    bandwidth_mbit: Optional[PositiveInt] = WAN_BANDWIDTH_MBIT
     loss_pct: NonNegativeFloat = 0
     # Peers per /24; 1 = every peer on its own subnet.
     hosts_per_subnet: PositiveInt = 1

--- a/src/deployments/experiments/tests/test_wan_profile.py
+++ b/src/deployments/experiments/tests/test_wan_profile.py
@@ -1,0 +1,35 @@
+from src.deployments.experiments.libp2p.degraded import DegradedConfig
+from src.deployments.experiments.libp2p.nimlibp2p import ExpConfig, build_nodes
+from src.deployments.experiments.libp2p.shadow_gossipsub import ExpConfig as ShadowConfig
+from src.deployments.libp2p.bridge import WAN_BANDWIDTH_MBIT, WAN_LATENCY_MS
+
+
+def test_cluster_runs_are_shaped_by_default():
+    config = ExpConfig()
+    assert config.network_delay == WAN_LATENCY_MS
+    assert config.network_bandwidth_mbit == WAN_BANDWIDTH_MBIT
+
+
+def test_shadow_runs_are_shaped_by_default():
+    """Both platforms take the profile from one constant so they cannot drift apart."""
+    config = ShadowConfig()
+    assert config.latency_ms == WAN_LATENCY_MS
+    assert config.bandwidth_mbit == WAN_BANDWIDTH_MBIT
+
+
+def test_the_qdisc_is_actually_attached_without_a_values_file():
+    nodes = build_nodes(namespace="test", params=ExpConfig())
+    init_containers = nodes.spec.template.spec.init_containers or []
+    commands = " ".join(" ".join(c.command or []) + " ".join(c.args or []) for c in init_containers)
+    assert "netem" in commands
+    assert f"{WAN_LATENCY_MS}ms" in commands
+
+
+def test_a_scenario_can_still_override_the_profile():
+    assert DegradedConfig().network_delay == 200
+
+
+def test_shaping_can_be_turned_off_explicitly():
+    config = ExpConfig(network_delay=0, network_bandwidth_mbit=0)
+    nodes = build_nodes(namespace="test", params=config)
+    assert not (nodes.spec.template.spec.init_containers or [])

--- a/src/deployments/libp2p/bridge.py
+++ b/src/deployments/libp2p/bridge.py
@@ -14,6 +14,10 @@ STABLE_START_SHIFT = timedelta(minutes=3)
 STABLE_END_SHIFT = timedelta(seconds=-30)
 """How far before publishing ends to stop, so teardown stays out of the window."""
 
+WAN_LATENCY_MS = 50
+"""Standard link profile for the regression matrix, applied on both platforms."""
+WAN_BANDWIDTH_MBIT = 50
+
 
 class Bridge(event_window_bridge.EventWindowBridge):
     interval: Literal["complete", "stable"] = "complete"


### PR DESCRIPTION
Makes 50ms/50Mbit the default on both platforms, so the code matches what the rulebook already requires.