### PR TITLE
Record the image digest the nodes actually pulled

### DIFF
--- a/src/deployments/core/k8s_rollout.py
+++ b/src/deployments/core/k8s_rollout.py
@@ -225,6 +225,26 @@ def get_pods_for_statefulset(name: str, namespace: str, api_client=None) -> Iter
     )
 
 
+def resolved_images(name: str, namespace: str, api_client=None) -> dict:
+    """Digest each container of a StatefulSet's pods actually pulled, keyed by container.
+
+    A pod spec holds a mutable tag, so it does not say which binary ran. Values are lists
+    because a mid-run rollout can leave pods on different digests.
+    """
+    digests: dict = {}
+    try:
+        pods = get_pods_for_statefulset(name, namespace, api_client)
+    except ApiException as e:
+        logger.warning(f"Could not resolve images for `{namespace}/{name}`: {e}")
+        return digests
+
+    for pod in pods:
+        for status in pod.status.container_statuses or []:
+            if status.image_id:
+                digests.setdefault(status.name, set()).add(status.image_id)
+    return {container: sorted(ids) for container, ids in digests.items()}
+
+
 def check_pod_condition(
     pod: V1Pod, condition: Optional[Tuple[str, str] | Callable[[V1Pod], bool]] = None
 ) -> bool:

--- a/src/deployments/core/k8s_rollout.py
+++ b/src/deployments/core/k8s_rollout.py
@@ -239,7 +239,7 @@ def resolved_images(name: str, namespace: str, api_client=None) -> dict:
         return digests
 
     for pod in pods:
-        for status in pod.status.container_statuses or []:
+        for status in getattr(pod.status, "container_statuses", None) or []:
             if status.image_id:
                 digests.setdefault(status.name, set()).add(status.image_id)
     return {container: sorted(ids) for container, ids in digests.items()}

--- a/src/deployments/core/tests/test_resolved_images.py
+++ b/src/deployments/core/tests/test_resolved_images.py
@@ -1,0 +1,66 @@
+import logging
+from unittest.mock import MagicMock
+
+from kubernetes.client.rest import ApiException
+
+from src.deployments.core import k8s_rollout
+from src.deployments.core.k8s_rollout import resolved_images
+
+DIGEST = "docker.io/radiken/dst-test-node@sha256:" + "a" * 64
+OTHER = "docker.io/radiken/dst-test-node@sha256:" + "b" * 64
+
+
+def _container(name, image_id):
+    # `name` is a MagicMock constructor kwarg, so it has to be set after construction.
+    status = MagicMock(image_id=image_id)
+    status.name = name
+    return status
+
+
+def _pod(*containers):
+    pod = MagicMock()
+    pod.status.container_statuses = [_container(name, image_id) for name, image_id in containers]
+    return pod
+
+
+def test_reports_the_digest_the_pods_pulled(mocker):
+    mocker.patch.object(
+        k8s_rollout, "get_pods_for_statefulset", return_value=[_pod(("libp2p-node", DIGEST))] * 3
+    )
+    assert resolved_images("pod", "zerotesting") == {"libp2p-node": [DIGEST]}
+
+
+def test_a_split_rollout_reports_both_digests(mocker):
+    """One mutable tag can resolve differently per pod; a single value would hide that."""
+    mocker.patch.object(
+        k8s_rollout,
+        "get_pods_for_statefulset",
+        return_value=[_pod(("libp2p-node", DIGEST)), _pod(("libp2p-node", OTHER))],
+    )
+    assert resolved_images("pod", "zerotesting") == {"libp2p-node": [DIGEST, OTHER]}
+
+
+def test_containers_are_reported_separately(mocker):
+    mocker.patch.object(
+        k8s_rollout,
+        "get_pods_for_statefulset",
+        return_value=[_pod(("libp2p-node", DIGEST), ("sidecar", OTHER))],
+    )
+    assert resolved_images("pod", "zerotesting") == {"libp2p-node": [DIGEST], "sidecar": [OTHER]}
+
+
+def test_pods_that_have_not_pulled_yet_are_skipped(mocker):
+    mocker.patch.object(
+        k8s_rollout, "get_pods_for_statefulset", return_value=[_pod(("libp2p-node", ""))]
+    )
+    assert resolved_images("pod", "zerotesting") == {}
+
+
+def test_an_api_error_does_not_take_the_run_down(mocker, caplog):
+    """Recording which binary ran is worth a warning, not a failed experiment."""
+    mocker.patch.object(
+        k8s_rollout, "get_pods_for_statefulset", side_effect=ApiException(status=403)
+    )
+    with caplog.at_level(logging.WARNING):
+        assert resolved_images("pod", "zerotesting") == {}
+    assert "Could not resolve images" in caplog.text

--- a/src/deployments/core/tests/test_resolved_images.py
+++ b/src/deployments/core/tests/test_resolved_images.py
@@ -64,3 +64,12 @@ def test_an_api_error_does_not_take_the_run_down(mocker, caplog):
     with caplog.at_level(logging.WARNING):
         assert resolved_images("pod", "zerotesting") == {}
     assert "Could not resolve images" in caplog.text
+
+
+def test_a_pod_that_has_not_started_reports_nothing_rather_than_a_wrong_digest(mocker):
+    """Read before the pods run, container_statuses is empty; the caller must see that."""
+    pod = MagicMock()
+    pod.metadata.name = "pod-0"
+    pod.status.container_statuses = None
+    mocker.patch.object(k8s_rollout, "get_pods_for_statefulset", return_value=[pod])
+    assert resolved_images("pod", "zerotesting") == {}

--- a/src/deployments/experiments/libp2p/nimlibp2p.py
+++ b/src/deployments/experiments/libp2p/nimlibp2p.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, NonNegativeFloat, NonNegative
 
 from src.deployments.core.builders import ServiceBuilder
 from src.deployments.core.configs.container import Image
+from src.deployments.core.k8s_rollout import resolved_images
 from src.deployments.experiments.base_experiment import BaseExperiment
 from src.deployments.libp2p.bridge import Bridge
 from src.deployments.libp2p.builders.builders import Libp2pStatefulSetBuilder
@@ -242,6 +243,14 @@ class NimLibp2pExperiment(BaseExperiment[ExpConfig]):
         namespace = nodes.metadata.namespace
 
         await self.deploy(deployment=nodes, wait_for_ready=self.config.wait_nodes_ready)
+
+        self.log_event(
+            {
+                "event": "images_resolved",
+                "requested": f"{self.config.image.repo}:{self.config.image.tag}",
+                "resolved": resolved_images(name, namespace, self.api_client),
+            }
+        )
 
         await self._after_nodes(nodes)
 

--- a/src/deployments/experiments/libp2p/nimlibp2p.py
+++ b/src/deployments/experiments/libp2p/nimlibp2p.py
@@ -244,6 +244,12 @@ class NimLibp2pExperiment(BaseExperiment[ExpConfig]):
 
         await self.deploy(deployment=nodes, wait_for_ready=self.config.wait_nodes_ready)
 
+        await self._after_nodes(nodes)
+
+        await asyncio.sleep(self.config.delay_cold_start)
+
+        # After the cold start, not the deploy: a scenario that does not wait for readiness
+        # has pods with no container status yet, which would record no digest at all.
         self.log_event(
             {
                 "event": "images_resolved",
@@ -251,10 +257,6 @@ class NimLibp2pExperiment(BaseExperiment[ExpConfig]):
                 "resolved": resolved_images(name, namespace, self.api_client),
             }
         )
-
-        await self._after_nodes(nodes)
-
-        await asyncio.sleep(self.config.delay_cold_start)
 
         logger.info(f"Starting publish loop for nodes in `{name}`")
 


### PR DESCRIPTION
Logs an `images_resolved` event so a run's output says which binary ran, not just which tag was asked for.

Related to #158 