### PR TITLE
Allow publishing through a port-forward instead of the NodePort

### DIFF
--- a/src/deployments/core/port_forward.py
+++ b/src/deployments/core/port_forward.py
@@ -1,0 +1,66 @@
+"""Reach an in-cluster service through the API server rather than its NodePort.
+
+`kubectl port-forward` tunnels over the API server, so it works wherever kubectl does.
+A NodePort needs the node reachable on a high port, which is a separate network path and
+is not always open from where a run is driven.
+"""
+
+import asyncio
+import logging
+import re
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Tuple
+
+from src.deployments.core.k8s_kubeconfig import get_config_file
+
+logger = logging.getLogger(__name__)
+
+_FORWARDING = re.compile(r"Forwarding from 127\.0\.0\.1:(\d+)")
+
+
+async def _local_port(proc: asyncio.subprocess.Process) -> int:
+    """Read the port kubectl chose from its first Forwarding line."""
+    assert proc.stdout is not None
+    while True:
+        raw = await proc.stdout.readline()
+        if not raw:
+            raise RuntimeError("kubectl port-forward exited before it was listening")
+        line = raw.decode(errors="replace").strip()
+        logger.debug(f"port-forward: {line}")
+        found = _FORWARDING.search(line)
+        if found:
+            return int(found.group(1))
+
+
+@asynccontextmanager
+async def port_forward(
+    target: str, remote_port: int, namespace: str, *, ready_timeout_s: int = 30
+) -> AsyncIterator[Tuple[str, int]]:
+    """Yield `(host, port)` for a tunnel to `target`, eg. `svc/zerotesting-publisher`.
+
+    The local port is left for the kernel to choose and read back from kubectl, so
+    parallel runs cannot collide on it.
+    """
+    cfg = get_config_file()
+    cmd = (
+        ["kubectl"]
+        + (["--kubeconfig", cfg] if cfg else [])
+        + ["-n", namespace, "port-forward", target, f":{remote_port}"]
+    )
+    logger.info(f"Opening a port-forward to {target}:{remote_port} in `{namespace}`")
+    proc = await asyncio.create_subprocess_exec(
+        *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT
+    )
+    try:
+        port = await asyncio.wait_for(_local_port(proc), ready_timeout_s)
+        logger.info(f"Port-forward listening on 127.0.0.1:{port} -> {target}:{remote_port}")
+        yield "127.0.0.1", port
+    finally:
+        if proc.returncode is None:
+            proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), 10)
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+        logger.info(f"Closed the port-forward to {target}")

--- a/src/deployments/core/tests/test_port_forward.py
+++ b/src/deployments/core/tests/test_port_forward.py
@@ -1,0 +1,96 @@
+import asyncio
+
+import pytest
+
+from src.deployments.core import port_forward as pf
+
+
+class FakeStdout:
+    def __init__(self, lines):
+        self._lines = list(lines)
+
+    async def readline(self):
+        return self._lines.pop(0) if self._lines else b""
+
+
+class FakeProc:
+    def __init__(self, lines, returncode=None):
+        self.stdout = FakeStdout(lines)
+        self.returncode = returncode
+        self.terminated = False
+        self.killed = False
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = -15
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+    async def wait(self):
+        return self.returncode
+
+
+def _spawn(proc, captured=None):
+    async def create(*cmd, **kwargs):
+        if captured is not None:
+            captured.extend(cmd)
+        return proc
+
+    return create
+
+
+@pytest.mark.asyncio
+async def test_reads_back_the_port_kubectl_chose(mocker):
+    """The local port is left to the kernel, so it has to be parsed rather than assumed."""
+    proc = FakeProc([b"Forwarding from 127.0.0.1:54321 -> 8645\n"])
+    mocker.patch.object(asyncio, "create_subprocess_exec", _spawn(proc))
+
+    async with pf.port_forward("svc/zerotesting-publisher", 8645, "zerotesting") as (host, port):
+        assert (host, port) == ("127.0.0.1", 54321)
+
+
+@pytest.mark.asyncio
+async def test_skips_noise_before_the_forwarding_line(mocker):
+    proc = FakeProc([b"some warning\n", b"Forwarding from 127.0.0.1:7000 -> 8645\n"])
+    mocker.patch.object(asyncio, "create_subprocess_exec", _spawn(proc))
+
+    async with pf.port_forward("svc/x", 8645, "ns") as (_, port):
+        assert port == 7000
+
+
+@pytest.mark.asyncio
+async def test_the_tunnel_is_closed_on_the_way_out(mocker):
+    proc = FakeProc([b"Forwarding from 127.0.0.1:7000 -> 8645\n"])
+    mocker.patch.object(asyncio, "create_subprocess_exec", _spawn(proc))
+
+    async with pf.port_forward("svc/x", 8645, "ns"):
+        pass
+    assert proc.terminated, "kubectl must not be left running after the run"
+
+
+@pytest.mark.asyncio
+async def test_a_tunnel_that_never_listens_fails_loudly(mocker):
+    """Silence here would look like a publisher that is simply not answering."""
+    proc = FakeProc([])  # kubectl exited without ever forwarding
+    mocker.patch.object(asyncio, "create_subprocess_exec", _spawn(proc))
+
+    with pytest.raises(RuntimeError, match="exited before it was listening"):
+        async with pf.port_forward("svc/x", 8645, "ns"):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_the_namespace_and_target_reach_kubectl(mocker):
+    proc = FakeProc([b"Forwarding from 127.0.0.1:7000 -> 8645\n"])
+    cmd = []
+    mocker.patch.object(asyncio, "create_subprocess_exec", _spawn(proc, cmd))
+
+    async with pf.port_forward("svc/zerotesting-publisher", 8645, "zerotesting"):
+        pass
+
+    assert "port-forward" in cmd
+    assert "svc/zerotesting-publisher" in cmd
+    assert ":8645" in cmd
+    assert cmd[cmd.index("-n") + 1] == "zerotesting"

--- a/src/deployments/experiments/libp2p/nimlibp2p.py
+++ b/src/deployments/experiments/libp2p/nimlibp2p.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import random
 import traceback
+from contextlib import AsyncExitStack
 from typing import ClassVar, Literal
 
 from kubernetes.client import V1Probe, V1ServicePort, V1StatefulSet, V1TCPSocketAction
@@ -10,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, NonNegativeFloat, NonNegative
 from src.deployments.core.builders import ServiceBuilder
 from src.deployments.core.configs.container import Image
 from src.deployments.core.k8s_rollout import resolved_images
+from src.deployments.core.port_forward import port_forward
 from src.deployments.experiments.base_experiment import BaseExperiment
 from src.deployments.libp2p.bridge import Bridge
 from src.deployments.libp2p.builders.builders import Libp2pStatefulSetBuilder
@@ -27,6 +29,8 @@ Muxer = Literal["yamux", "quic", "mplex"]
 Discovery = Literal["static", "kad-dht"]
 
 BOOTSTRAP_NAME = "bootstrap"
+PUBLISHER_SERVICE = "zerotesting-publisher"
+PUBLISHER_PORT = 8645
 
 
 class ExpConfig(BaseModel):
@@ -49,6 +53,8 @@ class ExpConfig(BaseModel):
     network_bandwidth_mbit: NonNegativeInt = 0  # 0 = uncapped; folded into the netem qdisc
     network_loss_pct: float = Field(default=0, ge=0, le=100)  # percent; folded into the netem qdisc
     node_start_delay: NonNegativeInt = 60
+    publish_via_port_forward: bool = False
+    """Reach the publisher through the API server instead of its NodePort."""
     post_publish_dwell: NonNegativeInt = 90
     max_failed_publishes: NonNegativeInt = 0
     """Publishes that may fail before the run is treated as invalid."""
@@ -265,6 +271,16 @@ class NimLibp2pExperiment(BaseExperiment[ExpConfig]):
 
         logger.info(f"Starting publish loop for nodes in `{name}`")
 
+        async with AsyncExitStack() as publish_stack:
+            if self.config.publish_via_port_forward:
+                host, port = await publish_stack.enter_async_context(
+                    port_forward(f"svc/{PUBLISHER_SERVICE}", PUBLISHER_PORT, self.namespace)
+                )
+                publish_stack.enter_context(publisher_endpoint(host, port))
+
+            await self._publish_all(nodes, name, namespace)
+
+    async def _publish_all(self, nodes: V1StatefulSet, name: str, namespace: str) -> None:
         self.log_event("start_messages")
 
         mid_run = asyncio.create_task(self._mid_run(nodes))

--- a/src/deployments/pod_api_requester/pod_api_requester.py
+++ b/src/deployments/pod_api_requester/pod_api_requester.py
@@ -2,6 +2,7 @@
 import asyncio
 import json
 import logging
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Dict, Optional, Tuple, Union
 
@@ -20,6 +21,25 @@ _DEFAULTS = {
     "service_name": "zerotesting-publisher",
     "app": "zerotenkay-publisher",
 }
+
+_endpoint_override: Optional[Tuple[str, str]] = None
+
+
+@contextmanager
+def publisher_endpoint(host: str, port: int):
+    """Send requests to `host:port` instead of discovering the service's NodePort.
+
+    For reaching the publisher through a port-forward when its NodePort is not routable
+    from where the run is driven.
+    """
+    global _endpoint_override
+    previous = _endpoint_override
+    _endpoint_override = (host, str(port))
+    logger.info(f"pod-api-requester endpoint overridden to {host}:{port}")
+    try:
+        yield
+    finally:
+        _endpoint_override = previous
 
 
 class PodApiError(Exception):
@@ -149,6 +169,9 @@ def _get_api_requester_info(
     publisher_pod: str | NonNegativeInt = 0,
 ) -> Tuple[str, str]:
     """Find the pod-api-requester pod in the cluster."""
+    if _endpoint_override is not None:
+        return _endpoint_override
+
     v1 = client.CoreV1Api()
 
     try:

--- a/src/deployments/pod_api_requester/tests/test_publisher_endpoint.py
+++ b/src/deployments/pod_api_requester/tests/test_publisher_endpoint.py
@@ -1,0 +1,44 @@
+import pytest
+
+from src.deployments.pod_api_requester import pod_api_requester as par
+from src.deployments.pod_api_requester.pod_api_requester import publisher_endpoint
+
+
+def _discover():
+    return par._get_api_requester_info(namespace="ns", service_name="svc", app="app")
+
+
+def test_the_override_replaces_nodeport_discovery(mocker):
+    """The k8s lookup must not run at all, since its answer is the unreachable path."""
+    api = mocker.patch.object(par.client, "CoreV1Api")
+    with publisher_endpoint("127.0.0.1", 54321):
+        assert _discover() == ("127.0.0.1", "54321")
+    api.assert_not_called()
+
+
+def test_discovery_is_restored_afterwards(mocker):
+    mocker.patch.object(par, "_get_api_requester_info", wraps=par._get_api_requester_info)
+    with publisher_endpoint("127.0.0.1", 1):
+        pass
+    assert par._endpoint_override is None
+
+
+def test_nesting_restores_the_outer_override():
+    with publisher_endpoint("127.0.0.1", 1):
+        with publisher_endpoint("127.0.0.1", 2):
+            assert _discover() == ("127.0.0.1", "2")
+        assert _discover() == ("127.0.0.1", "1")
+
+
+def test_an_exception_still_restores_discovery():
+    with pytest.raises(ValueError):
+        with publisher_endpoint("127.0.0.1", 1):
+            raise ValueError("boom")
+    assert par._endpoint_override is None
+
+
+def test_the_url_the_requester_builds_points_at_the_tunnel():
+    template = "http://{target_ip}:{node_port}/process"
+    with publisher_endpoint("127.0.0.1", 54321):
+        ip, port = _discover()
+    assert template.format(target_ip=ip, node_port=port) == "http://127.0.0.1:54321/process"


### PR DESCRIPTION
Lets a run reach the publisher over the API server when its NodePort is not routable from where the run is driven. Off by default.