### PR TITLE
Allow parsing JSON logs from Victoria

### DIFF
--- a/dst_dashboard/processors/dataset_processor.py
+++ b/dst_dashboard/processors/dataset_processor.py
@@ -176,7 +176,7 @@ class DatasetProcessor:
             if pattern == "received":
                 tracer = tracer.with_received_pattern_group(log_format="TEXT")
             elif pattern == "sent":
-                tracer = tracer.with_sent_pattern_group()
+                tracer = tracer.with_sent_pattern_group(log_format="TEXT")
             else:
                 # Default to received for message delay analysis
                 tracer = tracer.with_received_pattern_group(log_format="TEXT")

--- a/dst_dashboard/processors/dataset_processor.py
+++ b/dst_dashboard/processors/dataset_processor.py
@@ -174,12 +174,12 @@ class DatasetProcessor:
 
             # Use specific pattern if provided
             if pattern == "received":
-                tracer = tracer.with_received_pattern_group()
+                tracer = tracer.with_received_pattern_group(log_format="TEXT")
             elif pattern == "sent":
                 tracer = tracer.with_sent_pattern_group()
             else:
                 # Default to received for message delay analysis
-                tracer = tracer.with_received_pattern_group()
+                tracer = tracer.with_received_pattern_group(log_format="TEXT")
 
             return tracer
         else:

--- a/src/analysis/mesh_analysis/analyzers/gossipsub_priority_queues_analyzer.py
+++ b/src/analysis/mesh_analysis/analyzers/gossipsub_priority_queues_analyzer.py
@@ -60,7 +60,7 @@ class GossipsubPriorityQueuesAnalyzer(Analyzer):
         tracer = (
             Nimlibp2pTracer()
             .with_extra_fields(["kubernetes.pod_name"])
-            .with_received_pattern_group()
+            .with_received_pattern_group(log_format="TEXT")
         )
 
         # Get dataframes for all nodes

--- a/src/analysis/mesh_analysis/analyzers/nimlibp2p_analyzer.py
+++ b/src/analysis/mesh_analysis/analyzers/nimlibp2p_analyzer.py
@@ -1,7 +1,7 @@
 import logging
 import traceback
 from pathlib import Path
-from typing import Iterable, List, Optional, Self
+from typing import Dict, Iterable, List, Literal, Optional, Self
 
 import pandas as pd
 import seaborn as sns
@@ -59,6 +59,12 @@ class Nimlibp2pAnalyzer(Analyzer):
     """
 
     msg_hash_key: str = "msgId"
+    enable_cache: bool = False
+    log_format: Optional[Literal["TEXT", "JSON"]] = "TEXT"
+
+    def with_log_format(self, log_format: Literal["TEXT", "JSON"]) -> Self:
+        self.log_format = log_format
+        return self
 
     def with_ss_check(
         self,
@@ -140,8 +146,8 @@ class Nimlibp2pAnalyzer(Analyzer):
         return (
             Nimlibp2pTracer()
             .with_extra_fields(extra_fields)
-            .with_received_pattern_group()
-            .with_sent_pattern_group()
+            .with_received_pattern_group(log_format=self.log_format)
+            .with_sent_pattern_group(log_format=self.log_format)
         )
 
     def analyze_reliability(
@@ -280,13 +286,22 @@ class Nimlibp2pAnalyzer(Analyzer):
 
         return Ok(None)
 
-    def _merge_dfs(self, dfs: List[List[pd.DataFrame]], has_shard: bool) -> List[pd.DataFrame]:
+    def _merge_dfs(
+        self, dfs: List[Dict[str, List[pd.DataFrame]]], has_shard: bool
+    ) -> List[pd.DataFrame]:
         logger.info("Merging and sorting information")
 
-        received_df = pd.concat(
-            [pd.concat(group["received"], ignore_index=True) for group in dfs],
-            ignore_index=True,
+        # Collect all "received_*" groups into one logical received DataFrame
+        received_parts = []
+        for group in dfs:
+            for key, df_list in group.items():
+                if key.startswith("received"):
+                    received_parts.extend(df_list)
+
+        received_df = (
+            pd.concat(received_parts, ignore_index=True) if received_parts else pd.DataFrame()
         )
+
         if has_shard:
             received_df = received_df.assign(
                 shard=received_df["kubernetes.pod_name"].str.extract(r".*-(\d+)-").astype(int)
@@ -297,10 +312,14 @@ class Nimlibp2pAnalyzer(Analyzer):
         received_df.set_index(columns, inplace=True)
         received_df.sort_index(inplace=True)
 
-        sent_df = pd.concat(
-            [pd.concat(group["sent"], ignore_index=True) for group in dfs],
-            ignore_index=True,
-        )
+        # Collect all "sent_*" groups into one logical received DataFrame
+        sent_parts = []
+        for group in dfs:
+            if "sent" in group:
+                sent_parts.extend(group["sent"])
+
+        sent_df = pd.concat(sent_parts, ignore_index=True) if sent_parts else pd.DataFrame()
+
         if has_shard:
             sent_df = sent_df.assign(
                 shard=sent_df["kubernetes.pod_name"].str.extract(r".*-(\d+)-").astype(int)

--- a/src/analysis/mesh_analysis/analyzers/nimlibp2p_analyzer.py
+++ b/src/analysis/mesh_analysis/analyzers/nimlibp2p_analyzer.py
@@ -315,8 +315,9 @@ class Nimlibp2pAnalyzer(Analyzer):
         # Collect all "sent_*" groups into one logical received DataFrame
         sent_parts = []
         for group in dfs:
-            if "sent" in group:
-                sent_parts.extend(group["sent"])
+            for key in group:
+                if "sent" in group:
+                    sent_parts.extend(group["sent"])
 
         sent_df = pd.concat(sent_parts, ignore_index=True) if sent_parts else pd.DataFrame()
 

--- a/src/analysis/mesh_analysis/analyzers/waku/waku_analyzer.py
+++ b/src/analysis/mesh_analysis/analyzers/waku/waku_analyzer.py
@@ -56,8 +56,8 @@ class WakuAnalyzer(Nimlibp2pAnalyzer):
     def reliability_tracer(self, extra_fields) -> MessageTracer:
         return (
             WakuTracer()
-            .with_received_pattern_group()
-            .with_sent_pattern_group()
+            .with_received_pattern_group(log_format=self.log_format)
+            .with_sent_pattern_group(log_format=self.log_format)
             .with_extra_fields(extra_fields)
         )
 

--- a/src/analysis/mesh_analysis/readers/tracers/message_tracer.py
+++ b/src/analysis/mesh_analysis/readers/tracers/message_tracer.py
@@ -1,7 +1,6 @@
 # Python Imports
 import logging
-from dataclasses import dataclass
-from typing import Callable, Dict, List, Self, Tuple
+from typing import Callable, List, Optional, Self
 
 import pandas as pd
 from pydantic import BaseModel, Field
@@ -9,15 +8,14 @@ from pydantic import BaseModel, Field
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class TracePair:
-    regex: str
+class TracePair(BaseModel):
+    regex: Optional[str] = None
     convert: Callable[[List[str]], pd.DataFrame]
 
 
-@dataclass
-class PatternGroup:
+class PatternGroup(BaseModel):
     name: str
+    fields: List[str] = Field(default_factory=lambda: ["_msg"])
     trace_pairs: List[TracePair]
     query: str
 
@@ -32,14 +30,15 @@ class MessageTracer(BaseModel):
     def with_wildcard_pattern(self) -> Self:
         self.patterns.append(
             PatternGroup(
-                "wildcard",
-                [TracePair(regex="(.*)", convert=self._trace_all_logs)],
+                name="wildcard",
+                fields=["_msg"],
+                trace_pairs=[TracePair(regex="(.*)", convert=self._trace_all_logs)],
                 query="*",
             )
         )
         return self
 
-    def trace(self, parsed_logs: List[List[Tuple]]) -> Dict[str, List[pd.DataFrame]]:
+    def trace(self, parsed_logs: List[List[tuple]]) -> dict[str, list[pd.DataFrame]]:
         """
         :type parsed_logs: List[List[List]]
         :param parsed_logs: List of groups of matched patterns.

--- a/src/analysis/mesh_analysis/readers/tracers/nimlibp2p_tracer.py
+++ b/src/analysis/mesh_analysis/readers/tracers/nimlibp2p_tracer.py
@@ -1,10 +1,9 @@
 import logging
-from typing import ClassVar, List, Self
+from typing import ClassVar, List, Literal, Self
 
 import numpy as np
 import pandas as pd
 
-# Project Imports
 from src.analysis.mesh_analysis.readers.tracers.message_tracer import (
     MessageTracer,
     PatternGroup,
@@ -16,41 +15,51 @@ logger = logging.getLogger(__name__)
 
 class Nimlibp2pTracer(MessageTracer):
     unknown_sender_str: ClassVar[str] = "Unknown"
+    log_field_prefix: str = "log."
 
     def with_extra_fields(self, extra_fields: List[str]) -> Self:
         self.extra_fields = extra_fields
         return self
 
-    def with_received_pattern_group(self) -> Self:
+    def _prefix_fields(self, fields: List[str]) -> List[str]:
+        return [f"{self.log_field_prefix}{field}" for field in fields]
+
+    def with_received_pattern_group(self, log_format: Literal["TEXT", "JSON"]) -> Self:
+        received_fields = (
+            self._prefix_fields(["msgId", "sentAt", "timestamp", "delayMs"])
+            if log_format == "JSON"
+            else ["_msg"]
+        )
+        regex = (
+            r"Received message.*?msgId=([\w*]+).*?sentAt=([\w*]+).*?current=([\w*]+).*?delayMs=(-?[\w*]+)"
+            if log_format == "TEXT"
+            else None
+        )
         self.patterns.append(
             PatternGroup(
-                "received",
-                trace_pairs=[
-                    TracePair(
-                        # delayMs goes negative when the sender's clock is ahead of the
-                        # receiver's, so the sign has to be part of the match: `\w` alone
-                        # drops those deliveries and under-reports delivery.
-                        regex=r"Received message.*?msgId=([\w*]+).*?sentAt=([\w*]+).*?current=([\w*]+).*?delayMs=(-?[\w*]+)",
-                        convert=self._trace_received_in_logs,
-                    ),
-                ],
+                name="received",
+                fields=received_fields,
+                trace_pairs=[TracePair(regex=regex, convert=self._trace_received_in_logs)],
                 query="Received message",
             )
         )
         return self
 
-    def with_sent_pattern_group(self) -> Self:
-        sent_pattern_group = PatternGroup(
-            name="sent",
-            trace_pairs=[
-                TracePair(
-                    regex=r"Sent message.*?msgId=([\w*]+).*?timestamp=([\w*]+)",
-                    convert=self._trace_sent_in_logs,
-                ),
-            ],
-            query="Sent message",
+    def with_sent_pattern_group(self, log_format: Literal["TEXT", "JSON"]) -> Self:
+        sent_fields = (
+            self._prefix_fields(["msgId", "timestamp"]) if log_format == "JSON" else ["_msg"]
         )
-        self.patterns.append(sent_pattern_group)
+        regex = (
+            r"Sent message.*?msgId=([\w*]+).*?timestamp=([\w*]+)" if log_format == "TEXT" else None
+        )
+        self.patterns.append(
+            PatternGroup(
+                name="sent",
+                fields=sent_fields,
+                trace_pairs=[TracePair(regex=regex, convert=self._trace_sent_in_logs)],
+                query="Sent message",
+            )
+        )
         return self
 
     def _trace_received_in_logs(self, parsed_logs: List) -> pd.DataFrame:
@@ -98,24 +107,4 @@ class Nimlibp2pTracer(MessageTracer):
         df["msgId"] = pd.to_numeric(df["msgId"], errors="coerce").fillna(-1).astype(int)
         df["timestamp"] = df["timestamp"].astype(np.uint64)
         df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ns")
-
-        return df
-
-    def _create_dataframe_with_timestamp(self, parsed_logs: List[str], columns: List[str]):
-        try:
-            df = pd.DataFrame(parsed_logs, columns=columns)
-            df["timestamp"] = df["timestamp"].astype(np.uint64)
-            df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ns")
-        except ValueError as e:
-            lines = len(parsed_logs)
-            try:
-                logs_columns = len(parsed_logs[0])
-            except IndexError:
-                logs_columns = "N/A"
-            raise ValueError(
-                f"Failed to create dataframe from parsed logs.\n"
-                f"parsed_logs has {logs_columns} columns and {lines} entries\n"
-                f"expected {len(columns)} columns: {columns}"
-            ) from e
-
         return df

--- a/src/analysis/mesh_analysis/readers/tracers/nimlibp2p_tracer.py
+++ b/src/analysis/mesh_analysis/readers/tracers/nimlibp2p_tracer.py
@@ -26,7 +26,7 @@ class Nimlibp2pTracer(MessageTracer):
 
     def with_received_pattern_group(self, log_format: Literal["TEXT", "JSON"]) -> Self:
         received_fields = (
-            self._prefix_fields(["msgId", "sentAt", "timestamp", "delayMs"])
+            self._prefix_fields(["msgId", "sentAt", "current", "delayMs"])
             if log_format == "JSON"
             else ["_msg"]
         )

--- a/src/analysis/mesh_analysis/readers/tracers/tests/test_nimlibp2p_tracer.py
+++ b/src/analysis/mesh_analysis/readers/tracers/tests/test_nimlibp2p_tracer.py
@@ -79,7 +79,7 @@ def test_received_json():
     assert group.fields == [
         "log.msgId",
         "log.sentAt",
-        "log.timestamp",
+        "log.current",
         "log.delayMs",
     ]
     assert pair.regex is None

--- a/src/analysis/mesh_analysis/readers/tracers/tests/test_nimlibp2p_tracer.py
+++ b/src/analysis/mesh_analysis/readers/tracers/tests/test_nimlibp2p_tracer.py
@@ -14,7 +14,7 @@ NEGATIVE = (
 
 
 def _received_regex():
-    tracer = Nimlibp2pTracer().with_received_pattern_group()
+    tracer = Nimlibp2pTracer().with_received_pattern_group(log_format="TEXT")
     (group,) = [p for p in tracer.patterns if p.name == "received"]
     (pair,) = group.trace_pairs
     return re.compile(pair.regex)
@@ -35,7 +35,7 @@ def test_negative_delay_is_parsed():
 
 
 def test_negative_delay_survives_conversion():
-    tracer = Nimlibp2pTracer().with_received_pattern_group()
+    tracer = Nimlibp2pTracer().with_received_pattern_group(log_format="TEXT")
     df = tracer._trace_received_in_logs(
         [("2759438560592407784", "1785892519584947712", "1785892519583493632", "-1")]
     )
@@ -68,3 +68,82 @@ class TestNegativeDelayWarning:
         tracer = Nimlibp2pTracer().with_extra_fields([])
         df = tracer._trace_received_in_logs(self._rows(["10", "-3"]))
         assert len(df) == 2
+
+
+def test_received_json():
+    tracer = Nimlibp2pTracer().with_received_pattern_group(log_format="JSON")
+    (group,) = tracer.patterns
+    (pair,) = group.trace_pairs
+
+    assert group.name == "received"
+    assert group.fields == [
+        "log.msgId",
+        "log.sentAt",
+        "log.timestamp",
+        "log.delayMs",
+    ]
+    assert pair.regex is None
+
+    parsed_logs = [
+        [
+            [
+                [
+                    "13647046878266911",
+                    "1785892519584947712",
+                    "1785892519585947712",
+                    "1",
+                ]
+            ]
+        ]
+    ]
+
+    dfs = tracer.trace(parsed_logs)
+    received_df = dfs["received"][0]
+
+    assert list(received_df.columns) == [
+        "msgId",
+        "sentAt",
+        "timestamp",
+        "delayMs",
+    ]
+    assert received_df.loc[0, "msgId"] == 13647046878266911
+    assert received_df.loc[0, "sentAt"].value == 1785892519584947712
+    assert received_df.loc[0, "timestamp"].value == 1785892519585947712
+    assert received_df.loc[0, "delayMs"] == "1"
+    assert str(received_df["sentAt"].dtype) == "datetime64[ns]"
+    assert str(received_df["timestamp"].dtype) == "datetime64[ns]"
+
+
+def test_sent_json():
+    tracer = Nimlibp2pTracer().with_sent_pattern_group(log_format="JSON")
+    (group,) = tracer.patterns
+    (pair,) = group.trace_pairs
+
+    assert group.name == "sent"
+    assert group.fields == [
+        "log.msgId",
+        "log.timestamp",
+    ]
+    assert pair.regex is None
+
+    parsed_logs = [
+        [
+            [
+                [
+                    "13647046878266911",
+                    "1785892519584947712",
+                ]
+            ]
+        ]
+    ]
+
+    dfs = tracer.trace(parsed_logs)
+    sent_df = dfs["sent"][0]
+
+    assert list(sent_df.columns) == [
+        "msgId",
+        "timestamp",
+    ]
+    assert sent_df.loc[0, "msgId"] == 13647046878266911
+    assert sent_df.loc[0, "timestamp"].value == 1785892519584947712
+    assert str(sent_df["timestamp"].dtype) == "datetime64[ns]"

--- a/src/analysis/mesh_analysis/readers/tracers/tests/test_waku_tracer.py
+++ b/src/analysis/mesh_analysis/readers/tracers/tests/test_waku_tracer.py
@@ -6,23 +6,40 @@ from src.analysis.mesh_analysis.readers.tracers.waku_tracer import WakuTracer
 
 
 def mock_queries(data, tracer):
-    results = [[] for _ in tracer.patterns]
-    for i, pattern_group in enumerate(tracer.patterns):
+    """
+    Build the same parsed_logs structure that VictoriaReader.make_queries() passes
+    to MessageTracer.trace().
+
+    Data is ordered to match tracer.patterns. Each inner list represents the rows
+    returned by that pattern group's separate VictoriaLogs query.
+    """
+    if len(data) != len(tracer.patterns):
+        raise ValueError(
+            f"Expected logs for {len(tracer.patterns)} pattern groups, got {len(data)}"
+        )
+
+    results = []
+
+    for pattern_group, log_lines in zip(tracer.patterns, data):
         query_results = [[] for _ in pattern_group.trace_pairs]
-        for log_line in data:
-            for j, trace_pair in enumerate(pattern_group.trace_pairs):
-                pattern = trace_pair.regex
-                match = re.search(pattern, log_line[0])
+
+        for log_line in log_lines:
+            for index, trace_pair in enumerate(pattern_group.trace_pairs):
+                if trace_pair.regex is None:
+                    query_results[index].append(list(log_line))
+                    continue
+
+                match = re.search(trace_pair.regex, log_line[0])
                 if match:
-                    match_as_list = list(match.groups())
-                    match_as_list.extend(log_line[1:])
-                    query_results[j].append(match_as_list)
-            results[i].extend(query_results)
+                    query_results[index].append([*match.groups(), *log_line[1:]])
+
+        results.append(query_results)
+
     return results
 
 
-def test_received_regex_matches_text():
-    tracer = WakuTracer().with_received_pattern_group()
+def test_relay_received_regex_matches_plain_message_text():
+    tracer = WakuTracer().with_received_pattern_group(log_format="TEXT")
 
     line = (
         "received relay message my_peer_id=16U*GiNg1a "
@@ -30,11 +47,18 @@ def test_received_regex_matches_text():
         "from_peer_id=16U*wJXtuH receivedTime=1763643976019361536"
     )
 
-    parsed_logs = mock_queries([[line]], tracer)
+    parsed_logs = mock_queries(
+        [
+            [(line,)],
+            [],
+            [],
+        ],
+        tracer,
+    )
     dfs = tracer.trace(parsed_logs)
-    received_df = dfs["received"][0]
+    received_df = dfs["received_relay"][0]
 
-    assert list(received_df.columns[:4]) == [
+    assert list(received_df.columns) == [
         "receiver_peer_id",
         "msg_hash",
         "sender_peer_id",
@@ -50,41 +74,399 @@ def test_received_regex_matches_text():
     assert pd.api.types.is_datetime64_ns_dtype(received_df["timestamp"])
 
 
-def test_received_regex_matches_json():
-    tracer = WakuTracer().with_received_pattern_group()
+def test_relay_received_regex_matches_json_encoded_message_text():
+    """
+    This is still TEXT mode: the entire serialized JSON-looking message exists in
+    _msg, so the tracer must extract values through the relay regex.
+    """
+    tracer = WakuTracer().with_received_pattern_group(log_format="TEXT")
 
     line = (
-        '{"lvl":"DBG",'
-        '"ts":"2026-07-16 15:10:00.145+00:00",'
-        '"msg":"received relay message",'
+        '{"ts":"2026-07-20 21:09:12.918+00:00",'
+        '"_msg":"received relay message",'
         '"topics":"waku relay",'
         '"tid":7,'
         '"file":"protocol.nim:221",'
-        '"my_peer_id":"16U*S6zwhq",'
-        '"msg_hash":"0x4d19ab4d7deebcd5c1935d7c27caab678566dbb14f3bf7858d09d466e7c79af7",'
-        '"msg_id":"b9cfa467b62a...67128d31aecc",'
-        '"from_peer_id":"16U*74x9yd",'
+        '"my_peer_id":"16U*JttkFq",'
+        '"msg_hash":"0xe0a42cf351ada62465857c547d8bd4b101e59f27c3ac30098ad9cf58bf38ac5b",'
+        '"msg_id":"5e204f6fdb5f...9183b433dd30",'
+        '"from_peer_id":"16U*iyAikJ",'
         '"topic":"/waku/2/rs/0/0",'
         '"contentTopic":"/my-app/1/dst/proto",'
-        '"receivedTime":1784214600145432320,'
+        '"receivedTime":1784581752918722048,'
         '"payloadSizeBytes":1000.0}'
     )
 
-    parsed_logs = mock_queries([[line]], tracer)
+    parsed_logs = mock_queries(
+        [
+            [(line,)],
+            [],
+            [],
+        ],
+        tracer,
+    )
     dfs = tracer.trace(parsed_logs)
-    received_df = dfs["received"][0]
+    received_df = dfs["received_relay"][0]
 
-    assert list(received_df.columns[:4]) == [
+    assert received_df.loc[0, "receiver_peer_id"] == "16U*JttkFq"
+    assert (
+        received_df.loc[0, "msg_hash"]
+        == "0xe0a42cf351ada62465857c547d8bd4b101e59f27c3ac30098ad9cf58bf38ac5b"
+    )
+    assert received_df.loc[0, "sender_peer_id"] == "16U*iyAikJ"
+    assert received_df.loc[0, "timestamp"] == pd.Timestamp(1784581752918722048, unit="ns")
+    assert pd.api.types.is_datetime64_ns_dtype(received_df["timestamp"])
+
+
+def test_relay_received_json():
+    tracer = WakuTracer().with_received_pattern_group(log_format="JSON")
+    relay_group, _, _ = tracer.patterns
+    (relay_pair,) = relay_group.trace_pairs
+
+    assert relay_group.name == "received_relay"
+    assert relay_group.fields == [
+        "log.my_peer_id",
+        "log.msg_hash",
+        "log.from_peer_id",
+        "log.receivedTime",
+    ]
+    assert relay_pair.regex is None
+
+    message_hash = "0xe0a42cf351ada62465857c547d8bd4b101e59f27c3ac30098ad9cf58bf38ac5b"
+    parsed_logs = mock_queries(
+        [
+            [
+                (
+                    "16U*JttkFq",
+                    message_hash,
+                    "16U*iyAikJ",
+                    1784581752918722048,
+                )
+            ],
+            [],
+            [],
+        ],
+        tracer,
+    )
+
+    dfs = tracer.trace(parsed_logs)
+    received_df = dfs["received_relay"][0]
+
+    assert list(received_df.columns) == [
         "receiver_peer_id",
         "msg_hash",
         "sender_peer_id",
         "timestamp",
     ]
-    assert received_df.loc[0, "receiver_peer_id"] == "16U*S6zwhq"
-    assert (
-        received_df.loc[0, "msg_hash"]
-        == "0x4d19ab4d7deebcd5c1935d7c27caab678566dbb14f3bf7858d09d466e7c79af7"
-    )
-    assert received_df.loc[0, "sender_peer_id"] == "16U*74x9yd"
-    assert received_df.loc[0, "timestamp"] == pd.Timestamp(1784214600145432320, unit="ns")
+    assert received_df.loc[0, "receiver_peer_id"] == "16U*JttkFq"
+    assert received_df.loc[0, "msg_hash"] == message_hash
+    assert received_df.loc[0, "sender_peer_id"] == "16U*iyAikJ"
+    assert received_df.loc[0, "timestamp"] == pd.Timestamp(1784581752918722048, unit="ns")
     assert pd.api.types.is_datetime64_ns_dtype(received_df["timestamp"])
+
+
+def test_legacy_lightpush_received_json():
+    tracer = WakuTracer().with_received_pattern_group(log_format="JSON")
+    _, _, legacy_group = tracer.patterns
+    (legacy_pair,) = legacy_group.trace_pairs
+
+    assert legacy_group.name == "received_legacy_lightpush"
+    assert legacy_group.fields == [
+        "log.peer_id",
+        "log.msg_hash",
+        "log.receivedTime",
+    ]
+    assert legacy_pair.regex is None
+
+    message_hash = "0x1441e3e14e6f957d2a45332378cda900e066022412d6a1c47c95e587d82e6eb2"
+    parsed_logs = mock_queries(
+        [
+            [],
+            [],
+            [
+                (
+                    "12D*YCde2H",
+                    message_hash,
+                    1763646635380167168,
+                )
+            ],
+        ],
+        tracer,
+    )
+
+    dfs = tracer.trace(parsed_logs)
+    received_df = dfs["received_legacy_lightpush"][0]
+
+    assert received_df.loc[0, "receiver_peer_id"] == WakuTracer.unknown_sender_str
+    assert received_df.loc[0, "sender_peer_id"] == "12D*YCde2H"
+    assert received_df.loc[0, "msg_hash"] == message_hash
+    assert received_df.loc[0, "timestamp"] == pd.Timestamp(1763646635380167168, unit="ns")
+    assert pd.api.types.is_datetime64_ns_dtype(received_df["timestamp"])
+
+
+def test_received_json_fields_are_passed_to_correct_converters():
+    """
+    This is JSON mode: VictoriaReader has already extracted values from the
+    structured log.* fields, so no tracer regex should run.
+    """
+    tracer = WakuTracer().with_received_pattern_group(log_format="JSON")
+
+    assert [group.name for group in tracer.patterns] == [
+        "received_relay",
+        "received_lightpush",
+        "received_legacy_lightpush",
+    ]
+    assert [group.fields for group in tracer.patterns] == [
+        [
+            "log.my_peer_id",
+            "log.msg_hash",
+            "log.from_peer_id",
+            "log.receivedTime",
+        ],
+        [
+            "log.my_peer_id",
+            "log.peer_id",
+            "log.msg_hash",
+            "log.receivedTime",
+        ],
+        [
+            "log.peer_id",
+            "log.msg_hash",
+            "log.receivedTime",
+        ],
+    ]
+    assert all(pair.regex is None for group in tracer.patterns for pair in group.trace_pairs)
+
+    relay_hash = "0xe0a42cf351ada62465857c547d8bd4b101e59f27c3ac30098ad9cf58bf38ac5b"
+    lightpush_hash = "0x17cfd30767acac9b86c18333ba918abef93cc23f65b6c98c845c682584f92583"
+    legacy_hash = "0x1441e3e14e6f957d2a45332378cda900e066022412d6a1c47c95e587d82e6eb2"
+
+    parsed_logs = mock_queries(
+        [
+            [
+                (
+                    "16U*JttkFq",
+                    relay_hash,
+                    "16U*iyAikJ",
+                    1784581752918722048,
+                )
+            ],
+            [
+                (
+                    "16U*GiNg1a",
+                    "16U*wJXtuH",
+                    lightpush_hash,
+                    1763643976019361536,
+                )
+            ],
+            [
+                (
+                    "12D*YCde2H",
+                    legacy_hash,
+                    1763646635380167168,
+                )
+            ],
+        ],
+        tracer,
+    )
+
+    dfs = tracer.trace(parsed_logs)
+
+    relay_df = dfs["received_relay"][0]
+    assert list(relay_df.columns) == [
+        "receiver_peer_id",
+        "msg_hash",
+        "sender_peer_id",
+        "timestamp",
+    ]
+    assert relay_df.loc[0, "receiver_peer_id"] == "16U*JttkFq"
+    assert relay_df.loc[0, "msg_hash"] == relay_hash
+    assert relay_df.loc[0, "sender_peer_id"] == "16U*iyAikJ"
+    assert relay_df.loc[0, "timestamp"] == pd.Timestamp(1784581752918722048, unit="ns")
+
+    lightpush_df = dfs["received_lightpush"][0]
+    assert list(lightpush_df.columns) == [
+        "receiver_peer_id",
+        "sender_peer_id",
+        "msg_hash",
+        "timestamp",
+    ]
+    assert lightpush_df.loc[0, "receiver_peer_id"] == "16U*GiNg1a"
+    assert lightpush_df.loc[0, "sender_peer_id"] == "16U*wJXtuH"
+    assert lightpush_df.loc[0, "msg_hash"] == lightpush_hash
+    assert lightpush_df.loc[0, "timestamp"] == pd.Timestamp(1763643976019361536, unit="ns")
+
+    legacy_df = dfs["received_legacy_lightpush"][0]
+    assert list(legacy_df.columns) == [
+        "receiver_peer_id",
+        "sender_peer_id",
+        "msg_hash",
+        "timestamp",
+    ]
+    assert legacy_df.loc[0, "receiver_peer_id"] == WakuTracer.unknown_sender_str
+    assert legacy_df.loc[0, "sender_peer_id"] == "12D*YCde2H"
+    assert legacy_df.loc[0, "msg_hash"] == legacy_hash
+    assert legacy_df.loc[0, "timestamp"] == pd.Timestamp(1763646635380167168, unit="ns")
+
+    for dataframe in (relay_df, lightpush_df, legacy_df):
+        assert pd.api.types.is_datetime64_ns_dtype(dataframe["timestamp"])
+
+
+def test_sent_json_fields_are_passed_to_converter_without_regex():
+    tracer = WakuTracer().with_sent_pattern_group(log_format="JSON")
+
+    sent_group, mix_sent_group = tracer.patterns
+    group = sent_group
+    (pair,) = group.trace_pairs
+
+    assert group.fields == [
+        "log.my_peer_id",
+        "log.msg_hash",
+        "log.to_peer_id",
+        "log.sentTime",
+    ]
+    assert pair.regex is None
+
+    message_hash = "0x17cfd30767acac9b86c18333ba918abef93cc23f65b6c98c845c682584f92583"
+    parsed_logs = mock_queries(
+        [
+            [
+                (
+                    "16U*GiNg1a",
+                    message_hash,
+                    "16U*wJXtuH",
+                    1763643976019361536,
+                )
+            ],
+            [],
+        ],
+        tracer,
+    )
+
+    dfs = tracer.trace(parsed_logs)
+    sent_df = dfs["sent"][0]
+
+    assert list(sent_df.columns) == [
+        "sender_peer_id",
+        "msg_hash",
+        "receiver_peer_id",
+        "timestamp",
+    ]
+    assert sent_df.loc[0, "sender_peer_id"] == "16U*GiNg1a"
+    assert sent_df.loc[0, "msg_hash"] == message_hash
+    assert sent_df.loc[0, "receiver_peer_id"] == "16U*wJXtuH"
+    assert sent_df.loc[0, "timestamp"] == pd.Timestamp(1763643976019361536, unit="ns")
+    assert pd.api.types.is_datetime64_ns_dtype(sent_df["timestamp"])
+
+
+def test_vlogs_separates_normal_and_mixnet_sent_messages():
+    tracer = WakuTracer().with_sent_pattern_group(log_format="TEXT")
+    sent_group, mix_sent_group = tracer.patterns
+
+    assert sent_group.name == "sent"
+    assert sent_group.query == '"sent relay message" AND NOT publishWithConn'
+
+    assert mix_sent_group.name == "mix sent"
+    assert mix_sent_group.query == '"sent relay message" AND publishWithConn'
+
+    normal_hash = "0x17cfd30767acac9b86c18333ba918abef93cc23f65b6c98c845c682584f92583"
+    mixnet_hash = "0xe0a42cf351ada62465857c547d8bd4b101e59f27c3ac30098ad9cf58bf38ac5b"
+
+    normal_relay_line = (
+        "sent relay message "
+        "my_peer_id=16U*NormalSender "
+        f"msg_hash={normal_hash} "
+        "to_peer_id=16U*NormalReceiver "
+        "sentTime=1763643976019361536"
+    )
+    mixnet_line = (
+        "sent relay message publishWithConn "
+        "my_peer_id=16U*MixnetSender "
+        "peer_id=16U*MixnetReceiver "
+        f"msg_hash={mixnet_hash} "
+        "sentTime=1763646635380167168"
+    )
+
+    parsed_logs = mock_queries(
+        [
+            [(normal_relay_line,)],
+            [(mixnet_line,)],
+        ],
+        tracer,
+    )
+
+    dfs = tracer.trace(parsed_logs)
+
+    sent_df = dfs["sent"][0]
+    assert len(sent_df) == 1
+    assert sent_df.loc[0, "sender_peer_id"] == "16U*NormalSender"
+    assert sent_df.loc[0, "msg_hash"] == normal_hash
+    assert sent_df.loc[0, "receiver_peer_id"] == "16U*NormalReceiver"
+    assert sent_df.loc[0, "timestamp"] == pd.Timestamp(1763643976019361536, unit="ns")
+
+    mix_sent_df = dfs["mix sent"][0]
+    assert len(mix_sent_df) == 1
+    assert mix_sent_df.loc[0, "sender_peer_id"] == "16U*MixnetSender"
+    assert mix_sent_df.loc[0, "receiver_peer_id"] == "16U*MixnetReceiver"
+    assert mix_sent_df.loc[0, "msg_hash"] == mixnet_hash
+    assert mix_sent_df.loc[0, "timestamp"] == pd.Timestamp(1763646635380167168, unit="ns")
+
+
+def test_vlogs_separates_normal_and_mixnet_sent_json_messages():
+    tracer = WakuTracer().with_sent_pattern_group(log_format="JSON")
+    sent_group, mix_sent_group = tracer.patterns
+
+    assert sent_group.fields == [
+        "log.my_peer_id",
+        "log.msg_hash",
+        "log.to_peer_id",
+        "log.sentTime",
+    ]
+    assert mix_sent_group.fields == [
+        "log.my_peer_id",
+        "log.peer_id",
+        "log.msg_hash",
+        "log.sentTime",
+    ]
+
+    assert sent_group.trace_pairs[0].regex is None
+    assert mix_sent_group.trace_pairs[0].regex is None
+
+    normal_hash = "0x17cfd30767acac9b86c18333ba918abef93cc23f65b6c98c845c682584f92583"
+    mixnet_hash = "0xe0a42cf351ada62465857c547d8bd4b101e59f27c3ac30098ad9cf58bf38ac5b"
+
+    parsed_logs = mock_queries(
+        [
+            [
+                (
+                    "16U*NormalSender",
+                    normal_hash,
+                    "16U*NormalReceiver",
+                    1763643976019361536,
+                )
+            ],
+            [
+                (
+                    "16U*MixnetSender",
+                    "16U*MixnetReceiver",
+                    mixnet_hash,
+                    1763646635380167168,
+                )
+            ],
+        ],
+        tracer,
+    )
+
+    dfs = tracer.trace(parsed_logs)
+
+    sent_df = dfs["sent"][0]
+    assert len(sent_df) == 1
+    assert sent_df.loc[0, "sender_peer_id"] == "16U*NormalSender"
+    assert sent_df.loc[0, "msg_hash"] == normal_hash
+    assert sent_df.loc[0, "receiver_peer_id"] == "16U*NormalReceiver"
+
+    mix_sent_df = dfs["mix sent"][0]
+    assert len(mix_sent_df) == 1
+    assert mix_sent_df.loc[0, "sender_peer_id"] == "16U*MixnetSender"
+    assert mix_sent_df.loc[0, "receiver_peer_id"] == "16U*MixnetReceiver"
+    assert mix_sent_df.loc[0, "msg_hash"] == mixnet_hash

--- a/src/analysis/mesh_analysis/readers/tracers/waku_tracer.py
+++ b/src/analysis/mesh_analysis/readers/tracers/waku_tracer.py
@@ -72,7 +72,7 @@ class WakuTracer(MessageTracer):
 
         self._append_pattern_group(
             name="received_lightpush",
-            query="handling lightpush request",
+            query='"handling lightpush request" AND NOT "waku lightpush legacy"',
             log_format=log_format,
             fields=self._prefix_fields(
                 [
@@ -93,7 +93,7 @@ class WakuTracer(MessageTracer):
 
         self._append_pattern_group(
             name="received_legacy_lightpush",
-            query="handling lightpush request",
+            query='"handling lightpush request" AND "waku lightpush legacy"',
             log_format=log_format,
             fields=self._prefix_fields(
                 [

--- a/src/analysis/mesh_analysis/readers/tracers/waku_tracer.py
+++ b/src/analysis/mesh_analysis/readers/tracers/waku_tracer.py
@@ -1,5 +1,5 @@
 import logging
-from typing import ClassVar, List, Self
+from typing import Callable, ClassVar, List, Literal, Self
 
 import numpy as np
 import pandas as pd
@@ -16,94 +16,208 @@ logger = logging.getLogger(__name__)
 
 class WakuTracer(MessageTracer):
     unknown_sender_str: ClassVar[str] = "Unknown"
+    log_field_prefix: ClassVar[str] = "log."
 
     def with_extra_fields(self, extra_fields: List[str]) -> Self:
         self.extra_fields = extra_fields
         return self
 
-    def with_received_pattern_group(self) -> Self:
+    def _prefix_fields(self, fields: List[str]) -> List[str]:
+        return [f"{self.log_field_prefix}{field}" for field in fields]
+
+    def _append_pattern_group(
+        self,
+        *,
+        name: str,
+        query: str,
+        log_format: Literal["TEXT", "JSON"],
+        fields: List[str],
+        text_regex: str,
+        convert: Callable[[List], pd.DataFrame],
+    ) -> None:
         self.patterns.append(
             PatternGroup(
-                "received",
+                name=name,
+                fields=fields if log_format == "JSON" else ["_msg"],
                 trace_pairs=[
                     TracePair(
-                        regex=r"received relay message.*?my_peer_id[\s\":=]+([\w*]+).*?msg_hash[\s\":=]+(0x[\da-f]+).*?from_peer_id[\s\":=]+([\w*]+).*?receivedTime[\s\":=]+(\d+)",
-                        convert=self._trace_received_in_logs,
-                    ),
-                    TracePair(
-                        regex=
-                        # Legacy lightpush
-                        # Example from jswaku:
-                        # NTC 2025-11-20 13:50:35.376+00:00 handling lightpush request topics="waku lightpush legacy" tid=7 file=protocol.nim:48 peer_id=12D*YCde2H requestId=46e649c7-f0db-409c-afed-c34f17e2ff7b pubsubTopic=/waku/2/rs/2/0 msg_hash=0x1441e3e14e6f957d2a45332378cda900e066022412d6a1c47c95e587d82e6eb2 receivedTime=1763646635380167168
-                        r'handling lightpush request.*?topics="waku lightpush legacy".*?peer_id=([\w*]+).*?msg_hash=(0x[\da-f]+).*?receivedTime=(\d+)',
-                        convert=self._trace_legacy_lightpush_in_logs,
-                    ),
-                    TracePair(
-                        regex=
-                        # Example from nwaku:
-                        # NTC 2025-11-20 13:06:16.015+00:00 handling lightpush request topics="waku lightpush" tid=7 file=protocol.nim:79 my_peer_id=16U*GiNg1a peer_id=16U*wJXtuH requestId=db01d1a6519de2145f10 pubsubTopic="some(\"/waku/2/rs/2/0\")" msg_hash=0x17cfd30767acac9b86c18333ba918abef93cc23f65b6c98c845c682584f92583 receivedTime=1763643976019361536
-                        r"handling lightpush request.*?my_peer_id=([\w*]+).*?peer_id=([\w*]+).*?msg_hash=(0x[\da-f]+).*?receivedTime=(\d+)",
-                        convert=self._trace_lightpush_in_logs,
+                        regex=text_regex if log_format == "TEXT" else None,
+                        convert=convert,
                     ),
                 ],
-                query="(received relay message OR  handling lightpush request)",
+                query=query,
             )
         )
+
+    def with_received_pattern_group(self, log_format: Literal["TEXT", "JSON"]) -> Self:
+        self._append_pattern_group(
+            name="received_relay",
+            query="received relay message",
+            log_format=log_format,
+            fields=self._prefix_fields(
+                [
+                    "my_peer_id",
+                    "msg_hash",
+                    "from_peer_id",
+                    "receivedTime",
+                ]
+            ),
+            text_regex=(
+                r"received relay message.*?my_peer_id[\s\":=]+([\w*]+).*?"
+                r"msg_hash[\s\":=]+(0x[\da-f]+).*?from_peer_id[\s\":=]+([\w*]+).*?"
+                r"receivedTime[\s\":=]+(\d+)"
+            ),
+            convert=self._trace_received_in_logs,
+        )
+
+        self._append_pattern_group(
+            name="received_lightpush",
+            query="handling lightpush request",
+            log_format=log_format,
+            fields=self._prefix_fields(
+                [
+                    "my_peer_id",
+                    "peer_id",
+                    "msg_hash",
+                    "receivedTime",
+                ]
+            ),
+            text_regex=(
+                # Example from nwaku:
+                # NTC 2025-11-20 13:06:16.015+00:00 handling lightpush request topics="waku lightpush" tid=7 file=protocol.nim:79 my_peer_id=16U*GiNg1a peer_id=16U*wJXtuH requestId=db01d1a6519de2145f10 pubsubTopic="some(\"/waku/2/rs/2/0\")" msg_hash=0x17cfd30767acac9b86c18333ba918abef93cc23f65b6c98c845c682584f92583 receivedTime=1763643976019361536
+                r"handling lightpush request.*?my_peer_id=([\w*]+).*?"
+                r"peer_id=([\w*]+).*?msg_hash=(0x[\da-f]+).*?receivedTime=(\d+)"
+            ),
+            convert=self._trace_lightpush_in_logs,
+        )
+
+        self._append_pattern_group(
+            name="received_legacy_lightpush",
+            query="handling lightpush request",
+            log_format=log_format,
+            fields=self._prefix_fields(
+                [
+                    "peer_id",
+                    "msg_hash",
+                    "receivedTime",
+                ]
+            ),
+            text_regex=(
+                # Legacy lightpush
+                # Example from jswaku:
+                # NTC 2025-11-20 13:50:35.376+00:00 handling lightpush request topics="waku lightpush legacy" tid=7 file=protocol.nim:48 peer_id=12D*YCde2H requestId=46e649c7-f0db-409c-afed-c34f17e2ff7b pubsubTopic=/waku/2/rs/2/0 msg_hash=0x1441e3e14e6f957d2a45332378cda900e066022412d6a1c47c95e587d82e6eb2 receivedTime=1763646635380167168
+                r'handling lightpush request.*?topics="waku lightpush legacy".*?'
+                r"peer_id=([\w*]+).*?msg_hash=(0x[\da-f]+).*?receivedTime=(\d+)"
+            ),
+            convert=self._trace_legacy_lightpush_in_logs,
+        )
+
         return self
 
-    def with_sent_pattern_group(self) -> Self:
-        sent_pattern_group = PatternGroup(
+    def with_sent_pattern_group(self, log_format: Literal["TEXT", "JSON"]) -> Self:
+        self._append_pattern_group(
             name="sent",
-            trace_pairs=[
-                TracePair(
-                    regex=r"sent relay message.*?my_peer_id[\s\":=]+([\w*]+).*?msg_hash[\s\":=]+(0x[\da-f]+).*?to_peer_id[\s\":=]+([\w*]+).*?sentTime[\s\":=]+(\d+)",
-                    convert=self._trace_sent_in_logs,
-                ),
-                TracePair(
-                    regex=r"publishWithConn.*?my_peer_id=([\w*]+).*?peer_id=([\w*]+).*?msg_hash=(0x[\da-f]+).*?sentTime=(\d+)",
-                    convert=self._trace_mixnet_in_logs,
-                ),
-            ],
-            query="sent relay message",
+            query='"sent relay message" AND NOT publishWithConn',
+            log_format=log_format,
+            fields=self._prefix_fields(
+                [
+                    "my_peer_id",
+                    "msg_hash",
+                    "to_peer_id",
+                    "sentTime",
+                ]
+            ),
+            text_regex=(
+                r"sent relay message.*?my_peer_id=([\w*]+).*?"
+                r"msg_hash=(0x[\da-f]+).*?to_peer_id=([\w*]+).*?sentTime=(\d+)"
+            ),
+            convert=self._trace_sent_in_logs,
         )
-        self.patterns.append(sent_pattern_group)
+
+        self._append_pattern_group(
+            name="mix sent",
+            query='"sent relay message" AND publishWithConn',
+            log_format=log_format,
+            fields=self._prefix_fields(
+                [
+                    "my_peer_id",
+                    "peer_id",
+                    "msg_hash",
+                    "sentTime",
+                ]
+            ),
+            text_regex=(
+                r"publishWithConn.*?my_peer_id=([\w*]+).*?"
+                r"peer_id=([\w*]+).*?msg_hash=(0x[\da-f]+).*?sentTime=(\d+)"
+            ),
+            convert=self._trace_mixnet_in_logs,
+        )
+
         return self
 
     def _trace_received_in_logs(self, parsed_logs: List) -> pd.DataFrame:
+        # parsed_logs: [my_peer_id, msg_hash, from_peer_id, receivedTime, *extra_fields]
         columns = ["receiver_peer_id", "msg_hash", "sender_peer_id", "timestamp"]
         columns.extend(self.extra_fields)
 
-        df = self._create_dataframe_with_timestamp(parsed_logs, columns)
+        rows = []
+        for row in parsed_logs:
+            my_peer_id, msg_hash, from_peer_id, receivedTime, *extras = row
+            rows.append([my_peer_id, msg_hash, from_peer_id, receivedTime, *extras])
 
+        df = self._create_dataframe_with_timestamp(rows, columns)
         return df
 
     def _trace_sent_in_logs(self, parsed_logs: List) -> pd.DataFrame:
+        # parsed_logs: [my_peer_id, msg_hash, to_peer_id, sentTime, *extra_fields]
         columns = ["sender_peer_id", "msg_hash", "receiver_peer_id", "timestamp"]
         columns.extend(self.extra_fields)
 
-        df = self._create_dataframe_with_timestamp(parsed_logs, columns)
+        rows = []
+        for row in parsed_logs:
+            my_peer_id, msg_hash, to_peer_id, sentTime, *extras = row
+            rows.append([my_peer_id, msg_hash, to_peer_id, sentTime, *extras])
+
+        df = self._create_dataframe_with_timestamp(rows, columns)
         return df
 
     def _trace_mixnet_in_logs(self, parsed_logs: List) -> pd.DataFrame:
+        # parsed_logs: [my_peer_id, peer_id, msg_hash, sentTime, *extra_fields]
         columns = ["sender_peer_id", "receiver_peer_id", "msg_hash", "timestamp"]
         columns.extend(self.extra_fields)
 
-        df = self._create_dataframe_with_timestamp(parsed_logs, columns)
+        rows = []
+        for row in parsed_logs:
+            my_peer_id, peer_id, msg_hash, sentTime, *extras = row
+            rows.append([my_peer_id, peer_id, msg_hash, sentTime, *extras])
+
+        df = self._create_dataframe_with_timestamp(rows, columns)
         return df
 
     def _trace_lightpush_in_logs(self, parsed_logs: List) -> pd.DataFrame:
+        # parsed_logs: [my_peer_id, peer_id, msg_hash, receivedTime, *extra_fields]
         columns = ["receiver_peer_id", "sender_peer_id", "msg_hash", "timestamp"]
         columns.extend(self.extra_fields)
 
-        df = self._create_dataframe_with_timestamp(parsed_logs, columns)
+        rows = []
+        for row in parsed_logs:
+            my_peer_id, peer_id, msg_hash, receivedTime, *extras = row
+            rows.append([my_peer_id, peer_id, msg_hash, receivedTime, *extras])
+
+        df = self._create_dataframe_with_timestamp(rows, columns)
         return df
 
     def _trace_legacy_lightpush_in_logs(self, parsed_logs: List) -> pd.DataFrame:
+        # parsed_logs: [peer_id, msg_hash, receivedTime, *extra_fields]
         columns = ["receiver_peer_id", "sender_peer_id", "msg_hash", "timestamp"]
         columns.extend(self.extra_fields)
 
-        parsed_logs = [[self.__class__.unknown_sender_str] + row for row in parsed_logs if row]
-        df = self._create_dataframe_with_timestamp(parsed_logs, columns)
+        rows = []
+        for row in parsed_logs:
+            peer_id, msg_hash, receivedTime, *extras = row
+            rows.append([self.unknown_sender_str, peer_id, msg_hash, receivedTime, *extras])
+
+        df = self._create_dataframe_with_timestamp(rows, columns)
         return df
 
     def _trace_all_logs(self, parsed_logs: List) -> List:

--- a/src/analysis/mesh_analysis/readers/victoria_reader.py
+++ b/src/analysis/mesh_analysis/readers/victoria_reader.py
@@ -31,26 +31,40 @@ class VictoriaReader(Reader):
         self._tracer: MessageTracer = tracer
         self._config_query = victoria_config_query
 
-    def _fetch_data(self, url: str, headers: Dict, params: Dict, extra_fields: List[str]):
+    def _fetch_data(self, url: str, headers: Dict, params: Dict, fields: List[str]):
+        """
+        Fetch log lines from VictoriaLogs.
+
+        :param fields: List of field names to extract from each JSON log object (e.g. ["_msg", "log.from_peer_id", ...]).
+                       All fields are treated as required; missing fields will cause the line to be skipped with a warning.
+        """
         logs = []
         logger.debug(f"Fetching {params}")
         with requests.post(url=url, headers=headers, params=params, stream=True) as response:
             for line in response.iter_lines():
-                if line:
-                    try:
-                        parsed_object = json.loads(line)
-                    except json.decoder.JSONDecodeError as e:
-                        logger.info(line)
-                        exit()
-                    try:
-                        logs.append(
-                            (parsed_object["_msg"],) + tuple(parsed_object[k] for k in extra_fields)
-                        )
-                    except KeyError as e:
-                        logger.warning(f"Malformed log line skipped due to missing key {e}: {line}")
-                        continue
-        logger.debug(f"Fetched {len(logs)} log lines")
+                if not line:
+                    continue
+                try:
+                    parsed_object = json.loads(line)
+                except json.decoder.JSONDecodeError as e:
+                    logger.info(line)
+                    exit()
 
+                row = []
+                skip_line = False
+                for field in fields:
+                    if field not in parsed_object:
+                        logger.warning(
+                            f"Malformed log line skipped due to missing key {field}: {line}"
+                        )
+                        skip_line = True
+                        break
+                    row.append(parsed_object[field])
+                if skip_line:
+                    continue
+                logs.append(tuple(row))
+
+        logger.debug(f"Fetched {len(logs)} log lines")
         return logs
 
     def make_queries(self) -> List[List[Tuple]]:
@@ -71,19 +85,25 @@ class VictoriaReader(Reader):
 
         results = [[] for _ in self._tracer.patterns]
         for i, pattern_group in enumerate(self._tracer.patterns):
+            fields = pattern_group.fields + self._tracer.extra_fields
             logs = self._fetch_data(
                 self._config_query["url"],
                 self._config_query["headers"],
                 params[i],
-                self._tracer.extra_fields,
+                fields,
             )
             query_results = [[] for _ in pattern_group.trace_pairs]
             for log_line in logs:
                 for j, trace_pair in enumerate(pattern_group.trace_pairs):
                     pattern = trace_pair.regex
+                    if pattern is None:
+                        query_results[j].append(list(log_line))
+                        continue
+                    # Apply regex to the first field. Usually, this should be _msg.
                     match = re.search(pattern, log_line[0])
                     if match:
                         match_as_list = list(match.groups())
+                        # Append extra fields (if any). log_line[1:] corresponds to fields after _msg.
                         match_as_list.extend(log_line[1:])
                         query_results[j].append(match_as_list)
 


### PR DESCRIPTION
When using --format-json=True, Victoria parses the JSON of pod messages and stores the results in individual fields (eg. log.peer_id). Specify the expected fields in the tracers, and have Victoria include them in queries.