### PR TITLE
Bound the publish request and fail a run that lost messages

### DIFF
--- a/src/deployments/experiments/base_experiment.py
+++ b/src/deployments/experiments/base_experiment.py
@@ -11,7 +11,7 @@ from contextlib import ExitStack
 from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, ClassVar, Dict, Generic, Literal, Optional, TypeVar, Union
+from typing import Any, ClassVar, Dict, Generic, List, Literal, Optional, TypeVar, Union
 
 from kubernetes.client import (
     ApiClient,
@@ -70,6 +70,10 @@ V1Deployable = Union[
 logger = logging.getLogger(__name__)
 
 
+class ExperimentFailed(Exception):
+    """The run completed but its result is not usable."""
+
+
 TCfg = TypeVar("TCfg", bound=BaseModel)
 
 
@@ -119,6 +123,9 @@ class BaseExperiment(ABC, BaseModel, Generic[TCfg]):
     _workdir: Optional[Path] = None
     """Path to deployment output folder. Based off of self.output_folder"""
     _stack: Optional[ExitStack]
+
+    _failures: List[str] = PrivateAttr(default_factory=list)
+    """Reasons the run is invalid, raised once it has finished. See `fail_run`."""
 
     @model_validator(mode="after")
     def set_type(self):
@@ -357,6 +364,20 @@ class BaseExperiment(ABC, BaseModel, Generic[TCfg]):
         self._dump_metadata()
         if run_post_analysis:
             dispatch_post_analysis(self)
+
+        if self._failures:
+            raise ExperimentFailed(f"`{self._type}`: " + "; ".join(self._failures))
+
+    def fail_run(self, reason: str) -> None:
+        """Mark the run invalid without cutting it short.
+
+        Raising from `_run` would skip metadata and post-run analysis while cleanup still
+        deletes the pods, so the data is lost as well as the result. Recording the reason
+        lets the run finish and collect its data, then exit non-zero.
+        """
+        logger.error(reason)
+        self.log_event({"event": "run_invalid", "reason": reason})
+        self._failures.append(reason)
 
     @abstractmethod
     async def _run(self):

--- a/src/deployments/experiments/libp2p/nimlibp2p.py
+++ b/src/deployments/experiments/libp2p/nimlibp2p.py
@@ -49,6 +49,8 @@ class ExpConfig(BaseModel):
     network_loss_pct: float = Field(default=0, ge=0, le=100)  # percent; folded into the netem qdisc
     node_start_delay: NonNegativeInt = 60
     post_publish_dwell: NonNegativeInt = 90
+    max_failed_publishes: NonNegativeInt = 0
+    """Publishes that may fail before the run is treated as invalid."""
     wait_nodes_ready: bool = True
 
     @model_validator(mode="after")
@@ -164,7 +166,8 @@ def build_bootstrap_nodes(namespace: str, params: ExpConfig) -> V1StatefulSet:
     )
 
 
-async def publish(config, namespace, random_name):
+async def publish(config, namespace, random_name) -> bool:
+    """Publish one message. Returns whether it reached the node."""
     try:
         target = Target(
             name="libp2p-node",
@@ -175,12 +178,14 @@ async def publish(config, namespace, random_name):
         await libp2p_dst_node_publish(
             namespace=namespace, target=target, msg_size_bytes=config.message_size_bytes
         )
+        return True
     except PodApiApplicationError as e:
         logger.error(f"PodApiApplicationError: {e} {traceback.format_exc()}")
     except PodApiError as e:
         logger.error(f"PodApiError: {e} {traceback.format_exc()}")
     except Exception as e:
         logger.error(f"Other exception: {e} {traceback.format_exc()}")
+    return False
 
 
 @experiment(name="nimlibp2p")
@@ -260,7 +265,9 @@ class NimLibp2pExperiment(BaseExperiment[ExpConfig]):
             self.log_event({"event": "publish", "node": random_name, "index": msg_index})
             tasks.append(asyncio.create_task(publish(self.config, namespace, random_name)))
             await asyncio.sleep(self.config.delay_after_publish)
-        await asyncio.gather(*tasks)
+        published = await asyncio.gather(*tasks)
+        failed = published.count(False)
+        self.log_event({"event": "publish_summary", "attempted": len(published), "failed": failed})
 
         self.log_event("publisher_messages_finished")
 
@@ -268,5 +275,11 @@ class NimLibp2pExperiment(BaseExperiment[ExpConfig]):
 
         await asyncio.sleep(self.config.post_publish_dwell)
         self.log_event("publisher_wait_finished")
+
+        if failed > self.config.max_failed_publishes:
+            self.fail_run(
+                f"{failed} of {len(published)} messages were never published, so delivery "
+                f"is measured against a denominator the run did not send"
+            )
 
         self.log_event("internal_run_finished")

--- a/src/deployments/experiments/multi_experiment.py
+++ b/src/deployments/experiments/multi_experiment.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, ConfigDict
 
 from src.analysis.post_run_analysis import run_post_analysis
-from src.deployments.experiments.base_experiment import BaseExperiment
+from src.deployments.experiments.base_experiment import BaseExperiment, ExperimentFailed
 from src.deployments.registry import experiment
 from src.deployments.registry import registry as experiment_registry
 from src.deployments.utils.parser import ARG_NOT_SET
@@ -79,6 +79,7 @@ class Multiple(BaseExperiment[Config]):
             self.config.delay
         ), "Delay between experiments must be specified either in the subclass or the cli args (--delay)"
         completed_experiments = []
+        invalid: list[str] = []
         for params in param_list:
             this_time = datetime.now(dt_timezone.utc)
             logger.info(f"UTC time: {this_time.hour:02d}:{this_time.minute:02d}")
@@ -112,6 +113,13 @@ class Multiple(BaseExperiment[Config]):
             )
             try:
                 await experiment.run(run_post_analysis=False)
+            except ExperimentFailed as e:
+                # The run itself finished, so its data is worth analysing; only the result
+                # is not usable. Dropping it here would lose the analysis of the run that
+                # most needs looking at.
+                logger.error(f"Experiment result is not usable. {e}")
+                invalid.append(str(e))
+                completed_experiments.append(experiment)
             except Exception as e:
                 logger.error(f"Experiment failed. Exception: {e} {traceback.format_exc()}")
             else:
@@ -122,6 +130,9 @@ class Multiple(BaseExperiment[Config]):
 
         for experiment in completed_experiments:
             run_post_analysis(experiment)
+
+        if invalid:
+            self.fail_run(f"{len(invalid)} of the sweep's runs are not usable: {invalid}")
 
     @abstractmethod
     def get_params_list(self) -> List[dict]:

--- a/src/deployments/experiments/tests/test_fail_run.py
+++ b/src/deployments/experiments/tests/test_fail_run.py
@@ -1,0 +1,75 @@
+import json
+from typing import ClassVar
+
+import pytest
+from kubernetes.client import ApiClient
+from pydantic import BaseModel
+
+from src.deployments.experiments.base_experiment import BaseExperiment, ExperimentFailed
+
+
+class DummyCfg(BaseModel):
+    foo: str = "bar"
+
+
+def _experiment(tmp_path, body):
+    class Exp(BaseExperiment[DummyCfg]):
+        name: ClassVar[str] = "fail-run-test"
+        config: DummyCfg
+
+        async def _run(self):
+            body(self)
+
+        def _get_metadata(self) -> dict:
+            return {"stack": {"name": "dummy"}, "experiment": {"name": "dummy"}}
+
+    return Exp(
+        api_client=ApiClient(),
+        config=DummyCfg(),
+        namespace="ns",
+        output_folder=tmp_path / "run",
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_clean_run_does_not_raise(tmp_path):
+    await _experiment(tmp_path, lambda exp: None).run()
+
+
+@pytest.mark.asyncio
+async def test_a_failed_run_raises_once_it_has_finished(tmp_path):
+    exp = _experiment(tmp_path, lambda e: e.fail_run("3 of 600 messages never published"))
+    with pytest.raises(ExperimentFailed, match="never published"):
+        await exp.run()
+
+
+@pytest.mark.asyncio
+async def test_the_data_survives_a_failed_run(tmp_path):
+    """Raising from _run would skip metadata while cleanup still deletes the pods."""
+    exp = _experiment(tmp_path, lambda e: e.fail_run("bad run"))
+    with pytest.raises(ExperimentFailed):
+        await exp.run()
+
+    assert exp.metadata_log_path.exists()
+    assert json.loads(exp.metadata_log_path.read_text())["stack"]["name"] == "dummy"
+
+
+@pytest.mark.asyncio
+async def test_the_reason_is_written_to_the_event_log(tmp_path):
+    exp = _experiment(tmp_path, lambda e: e.fail_run("bad run"))
+    with pytest.raises(ExperimentFailed):
+        await exp.run()
+
+    events = [json.loads(line) for line in exp.events_log_path.read_text().splitlines() if line]
+    invalid = [e for e in events if e.get("event") == "run_invalid"]
+    assert invalid and invalid[0]["reason"] == "bad run"
+
+
+@pytest.mark.asyncio
+async def test_every_reason_is_reported_not_just_the_first(tmp_path):
+    def two(exp):
+        exp.fail_run("first")
+        exp.fail_run("second")
+
+    with pytest.raises(ExperimentFailed, match="first; second"):
+        await _experiment(tmp_path, two).run()

--- a/src/deployments/experiments/tests/test_fail_run.py
+++ b/src/deployments/experiments/tests/test_fail_run.py
@@ -73,3 +73,30 @@ async def test_every_reason_is_reported_not_just_the_first(tmp_path):
 
     with pytest.raises(ExperimentFailed, match="first; second"):
         await _experiment(tmp_path, two).run()
+
+
+@pytest.mark.asyncio
+async def test_a_sweep_still_analyses_a_run_it_marks_invalid(tmp_path, mocker):
+    """The run that lost messages is the one most worth analysing, so it must not be dropped."""
+    from src.deployments.experiments import multi_experiment
+
+    analysed = []
+    mocker.patch.object(multi_experiment, "run_post_analysis", lambda exp: analysed.append(exp))
+
+    bad = _experiment(tmp_path / "bad", lambda e: e.fail_run("2 messages never published"))
+    good = _experiment(tmp_path / "good", lambda e: None)
+
+    completed, invalid = [], []
+    for exp in (bad, good):
+        try:
+            await exp.run(run_post_analysis=False)
+        except ExperimentFailed as e:
+            invalid.append(str(e))
+            completed.append(exp)
+        else:
+            completed.append(exp)
+    for exp in completed:
+        multi_experiment.run_post_analysis(exp)
+
+    assert len(analysed) == 2, "both runs analysed, including the invalid one"
+    assert len(invalid) == 1

--- a/src/deployments/experiments/tests/test_publish_outcomes.py
+++ b/src/deployments/experiments/tests/test_publish_outcomes.py
@@ -1,0 +1,33 @@
+import pytest
+
+from src.deployments.experiments.libp2p import nimlibp2p
+from src.deployments.experiments.libp2p.nimlibp2p import ExpConfig, publish
+from src.deployments.pod_api_requester.pod_api_requester import (
+    PodApiApplicationError,
+    PodApiClientError,
+)
+
+
+@pytest.mark.asyncio
+async def test_a_delivered_publish_reports_success(mocker):
+    mocker.patch.object(nimlibp2p, "libp2p_dst_node_publish", return_value=None)
+    assert await publish(ExpConfig(), "ns", "pod-0") is True
+
+
+@pytest.mark.parametrize(
+    "error",
+    [PodApiClientError("timed out"), PodApiApplicationError("node said no"), RuntimeError("boom")],
+)
+@pytest.mark.asyncio
+async def test_a_lost_publish_is_reported_not_swallowed(mocker, error):
+    """Every failure used to be logged and discarded, so the count came out right anyway."""
+    mocker.patch.object(nimlibp2p, "libp2p_dst_node_publish", side_effect=error)
+    assert await publish(ExpConfig(), "ns", "pod-0") is False
+
+
+def test_no_publish_may_fail_by_default():
+    assert ExpConfig().max_failed_publishes == 0
+
+
+def test_the_tolerance_can_be_raised_for_a_run_that_expects_losses():
+    assert ExpConfig(max_failed_publishes=10).max_failed_publishes == 10

--- a/src/deployments/pod_api_requester/pod_api_requester.py
+++ b/src/deployments/pod_api_requester/pod_api_requester.py
@@ -117,11 +117,20 @@ class PodResponse(BaseModel):
     headers: Optional[Dict[str, str]] = None
 
 
-async def post_async(url, data):
+REQUEST_TIMEOUT_S = 30
+"""Cap on one pod-api-requester call.
+
+aiohttp's default is 300s and its connector pool holds 100 sockets, so requests to pods
+that are gone hold their slots long enough to starve a publish loop rather than failing.
+"""
+
+
+async def post_async(url, data, timeout_s: float = REQUEST_TIMEOUT_S):
     """Execute an async POST request.
 
     :param data: JSON data for the request."""
-    async with aiohttp.ClientSession() as session:
+    timeout = aiohttp.ClientTimeout(total=timeout_s)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
         async with session.post(url, json=data) as response:
             text = await response.text()
             return PodResponse(
@@ -192,6 +201,10 @@ async def pod_api_request(
     try:
         response = await post_async(url, data)
         response_obj = json.loads(response.text)
+    except asyncio.TimeoutError as e:
+        raise PodApiClientError(
+            f"pod-api-requester did not answer within {REQUEST_TIMEOUT_S}s."
+        ) from e
     except aiohttp.ClientError as e:
         raise PodApiClientError("Failed to make the request to pod-api-requester.") from e
     except json.JSONDecodeError as e:

--- a/src/deployments/pod_api_requester/tests/test_request_timeout.py
+++ b/src/deployments/pod_api_requester/tests/test_request_timeout.py
@@ -1,0 +1,65 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+
+from src.deployments.pod_api_requester import pod_api_requester
+from src.deployments.pod_api_requester.pod_api_requester import (
+    REQUEST_TIMEOUT_S,
+    PodApiClientError,
+    post_async,
+)
+
+
+class _Session:
+    """Captures the timeout aiohttp.ClientSession was built with."""
+
+    built_with = None
+
+    def __init__(self, *_, timeout=None, **__):
+        type(self).built_with = timeout
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_):
+        return False
+
+    def post(self, *_, **__):
+        response = MagicMock(status=200, reason="OK", headers={})
+        response.text = AsyncMock(return_value="{}")
+        context = MagicMock()
+        context.__aenter__ = AsyncMock(return_value=response)
+        context.__aexit__ = AsyncMock(return_value=False)
+        return context
+
+
+@pytest.mark.asyncio
+async def test_a_request_is_bounded_rather_than_using_the_300s_default(mocker):
+    mocker.patch.object(aiohttp, "ClientSession", _Session)
+    await post_async("http://node/process", {})
+    assert _Session.built_with.total == REQUEST_TIMEOUT_S
+
+
+@pytest.mark.asyncio
+async def test_the_bound_is_short_enough_to_free_the_connection_pool():
+    """aiohttp holds 100 sockets; at 300s each, publishes to dead pods starve the loop."""
+    assert REQUEST_TIMEOUT_S < 300
+
+
+@pytest.mark.asyncio
+async def test_a_timeout_surfaces_as_a_typed_error(mocker):
+    mocker.patch.object(
+        pod_api_requester, "_get_api_requester_info", return_value=("10.0.0.1", 30000)
+    )
+    mocker.patch.object(pod_api_requester, "post_async", side_effect=asyncio.TimeoutError)
+
+    with pytest.raises(PodApiClientError, match="did not answer within"):
+        await pod_api_requester.pod_api_request(
+            namespace="ns",
+            service_name="svc",
+            app="app",
+            url_template="http://{target_ip}:{node_port}/process",
+            data={},
+        )


### PR DESCRIPTION
Adds a 30s request timeout and makes a run that failed to publish exit non-zero instead of reporting success.