### PR TITLE
Cross-check log-derived delivery against the nodes' received counter

### DIFF
--- a/src/analysis/mesh_analysis/analyzers/nimlibp2p_analyzer.py
+++ b/src/analysis/mesh_analysis/analyzers/nimlibp2p_analyzer.py
@@ -21,6 +21,8 @@ sns.set_theme()
 class Node(BaseModel):
     name: str
     id: Optional[str]
+    missing: Optional[NonNegativeInt] = None
+    """How many of the run's messages this node never received."""
 
 
 class MissingMessages(BaseModel):
@@ -419,7 +421,7 @@ class Nimlibp2pAnalyzer(Analyzer):
             missing_hashes.extend(pivot_df[pivot_df[pod].isna()].index.tolist())
             pod_name = df[df[peer_identifier] == item[0]]["kubernetes.pod_name"].iloc[0]
             node_id = None if peer_identifier == "kubernetes.pod_name" else item[0]
-            nodes.append(Node(name=pod_name, id=node_id))
+            nodes.append(Node(name=pod_name, id=node_id, missing=int(unique_messages - count)))
             logger.warning(
                 f"Node {item[0]} ({pod_name}) {item[1]}/{unique_messages}: {missing_hashes}"
             )
@@ -444,7 +446,7 @@ class Nimlibp2pAnalyzer(Analyzer):
                 "kubernetes.pod_name"
             ].iloc[0]
             node_id = None if peer_identifier == "kubernetes.pod_name" else item[0]
-            results.append(Node(name=pod_name, id=node_id))
+            results.append(Node(name=pod_name, id=node_id, missing=int(unique_messages - count)))
             logger.warning(
                 f"Node {item[0]} ({pod_name}) {item[1]}/{unique_messages}: {missing_hashes}"
             )

--- a/src/analysis/post_run/delivery_cross_check.py
+++ b/src/analysis/post_run/delivery_cross_check.py
@@ -1,0 +1,84 @@
+"""Check a log-derived delivery number against the nodes' own received counter.
+
+Delivery is counted from log lines, so anything the collector drops reads as a message
+that was never delivered. The nodes also count receives themselves, in a counter that
+does not go through the log pipeline, so the two disagreeing says the shortfall is
+collection loss rather than a protocol failure. Believing either alone has burned us
+both ways: a sub-100% number reported as a finding, and a real parser bug mistaken for
+collector lag.
+"""
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+from result import Err, Ok
+
+from src.analysis.metrics import scrape_utils
+
+logger = logging.getLogger(__name__)
+
+RECEIVED_METRIC = "libp2p_gossipsub_received_total"
+TOLERANCE = 0.001
+"""Fractional gap treated as rounding rather than loss."""
+
+
+class DeliveryCrossCheck(BaseModel):
+    from_logs: int
+    from_counters: Optional[int]
+    verdict: str
+    detail: str
+
+
+def counter_deliveries(
+    url: str, namespace: str, start: datetime, end: datetime, step: int = 60
+) -> Optional[int]:
+    """Total receives the nodes counted over the window, or None if unavailable."""
+    query = f"sum(max_over_time({RECEIVED_METRIC}{{namespace='{namespace}'}}[{step}s]))"
+    match scrape_utils.get_query_data(scrape_utils.create_promql(url, query, start, end, step)):
+        case Ok(data):
+            series = data["data"]["result"]
+            values = [float(value) for point in series for _, value in point.get("values", [])]
+            return int(max(values)) if values else None
+        case Err(error):
+            logger.warning(f"Could not read `{RECEIVED_METRIC}`: {error}")
+            return None
+
+
+def cross_check(from_logs: int, from_counters: Optional[int]) -> DeliveryCrossCheck:
+    """Whether a delivery shortfall in the logs is real or an artefact of collection."""
+    if from_counters is None:
+        return DeliveryCrossCheck(
+            from_logs=from_logs,
+            from_counters=None,
+            verdict="unverified",
+            detail=f"{RECEIVED_METRIC} was not available, so the log count stands alone",
+        )
+
+    missing = from_counters - from_logs
+    if missing <= from_counters * TOLERANCE:
+        return DeliveryCrossCheck(
+            from_logs=from_logs,
+            from_counters=from_counters,
+            verdict="confirmed",
+            detail="the nodes' own counters agree with the logs",
+        )
+
+    return DeliveryCrossCheck(
+        from_logs=from_logs,
+        from_counters=from_counters,
+        verdict="collection_loss",
+        detail=(
+            f"the nodes counted {missing} more receives than the logs show "
+            f"({missing / from_counters:.2%} of deliveries), so delivery measured from logs "
+            f"is a floor, not the protocol's result"
+        ),
+    )
+
+
+def report(result: DeliveryCrossCheck) -> None:
+    if result.verdict == "collection_loss":
+        logger.warning(f"Delivery cross-check: {result.detail}")
+    else:
+        logger.info(f"Delivery cross-check ({result.verdict}): {result.detail}")

--- a/src/analysis/post_run/delivery_cross_check.py
+++ b/src/analysis/post_run/delivery_cross_check.py
@@ -31,10 +31,14 @@ class DeliveryCrossCheck(BaseModel):
     detail: str
 
 
-def counter_deliveries(
-    url: str, namespace: str, start: datetime, end: datetime, step: int = 60
-) -> Optional[int]:
+def _as_datetime(value) -> datetime:
+    """Metadata carries the window as ISO strings; the query builder needs datetimes."""
+    return value if isinstance(value, datetime) else datetime.fromisoformat(value)
+
+
+def counter_deliveries(url: str, namespace: str, start, end, step: int = 60) -> Optional[int]:
     """Total receives the nodes counted over the window, or None if unavailable."""
+    start, end = _as_datetime(start), _as_datetime(end)
     query = f"sum(max_over_time({RECEIVED_METRIC}{{namespace='{namespace}'}}[{step}s]))"
     match scrape_utils.get_query_data(scrape_utils.create_promql(url, query, start, end, step)):
         case Ok(data):

--- a/src/analysis/post_run/nimlibp2p.py
+++ b/src/analysis/post_run/nimlibp2p.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from src.analysis.mesh_analysis.analyzers.data_puller import DataPuller
 from src.analysis.mesh_analysis.analyzers.nimlibp2p_analyzer import Nimlibp2pAnalyzer
 from src.analysis.plotting.latency_plotter import plot_dump_latency
+from src.analysis.post_run.delivery_cross_check import counter_deliveries, cross_check, report
 
 if TYPE_CHECKING:
     from src.deployments.experiments.libp2p.nimlibp2p import NimLibp2pExperiment
@@ -13,6 +15,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 VICTORIA_LOGS_URL = "https://vlselect.lab.vac.dev/select/logsql/query"
+METRICS_URL = "https://metrics.lab.vac.dev/select/0/prometheus/api/v1/"
 REQUIRED_TIME_WINDOW_KEYS = ("start_time", "end_time")
 
 
@@ -23,6 +26,38 @@ def _require_bounded_query(stack: dict) -> None:
             "Nimlibp2p post-run analysis requires a bounded metadata stack; "
             f"missing: {missing}. Refusing to run an unbounded VictoriaLogs query."
         )
+
+
+def _log_derived_deliveries(reliability: dict) -> int:
+    """Deliveries the logs account for: everything expected, less what was not seen."""
+    expected = reliability["expected_num_peers"] * reliability["expected_num_messages"]
+    missing = sum(
+        len(entry["nodes"]) * len(entry["messages"])
+        for entry in reliability.get("missing_messages", [])
+    )
+    return expected - missing
+
+
+def _cross_check_delivery(results, stack: dict, dump_dir: Path) -> None:
+    reliability = next(
+        (r.intermediates for r in results if r.name == "reliability" and r.status != "error"), None
+    )
+    if reliability is None:
+        logger.info("No reliability result to cross-check")
+        return
+
+    from_logs = _log_derived_deliveries(reliability)
+    from_counters = counter_deliveries(
+        url=METRICS_URL,
+        namespace=stack["namespace"],
+        start=stack["start_time"],
+        end=stack["end_time"],
+    )
+    result = cross_check(from_logs, from_counters)
+    report(result)
+
+    dump_dir.mkdir(parents=True, exist_ok=True)
+    (dump_dir / "delivery_cross_check.json").write_text(result.model_dump_json(indent=2))
 
 
 def run_nimlibp2p_analysis(experiment: "NimLibp2pExperiment") -> None:
@@ -53,7 +88,7 @@ def run_nimlibp2p_analysis(experiment: "NimLibp2pExperiment") -> None:
     dump_dir = experiment.output_folder / "analysis_data"
 
     try:
-        (
+        results = (
             Nimlibp2pAnalyzer(dump_analysis_dir=str(dump_dir))
             .with_data_puller(DataPuller().with_kwargs(stack))
             .with_ss_check(stack["stateful_sets"], stack["nodes_per_statefulset"])
@@ -67,6 +102,11 @@ def run_nimlibp2p_analysis(experiment: "NimLibp2pExperiment") -> None:
         )
     except Exception:
         logger.exception("Nimlibp2p message analysis failed")
+    else:
+        try:
+            _cross_check_delivery(results, stack, dump_dir)
+        except Exception:
+            logger.exception("Delivery cross-check failed")
     try:
         plot_dump_latency(dump_dir, label=cfg.muxer)
     except Exception:

--- a/src/analysis/post_run/nimlibp2p.py
+++ b/src/analysis/post_run/nimlibp2p.py
@@ -29,11 +29,17 @@ def _require_bounded_query(stack: dict) -> None:
 
 
 def _log_derived_deliveries(reliability: dict) -> int:
-    """Deliveries the logs account for: everything expected, less what was not seen."""
+    """Deliveries the logs account for: everything expected, less what each node missed.
+
+    `messages` and `nodes` on a MissingMessages are independent marginals -- every message
+    somebody missed, and every node that missed something -- so multiplying them counts
+    deliveries that were never absent.
+    """
     expected = reliability["expected_num_peers"] * reliability["expected_num_messages"]
     missing = sum(
-        len(entry["nodes"]) * len(entry["messages"])
+        node.get("missing") or 0
         for entry in reliability.get("missing_messages", [])
+        for node in entry.get("nodes", [])
     )
     return expected - missing
 

--- a/src/analysis/post_run/tests/test_delivery_cross_check.py
+++ b/src/analysis/post_run/tests/test_delivery_cross_check.py
@@ -114,3 +114,35 @@ class TestLogDerivedCount:
             "missing_messages": [{"messages": ["m1"], "nodes": [{"name": "pod-0"}]}],
         }
         assert _log_derived_deliveries(reliability) == 100
+
+
+class TestWindowTypes:
+    """The metadata stack carries the window as ISO strings, not datetimes. Passing those
+    straight to the query builder raised `'str' object has no attribute 'tzinfo'` on the
+    first real run, because the tests until now only fed it datetimes."""
+
+    def _ok(self, mocker):
+        mocker.patch.object(
+            dcc.scrape_utils,
+            "get_query_data",
+            return_value=Ok({"data": {"result": [{"values": [[1, "600000"]]}]}}),
+        )
+
+    def test_accepts_the_iso_strings_the_metadata_actually_holds(self, mocker):
+        self._ok(mocker)
+        assert (
+            counter_deliveries("http://vm/", "ns", "2026-08-11T15:52:06", "2026-08-11T16:26:10")
+            == 600_000
+        )
+
+    def test_still_accepts_datetimes(self, mocker):
+        self._ok(mocker)
+        assert (
+            counter_deliveries(
+                "http://vm/",
+                "ns",
+                datetime(2026, 8, 11, 15, 52, 6, tzinfo=timezone.utc),
+                datetime(2026, 8, 11, 16, 26, 10, tzinfo=timezone.utc),
+            )
+            == 600_000
+        )

--- a/src/analysis/post_run/tests/test_delivery_cross_check.py
+++ b/src/analysis/post_run/tests/test_delivery_cross_check.py
@@ -80,10 +80,37 @@ class TestLogDerivedCount:
         }
         assert _log_derived_deliveries(reliability) == 600_000
 
-    def test_missing_messages_are_subtracted_per_node(self):
+    def test_what_each_node_missed_is_subtracted(self):
         reliability = {
             "expected_num_peers": 1000,
             "expected_num_messages": 600,
-            "missing_messages": [{"messages": ["m1", "m2"], "nodes": [{"name": "pod-0"}]}],
+            "missing_messages": [
+                {
+                    "messages": ["m1", "m2"],
+                    "nodes": [{"name": "pod-0", "missing": 2}, {"name": "pod-1", "missing": 1}],
+                }
+            ],
         }
-        assert _log_derived_deliveries(reliability) == 600_000 - 2
+        assert _log_derived_deliveries(reliability) == 600_000 - 3
+
+    def test_the_two_marginals_are_not_multiplied(self):
+        """43 nodes each missing a different message is 43 lost deliveries, not 43x43."""
+        reliability = {
+            "expected_num_peers": 1000,
+            "expected_num_messages": 600,
+            "missing_messages": [
+                {
+                    "messages": [f"m{i}" for i in range(43)],
+                    "nodes": [{"name": f"pod-{i}", "missing": 1} for i in range(43)],
+                }
+            ],
+        }
+        assert _log_derived_deliveries(reliability) == 600_000 - 43
+
+    def test_a_node_without_a_count_does_not_break_the_sum(self):
+        reliability = {
+            "expected_num_peers": 10,
+            "expected_num_messages": 10,
+            "missing_messages": [{"messages": ["m1"], "nodes": [{"name": "pod-0"}]}],
+        }
+        assert _log_derived_deliveries(reliability) == 100

--- a/src/analysis/post_run/tests/test_delivery_cross_check.py
+++ b/src/analysis/post_run/tests/test_delivery_cross_check.py
@@ -1,0 +1,89 @@
+import logging
+from datetime import datetime, timezone
+
+from result import Err, Ok
+
+from src.analysis.post_run import delivery_cross_check as dcc
+from src.analysis.post_run.delivery_cross_check import counter_deliveries, cross_check, report
+from src.analysis.post_run.nimlibp2p import _log_derived_deliveries
+
+
+def test_agreement_confirms_the_log_number():
+    assert cross_check(600_000, 600_000).verdict == "confirmed"
+
+
+def test_rounding_sized_gaps_are_not_reported_as_loss():
+    assert cross_check(599_950, 600_000).verdict == "confirmed"
+
+
+def test_a_real_shortfall_is_named_as_collection_loss():
+    """The nodes counted receives the logs never showed, so the logs are the floor."""
+    result = cross_check(548_000, 600_000)
+    assert result.verdict == "collection_loss"
+    assert "52000 more receives" in result.detail
+
+
+def test_more_in_the_logs_than_the_counters_is_not_loss():
+    """Counters freeze at teardown, so the logs legitimately run ahead."""
+    assert cross_check(600_000, 599_000).verdict == "confirmed"
+
+
+def test_a_missing_counter_leaves_the_number_unverified_rather_than_confirmed():
+    result = cross_check(548_000, None)
+    assert result.verdict == "unverified"
+    assert result.from_counters is None
+
+
+def test_collection_loss_is_warned_about_not_just_logged(caplog):
+    with caplog.at_level(logging.WARNING):
+        report(cross_check(548_000, 600_000))
+    assert "Delivery cross-check" in caplog.text
+    assert caplog.records[0].levelno == logging.WARNING
+
+
+def test_agreement_does_not_warn(caplog):
+    with caplog.at_level(logging.WARNING):
+        report(cross_check(600_000, 600_000))
+    assert not caplog.records
+
+
+class TestCounterQuery:
+    def _window(self):
+        return datetime(2026, 8, 10, tzinfo=timezone.utc), datetime(
+            2026, 8, 10, 1, tzinfo=timezone.utc
+        )
+
+    def test_takes_the_peak_of_the_summed_counter(self, mocker):
+        mocker.patch.object(
+            dcc.scrape_utils,
+            "get_query_data",
+            return_value=Ok({"data": {"result": [{"values": [[1, "10"], [2, "600000"]]}]}}),
+        )
+        assert counter_deliveries("http://vm/", "ns", *self._window()) == 600_000
+
+    def test_an_unavailable_metric_is_none_not_zero(self, mocker, caplog):
+        """Zero would read as total collection loss and flag every run."""
+        mocker.patch.object(
+            dcc.scrape_utils, "get_query_data", return_value=Err("Returned data is empty.")
+        )
+        with caplog.at_level(logging.WARNING):
+            assert counter_deliveries("http://vm/", "ns", *self._window()) is None
+        assert "Could not read" in caplog.text
+
+
+class TestLogDerivedCount:
+    def test_a_clean_run_counts_every_expected_delivery(self):
+        reliability = {
+            "expected_num_peers": 1000,
+            "expected_num_messages": 600,
+            "missing_messages": [],
+        }
+        assert _log_derived_deliveries(reliability) == 600_000
+
+    def test_missing_messages_are_subtracted_per_node(self):
+        reliability = {
+            "expected_num_peers": 1000,
+            "expected_num_messages": 600,
+            "missing_messages": [{"messages": ["m1", "m2"], "nodes": [{"name": "pod-0"}]}],
+        }
+        assert _log_derived_deliveries(reliability) == 600_000 - 2


### PR DESCRIPTION
Says whether a delivery shortfall is real or an artefact of log collection, instead of that being a manual step.