### PR TITLE
Scrape metrics and draw the standard plots in post-run analysis

### DIFF
--- a/src/analysis/data/data_file_handler.py
+++ b/src/analysis/data/data_file_handler.py
@@ -68,6 +68,24 @@ class DataFileHandler(DataHandler):
 
         return Ok(target_df)
 
+    def _resolve_csv_paths(self, path: Path) -> List[Path]:
+        """A DataPath's CSVs: the file itself, or the files a scrape wrote inside the folder.
+
+        Scrapper dumps `<location>/<metric folder>/<run name>`, so pointing a DataPath at a
+        scrape dump lands on the metric folder rather than a file.
+        """
+        if path.is_file():
+            return [path]
+
+        match file_utils.get_files_from_folder_path(path, self._include_files):
+            case Ok(file_names):
+                if not file_names:
+                    logger.error(f"{path} holds no files to read.")
+                return sorted(path / name for name in file_names)
+            case Err(error):
+                logger.error(error)
+                return []
+
     def concat_dataframes_from_files(
         self,
         named_files: List[DataPath],
@@ -80,22 +98,25 @@ class DataFileHandler(DataHandler):
                 logger.error(f"{file_path} cannot be loaded.")
                 continue
 
-            logger.info(f"Reading {file_path} with {points} datapoints")
-            file_df = pd.read_csv(file_path, parse_dates=["Time"], index_col="Time", nrows=points)
-            if len(file_df) < points:
-                logger.warning(f"Not enough datapoints in {file_path}")
+            for csv_path in self._resolve_csv_paths(file_path):
+                logger.info(f"Reading {csv_path} with {points} datapoints")
+                file_df = pd.read_csv(
+                    csv_path, parse_dates=["Time"], index_col="Time", nrows=points
+                )
+                if len(file_df) < points:
+                    logger.warning(f"Not enough datapoints in {csv_path}")
 
-            if self._ignore_columns:
-                columns_to_drop = [
-                    col
-                    for col in file_df.columns
-                    if any(col.startswith(prefix) for prefix in self._ignore_columns)
-                ]
-                if columns_to_drop:
-                    logger.info(f"Dropping {len(columns_to_drop)} columns: {columns_to_drop}")
-                    file_df = file_df.drop(columns=columns_to_drop)
+                if self._ignore_columns:
+                    columns_to_drop = [
+                        col
+                        for col in file_df.columns
+                        if any(col.startswith(prefix) for prefix in self._ignore_columns)
+                    ]
+                    if columns_to_drop:
+                        logger.info(f"Dropping {len(columns_to_drop)} columns: {columns_to_drop}")
+                        file_df = file_df.drop(columns=columns_to_drop)
 
-            file_df = file_df.reset_index(drop=True)
-            file_df["class"] = group_name
-            file_df["variable"] = data_file.name
-            self._dataframe = pd.concat([self._dataframe, file_df], ignore_index=True)
+                file_df = file_df.reset_index(drop=True)
+                file_df["class"] = group_name
+                file_df["variable"] = data_file.name
+                self._dataframe = pd.concat([self._dataframe, file_df], ignore_index=True)

--- a/src/analysis/data/tests/test_data_file_handler.py
+++ b/src/analysis/data/tests/test_data_file_handler.py
@@ -1,0 +1,58 @@
+import logging
+
+import pandas as pd
+
+from src.analysis.data.data_file_handler import DataFileHandler, DataPath
+
+
+def _write_csv(path, rows=3, value=1.0):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    times = pd.to_datetime([f"2026-08-10 01:{m:02d}:00" for m in range(rows)])
+    pd.DataFrame({"pod-0": [value] * rows}, index=times).rename_axis("Time").to_csv(path)
+
+
+def _concat(path, name="run"):
+    handler = DataFileHandler()
+    handler.concat_dataframes_from_files([DataPath(name=name, path=path)], "group", 3)
+    return handler.dataframe
+
+
+def test_reads_a_file_directly(tmp_path):
+    _write_csv(tmp_path / "libp2p-in")
+    assert len(_concat(tmp_path / "libp2p-in")) == 3
+
+
+def test_reads_a_scrape_metric_folder(tmp_path):
+    """Scrapper writes `<location>/<metric>/<run name>`, so the path is a folder."""
+    _write_csv(tmp_path / "libp2p-in" / "quic")
+    df = _concat(tmp_path / "libp2p-in")
+    assert len(df) == 3
+    assert df["variable"].unique().tolist() == ["run"]
+
+
+def test_reads_every_file_in_the_folder(tmp_path):
+    _write_csv(tmp_path / "libp2p-in" / "quic", value=1.0)
+    _write_csv(tmp_path / "libp2p-in" / "tcp", value=2.0)
+    df = _concat(tmp_path / "libp2p-in")
+    assert len(df) == 6
+    assert sorted(df["pod-0"].unique()) == [1.0, 2.0]
+
+
+def test_missing_path_is_skipped_not_fatal(tmp_path, caplog):
+    with caplog.at_level(logging.ERROR):
+        assert _concat(tmp_path / "absent").empty
+    assert "cannot be loaded" in caplog.text
+
+
+def test_empty_folder_reports_rather_than_reading_nothing_quietly(tmp_path, caplog):
+    (tmp_path / "libp2p-in").mkdir()
+    with caplog.at_level(logging.ERROR):
+        assert _concat(tmp_path / "libp2p-in").empty
+    assert "holds no files" in caplog.text
+
+
+def test_subfolders_are_not_mistaken_for_csvs(tmp_path):
+    """get_files_from_folder_path keeps files only, so a nested dir cannot be read as CSV."""
+    _write_csv(tmp_path / "libp2p-in" / "quic")
+    (tmp_path / "libp2p-in" / "nested").mkdir()
+    assert len(_concat(tmp_path / "libp2p-in")) == 3

--- a/src/analysis/post_run/metrics.py
+++ b/src/analysis/post_run/metrics.py
@@ -1,0 +1,90 @@
+"""Scrape a finished run's metrics and draw the standard plots.
+
+The reliability and latency analysis already runs itself, but the resource and mesh-health
+half of a regression report did not: every campaign grew its own scrape-and-plot script.
+These are the same figures, drawn the same way, off the run's own stable window.
+"""
+
+import logging
+from pathlib import Path
+from typing import Dict, List, NamedTuple, Optional
+
+from src.analysis.data.data_file_handler import DataPath
+from src.analysis.metrics.libp2p.scrape import Nimlibp2pScrapeBuilder
+from src.analysis.metrics.scrapper import Scrapper
+from src.analysis.plotting.config import DataGroup, PlotConfig
+from src.analysis.plotting.metrics_plotter import MetricsPlotter
+
+logger = logging.getLogger(__name__)
+
+
+class PlotSpec(NamedTuple):
+    name: str
+    metrics: List[str]
+    ylabel: str
+    scale: int
+    fig_size: List[int]
+
+
+STANDARD_PLOTS = [
+    PlotSpec("bandwidth", ["libp2p-in", "libp2p-out"], "KBytes/s", 1000, [14, 5]),
+    PlotSpec("memory", ["container-memory", "nim-gc-memory"], "MBytes", 1_000_000, [14, 5]),
+    PlotSpec("connections", ["connections", "mesh-peers"], "peers per node", 1, [14, 5]),
+]
+
+
+def scrape_run_metrics(
+    exp: dict, dump_location: Path, kube_config: Optional[str] = None, name: Optional[str] = None
+) -> Path:
+    """Dump the per-metric CSVs for one run's stable window."""
+    builder = Nimlibp2pScrapeBuilder().with_exp(exp, extract_name=name is None)
+    if name is not None:
+        builder.name = name
+    config = builder.with_dump_location(str(dump_location)).with_libp2p_metrics().build()
+    logger.info(f"Scraping `{config.name}` metrics: {config.start} -> {config.end}")
+    Scrapper(kube_config, config).query_and_dump_metrics()
+    return dump_location
+
+
+def plot_run_metrics(
+    dumps: Dict[str, Path], out_dir: Path, xlabel: str, plots: Optional[List[PlotSpec]] = None
+) -> List[Path]:
+    """Box-plot each standard figure across `dumps`, keyed by series label (eg. muxer).
+
+    Reads the scrape dump as it lies: `<dump>/<metric>/<run name>`.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written = []
+    configs = []
+    for spec in plots or STANDARD_PLOTS:
+        available = {label: dump for label, dump in dumps.items() if _has_any(dump, spec.metrics)}
+        if not available:
+            logger.warning(f"No data for the {spec.name} plot; skipping it")
+            continue
+        target = out_dir / spec.name
+        configs.append(
+            PlotConfig(
+                name=str(target),
+                metrics=spec.metrics,
+                groups=[
+                    DataGroup(name=label, data_paths=[DataPath(name=label, path=dump)])
+                    for label, dump in available.items()
+                ],
+                legend_order=list(available),
+                xlabel_name=xlabel,
+                ylabel_name=spec.ylabel,
+                scale_x=spec.scale,
+                fig_size=spec.fig_size,
+                outliers=False,
+            )
+        )
+        written.append(target.with_suffix(".jpg"))
+
+    if configs:
+        MetricsPlotter(configs=configs).create_plots()
+        logger.info(f"Wrote {len(configs)} plots to `{out_dir}/`")
+    return written
+
+
+def _has_any(dump: Path, metrics: List[str]) -> bool:
+    return any((dump / metric).is_dir() or (dump / metric).is_file() for metric in metrics)

--- a/src/analysis/post_run/nimlibp2p.py
+++ b/src/analysis/post_run/nimlibp2p.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from src.analysis.mesh_analysis.analyzers.data_puller import DataPuller
 from src.analysis.mesh_analysis.analyzers.nimlibp2p_analyzer import Nimlibp2pAnalyzer
 from src.analysis.plotting.latency_plotter import plot_dump_latency
+from src.analysis.post_run.metrics import plot_run_metrics, scrape_run_metrics
 
 if TYPE_CHECKING:
     from src.deployments.experiments.libp2p.nimlibp2p import NimLibp2pExperiment
@@ -71,3 +72,23 @@ def run_nimlibp2p_analysis(experiment: "NimLibp2pExperiment") -> None:
         plot_dump_latency(dump_dir, label=cfg.muxer)
     except Exception:
         logger.exception("Nimlibp2p latency plot failed")
+    try:
+        _scrape_and_plot(experiment)
+    except Exception:
+        logger.exception("Nimlibp2p metrics scrape failed")
+
+
+def _scrape_and_plot(experiment: "NimLibp2pExperiment") -> None:
+    """Resource and mesh-health figures, off the run's own stable window."""
+    exp = experiment.metadata
+    if not exp.get("results", {}).get("stable"):
+        logger.warning("Run has no stable window; skipping the metrics scrape")
+        return
+
+    label = experiment.config.muxer
+    dump = scrape_run_metrics(exp, experiment.output_folder / "metrics", name=label)
+    plot_run_metrics(
+        {label: dump},
+        experiment.output_folder / "plots",
+        xlabel=f"{experiment.namespace}, {experiment.config.num_relay_nodes} nodes",
+    )

--- a/src/analysis/post_run/tests/test_post_run_metrics.py
+++ b/src/analysis/post_run/tests/test_post_run_metrics.py
@@ -1,0 +1,56 @@
+import logging
+
+import pandas as pd
+
+from src.analysis.post_run.metrics import STANDARD_PLOTS, PlotSpec, plot_run_metrics
+
+
+def _scrape_dump(root, muxer, metrics, rows=6):
+    """Write a dump in the shape Scrapper produces: <dump>/<metric>/<run name>."""
+    dump = root / muxer
+    times = pd.to_datetime([f"2026-08-10 01:{m:02d}:00" for m in range(rows)])
+    for metric in metrics:
+        (dump / metric).mkdir(parents=True, exist_ok=True)
+        pd.DataFrame({"pod-0": [1.0] * rows, "pod-1": [2.0] * rows}, index=times).rename_axis(
+            "Time"
+        ).to_csv(dump / metric / muxer)
+    return dump
+
+
+def test_plots_a_scrape_dump_without_staging_it_first(tmp_path):
+    metrics = ["libp2p-in", "libp2p-out"]
+    dumps = {m: _scrape_dump(tmp_path / "metrics", m, metrics) for m in ("yamux", "quic")}
+    spec = [PlotSpec("bandwidth", metrics, "KBytes/s", 1000, [14, 5])]
+
+    written = plot_run_metrics(dumps, tmp_path / "plots", xlabel="test", plots=spec)
+
+    assert [p.name for p in written] == ["bandwidth.jpg"]
+    assert written[0].exists()
+
+
+def test_a_plot_with_no_data_is_skipped_and_said_so(tmp_path, caplog):
+    """A silently missing figure reads as "we did not measure that"."""
+    dumps = {"yamux": _scrape_dump(tmp_path / "metrics", "yamux", ["libp2p-in"])}
+    spec = [PlotSpec("memory", ["nim-gc-memory"], "MBytes", 1_000_000, [14, 5])]
+
+    with caplog.at_level(logging.WARNING):
+        assert plot_run_metrics(dumps, tmp_path / "plots", xlabel="test", plots=spec) == []
+    assert "No data for the memory plot" in caplog.text
+
+
+def test_a_muxer_missing_one_metric_does_not_drop_the_others(tmp_path):
+    root = tmp_path / "metrics"
+    dumps = {
+        "yamux": _scrape_dump(root, "yamux", ["connections"]),
+        "quic": _scrape_dump(root, "quic", ["libp2p-in"]),
+    }
+    spec = [PlotSpec("connections", ["connections"], "peers", 1, [9, 6])]
+
+    written = plot_run_metrics(dumps, tmp_path / "plots", xlabel="test", plots=spec)
+
+    assert written[0].exists()
+
+
+def test_the_standard_set_covers_the_report_figures():
+    names = {spec.name for spec in STANDARD_PLOTS}
+    assert names == {"bandwidth", "memory", "connections"}


### PR DESCRIPTION
The resource and mesh-health figures now come out of the run instead of a per-campaign script.

Includes #384, which it needs to read a scrape dump; review that one first.

Related to #158 