### PR TITLE
Capture pod logs with the run as a collector fallback

### DIFF
--- a/src/deployments/core/pod_logs.py
+++ b/src/deployments/core/pod_logs.py
@@ -1,0 +1,56 @@
+"""Pull pod logs straight off the cluster, as a fallback for the log collector.
+
+VictoriaLogs has intermittently shipped nothing for a namespace, which silently breaks
+the whole delivery analysis. Capturing the logs with the run makes it independent of the
+collector, at the cost of the dwell time it takes to pull them.
+"""
+
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Optional
+
+from kubernetes import client
+from kubernetes.client import ApiException
+
+logger = logging.getLogger(__name__)
+
+
+def capture_pod_logs(
+    namespace: str,
+    dest: Path,
+    api_client=None,
+    *,
+    label_selector: Optional[str] = None,
+    workers: int = 32,
+) -> int:
+    """Write each pod's log to `dest/<pod>.log`. Returns how many were captured.
+
+    Only the current container is returned, so a pod that restarted mid-run is captured
+    from the restart onwards: authoritative for pods that stayed up, incomplete for the
+    ones a churn scenario took down.
+    """
+    api = client.CoreV1Api(api_client or client.ApiClient())
+    try:
+        pods = api.list_namespaced_pod(namespace=namespace, label_selector=label_selector).items
+    except ApiException as e:
+        logger.warning(f"Could not list pods in `{namespace}` to capture logs: {e}")
+        return 0
+
+    dest.mkdir(parents=True, exist_ok=True)
+
+    def capture(name: str) -> bool:
+        try:
+            log = api.read_namespaced_pod_log(name=name, namespace=namespace)
+        except ApiException as e:
+            logger.warning(f"Could not read logs from pod `{name}`: {e.status}")
+            return False
+        (dest / f"{name}.log").write_text(log)
+        return True
+
+    names = [pod.metadata.name for pod in pods]
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        captured = sum(pool.map(capture, names))
+
+    logger.info(f"Captured {captured} of {len(names)} pod logs into `{dest}/`")
+    return captured

--- a/src/deployments/core/tests/test_pod_logs.py
+++ b/src/deployments/core/tests/test_pod_logs.py
@@ -1,0 +1,63 @@
+import logging
+from unittest.mock import MagicMock
+
+from kubernetes.client.rest import ApiException
+
+from src.deployments.core import pod_logs
+from src.deployments.core.pod_logs import capture_pod_logs
+
+
+def _api(pod_names, *, logs=None, list_error=None, read_error=None):
+    api = MagicMock()
+    if list_error:
+        api.list_namespaced_pod.side_effect = list_error
+    else:
+        pods = []
+        for name in pod_names:
+            pod = MagicMock()
+            pod.metadata.name = name
+            pods.append(pod)
+        api.list_namespaced_pod.return_value = MagicMock(items=pods)
+    if read_error:
+        api.read_namespaced_pod_log.side_effect = read_error
+    else:
+        api.read_namespaced_pod_log.side_effect = lambda name, namespace: (logs or {}).get(
+            name, f"log for {name}"
+        )
+    return api
+
+
+def test_writes_one_file_per_pod(mocker, tmp_path):
+    mocker.patch.object(pod_logs.client, "CoreV1Api", return_value=_api(["pod-0", "pod-1"]))
+    assert capture_pod_logs("ns", tmp_path) == 2
+    assert (tmp_path / "pod-0.log").read_text() == "log for pod-0"
+    assert (tmp_path / "pod-1.log").read_text() == "log for pod-1"
+
+
+def test_one_unreadable_pod_does_not_lose_the_rest(mocker, tmp_path, caplog):
+    api = _api(["pod-0", "pod-1"])
+    api.read_namespaced_pod_log.side_effect = lambda name, namespace: (
+        (_ for _ in ()).throw(ApiException(status=400)) if name == "pod-0" else "ok"
+    )
+    mocker.patch.object(pod_logs.client, "CoreV1Api", return_value=api)
+    with caplog.at_level(logging.WARNING):
+        assert capture_pod_logs("ns", tmp_path) == 1
+    assert (tmp_path / "pod-1.log").exists()
+    assert "Could not read logs from pod `pod-0`" in caplog.text
+
+
+def test_a_listing_failure_is_not_fatal(mocker, tmp_path, caplog):
+    """The capture is a fallback; losing it must not take the run down with it."""
+    mocker.patch.object(
+        pod_logs.client, "CoreV1Api", return_value=_api([], list_error=ApiException(status=403))
+    )
+    with caplog.at_level(logging.WARNING):
+        assert capture_pod_logs("ns", tmp_path) == 0
+    assert "Could not list pods" in caplog.text
+
+
+def test_the_destination_is_created(mocker, tmp_path):
+    mocker.patch.object(pod_logs.client, "CoreV1Api", return_value=_api(["pod-0"]))
+    dest = tmp_path / "nested" / "kubectl_logs"
+    assert capture_pod_logs("ns", dest) == 1
+    assert dest.is_dir()

--- a/src/deployments/experiments/libp2p/nimlibp2p.py
+++ b/src/deployments/experiments/libp2p/nimlibp2p.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import random
+import time
 import traceback
 from typing import ClassVar, Literal
 
@@ -9,6 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, NonNegativeFloat, NonNegative
 
 from src.deployments.core.builders import ServiceBuilder
 from src.deployments.core.configs.container import Image
+from src.deployments.core.pod_logs import capture_pod_logs
 from src.deployments.experiments.base_experiment import BaseExperiment
 from src.deployments.libp2p.bridge import Bridge
 from src.deployments.libp2p.builders.builders import Libp2pStatefulSetBuilder
@@ -49,6 +51,10 @@ class ExpConfig(BaseModel):
     network_loss_pct: float = Field(default=0, ge=0, le=100)  # percent; folded into the netem qdisc
     node_start_delay: NonNegativeInt = 60
     post_publish_dwell: NonNegativeInt = 90
+    capture_pod_logs: bool = True
+    """Pull pod logs with the run, so the analysis does not depend on the log collector."""
+    log_capture_lead: NonNegativeInt = 45
+    """Seconds of the dwell reserved for the capture; 1000 pods take about 30s."""
     wait_nodes_ready: bool = True
 
     @model_validator(mode="after")
@@ -266,7 +272,33 @@ class NimLibp2pExperiment(BaseExperiment[ExpConfig]):
 
         await mid_run
 
-        await asyncio.sleep(self.config.post_publish_dwell)
+        await self._dwell_and_capture()
         self.log_event("publisher_wait_finished")
 
         self.log_event("internal_run_finished")
+
+    async def _dwell_and_capture(self) -> None:
+        """Wait out the post-publish dwell, capturing pod logs before the pods go away.
+
+        The capture has to land inside the dwell, not after it: cleanup starts in the same
+        second the dwell ends and pulling a thousand logs takes longer than the pods last.
+        """
+        dwell = self.config.post_publish_dwell
+        if not self.config.capture_pod_logs or self.output_folder is None:
+            await asyncio.sleep(dwell)
+            return
+
+        started = time.monotonic()
+        # Let late deliveries land before reading the logs, but leave room to pull them.
+        await asyncio.sleep(max(dwell - self.config.log_capture_lead, 0))
+
+        self.log_event("log_capture_start")
+        captured = await asyncio.to_thread(
+            capture_pod_logs,
+            self.namespace,
+            self.output_folder / "kubectl_logs",
+            self.api_client,
+        )
+        self.log_event({"event": "log_capture_finished", "pods": captured})
+
+        await asyncio.sleep(max(dwell - (time.monotonic() - started), 0))

--- a/src/deployments/experiments/tests/test_dwell_capture.py
+++ b/src/deployments/experiments/tests/test_dwell_capture.py
@@ -1,0 +1,90 @@
+import asyncio
+
+import pytest
+from kubernetes.client import ApiClient
+
+from src.deployments.experiments.libp2p import nimlibp2p
+from src.deployments.experiments.libp2p.nimlibp2p import ExpConfig, NimLibp2pExperiment
+
+CAPTURE_SECONDS = 30
+
+
+def _experiment(tmp_path, **config):
+    exp = NimLibp2pExperiment(
+        api_client=ApiClient(),
+        config=ExpConfig(**config),
+        namespace="ns",
+        output_folder=tmp_path / "run",
+    )
+    exp.events_log_path = tmp_path / "events.log"
+    return exp
+
+
+class Clock:
+    """Fake clock so sleeps and the capture cost time without the test waiting."""
+
+    def __init__(self):
+        self.now = 0.0
+        self.events = []
+
+    async def sleep(self, seconds):
+        self.events.append(("sleep", seconds))
+        self.now += seconds
+
+    def capture(self, *_, **__):
+        self.events.append(("capture", CAPTURE_SECONDS))
+        self.now += CAPTURE_SECONDS
+        return 7
+
+    def monotonic(self):
+        return self.now
+
+    @property
+    def kinds(self):
+        return [kind for kind, _ in self.events]
+
+
+@pytest.fixture
+def clock(mocker):
+    fake = Clock()
+    mocker.patch.object(asyncio, "sleep", fake.sleep)
+    mocker.patch.object(nimlibp2p, "capture_pod_logs", fake.capture)
+    mocker.patch.object(nimlibp2p.time, "monotonic", fake.monotonic)
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_the_capture_lands_inside_the_dwell_not_after_it(tmp_path, clock):
+    """Cleanup starts the second the dwell ends, and 1000 logs take longer than that."""
+    await _experiment(tmp_path, post_publish_dwell=90, log_capture_lead=45)._dwell_and_capture()
+
+    assert clock.kinds == ["sleep", "capture", "sleep"]
+    assert clock.events[0] == ("sleep", 45)
+
+
+@pytest.mark.asyncio
+async def test_the_dwell_is_not_extended_by_the_capture(tmp_path, clock):
+    await _experiment(tmp_path, post_publish_dwell=90, log_capture_lead=45)._dwell_and_capture()
+    assert clock.now == 90
+
+
+@pytest.mark.asyncio
+async def test_a_slow_capture_does_not_shorten_the_dwell(tmp_path, clock):
+    """If the capture overruns its lead the dwell is already satisfied, not run negative."""
+    await _experiment(tmp_path, post_publish_dwell=40, log_capture_lead=20)._dwell_and_capture()
+    assert clock.now >= 40
+    assert all(seconds >= 0 for kind, seconds in clock.events if kind == "sleep")
+
+
+@pytest.mark.asyncio
+async def test_capture_can_be_turned_off(tmp_path, clock):
+    exp = _experiment(tmp_path, post_publish_dwell=90, capture_pod_logs=False)
+    await exp._dwell_and_capture()
+    assert clock.events == [("sleep", 90)]
+
+
+@pytest.mark.asyncio
+async def test_a_lead_longer_than_the_dwell_does_not_sleep_negative(tmp_path, clock):
+    await _experiment(tmp_path, post_publish_dwell=30, log_capture_lead=45)._dwell_and_capture()
+    assert clock.events[0] == ("sleep", 0)
+    assert all(seconds >= 0 for kind, seconds in clock.events if kind == "sleep")


### PR DESCRIPTION
Pulls each pod's log during the post-publish dwell so the analysis does not depend on VictoriaLogs having collected the run.