### PR TITLE
Write scraped CSVs with a .csv suffix

### DIFF
--- a/src/analysis/data/data_file_handler.py
+++ b/src/analysis/data/data_file_handler.py
@@ -30,8 +30,12 @@ class DataFileHandler(DataHandler):
         for folder in folders:
             folder_path = Path(folder)
             folder_df = pd.DataFrame()
-            match file_utils.get_files_from_folder_path(folder_path, self._include_files):
+            match file_utils.get_files_from_folder_path(
+                folder_path, self._include_files, extension="csv"
+            ):
                 case Ok(data_files_names):
+                    if not data_files_names:
+                        self._report_no_csvs(folder_path)
                     folder_df = self._concat_files_as_mean(
                         folder_df, data_files_names, folder_path, points
                     )
@@ -39,6 +43,19 @@ class DataFileHandler(DataHandler):
                     self._dataframe = pd.concat([self._dataframe, folder_df])
                 case Err(error):
                     logger.error(error)
+
+    @staticmethod
+    def _report_no_csvs(path: Path) -> None:
+        """Name the suffixless files, since scrapes taken before the .csv change have none."""
+        stale = [p.name for p in path.iterdir() if p.is_file() and not p.name.startswith(".")]
+        if stale:
+            logger.error(
+                f"{path} holds {len(stale)} file(s) with no .csv suffix ({', '.join(stale[:3])}"
+                f"{', ...' if len(stale) > 3 else ''}); rename them with "
+                f"`find {path} -type f ! -name '*.csv' -exec mv {{}} {{}}.csv \\;`"
+            )
+        else:
+            logger.error(f"{path} holds no files to read.")
 
     def _concat_files_as_mean(
         self, target_df: pd.DataFrame, data_files_path: List, location: Path, points: int

--- a/src/analysis/data/tests/test_data_file_handler.py
+++ b/src/analysis/data/tests/test_data_file_handler.py
@@ -1,0 +1,47 @@
+import logging
+
+import pandas as pd
+
+from src.analysis.data.data_file_handler import DataFileHandler
+
+
+def _write_csv(path, rows=3, value=1.0):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    times = pd.to_datetime([f"2026-08-10 01:{m:02d}:00" for m in range(rows)])
+    pd.DataFrame({"pod-0": [value] * rows}, index=times).rename_axis("Time").to_csv(path)
+
+
+def _mean(folder):
+    handler = DataFileHandler()
+    handler.concat_dataframes_from_folders_as_mean([folder], 3)
+    return handler.dataframe
+
+
+def test_reads_the_csvs_a_scrape_wrote(tmp_path):
+    _write_csv(tmp_path / "libp2p-in" / "quic.csv")
+    assert not _mean(tmp_path / "libp2p-in").empty
+
+
+def test_non_csv_files_are_left_alone(tmp_path):
+    """The folder is discovered rather than named, so junk in it must not be read."""
+    _write_csv(tmp_path / "libp2p-in" / "quic.csv")
+    (tmp_path / "libp2p-in" / ".DS_Store").write_bytes(b"\x00\x01junk")
+    (tmp_path / "libp2p-in" / "notes.txt").write_text("scratch")
+    assert not _mean(tmp_path / "libp2p-in").empty
+
+
+def test_a_scrape_taken_before_the_suffix_change_says_how_to_fix_it(tmp_path, caplog):
+    """Those dumps read as an empty folder otherwise, and an empty plot looks like a result."""
+    _write_csv(tmp_path / "libp2p-in" / "quic")
+    with caplog.at_level(logging.ERROR):
+        assert _mean(tmp_path / "libp2p-in").empty
+    assert "no .csv suffix" in caplog.text
+    assert "quic" in caplog.text
+    assert "-exec mv" in caplog.text
+
+
+def test_an_empty_folder_still_reports(tmp_path, caplog):
+    (tmp_path / "libp2p-in").mkdir()
+    with caplog.at_level(logging.ERROR):
+        assert _mean(tmp_path / "libp2p-in").empty
+    assert "holds no files" in caplog.text

--- a/src/analysis/metrics/libp2p/gossipsub_summary.py
+++ b/src/analysis/metrics/libp2p/gossipsub_summary.py
@@ -51,7 +51,7 @@ GAUGES = frozenset({"mesh-peers", "topic-peers", "connections"})
 def _per_node_values(metrics_dir: Path, folder: str, muxer: str) -> Optional[pd.Series]:
     """One value per relay node: a counter's total over the run, or a gauge's typical
     value across the window. Excludes bootstrap and publisher (only `pod-<n>` are relays)."""
-    csv = metrics_dir / folder / muxer
+    csv = metrics_dir / folder / f"{muxer}.csv"
     if not csv.exists():
         logger.warning(f"gossipsub summary: missing {csv}")
         return None

--- a/src/analysis/metrics/libp2p/tests/test_gossipsub_summary.py
+++ b/src/analysis/metrics/libp2p/tests/test_gossipsub_summary.py
@@ -12,7 +12,7 @@ def _write(metrics_dir, folder, muxer, rows):
     path.mkdir(parents=True, exist_ok=True)
     times = pd.to_datetime([f"2026-08-08 01:{m:02d}:00" for m in range(len(rows))])
     pd.DataFrame(rows, index=times, columns=["pod-0", "pod-1"]).rename_axis("Time").to_csv(
-        path / muxer
+        path / f"{muxer}.csv"
     )
 
 

--- a/src/analysis/metrics/libp2p/tests/test_mesh_metrics.py
+++ b/src/analysis/metrics/libp2p/tests/test_mesh_metrics.py
@@ -17,7 +17,7 @@ def _write_gauge_csv(metrics_dir: Path, folder: str, name: str, columns: dict) -
     n = len(next(iter(columns.values())))
     times = [f"2026-07-18 04:{40 + 5 * i:02d}:00" for i in range(n)]
     df = pd.DataFrame({"Time": times, **columns})
-    df.to_csv(d / name, index=False)
+    df.to_csv(d / f"{name}.csv", index=False)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/analysis/metrics/scrapper.py
+++ b/src/analysis/metrics/scrapper.py
@@ -35,7 +35,9 @@ class Scrapper(BaseModel):
                 case Ok(data):
                     logger.debug(f"Successfully extracted {metric_config.name} data from response")
                     file_location = (
-                        self._config.dump_location / metric_config.folder_name / self._config.name
+                        self._config.dump_location
+                        / metric_config.folder_name
+                        / f"{self._config.name}.csv"
                     ).as_posix()
                     self._dump_data(
                         metric_config.name,


### PR DESCRIPTION
Scrapper wrote its dumps without an extension, so nothing could identify them by name. Run names can contain dots themselves (`v2.2.0`), so "no extension" was not even reliable.

Existing scrapes need renaming to stay readable:

```
find <dump-dir> -type f ! -name '*.csv' -exec mv {} {}.csv \;
```