### PR TITLE
Affinity helpers

### DIFF
--- a/src/deployments/core/builders.py
+++ b/src/deployments/core/builders.py
@@ -35,6 +35,19 @@ from src.deployments.core.configs.statefulset import StatefulSetConfig, build_st
 
 logger = logging.getLogger(__name__)
 
+NODE_HOSTNAME_LABEL = "kubernetes.io/hostname"
+
+
+def _normalize_machines(machines: List[str] | str) -> List[str]:
+    if isinstance(machines, str):
+        machines = [machines]
+    else:
+        machines = list(machines)
+
+    if not machines:
+        raise ValueError("At least one machine must be provided.")
+    return machines
+
 
 class StatefulSetBuilder(BaseModel):
     config: StatefulSetConfig = Field(default_factory=StatefulSetConfig)
@@ -69,6 +82,38 @@ class StatefulSetBuilder(BaseModel):
         if self.config.stateful_set_spec.volume_claim_templates is None:
             self.config.stateful_set_spec.volume_claim_templates = []
         self.config.stateful_set_spec.volume_claim_templates.append(pvc)
+        return self
+
+    def with_allowed_machines(
+        self,
+        machines: List[str] | str,
+        *,
+        label_key: str = NODE_HOSTNAME_LABEL,
+        overwrite: bool = False,
+    ) -> Self:
+        """Restrict pods to machines whose label value is in ``machines``."""
+        self.config.stateful_set_spec.pod_template_spec_config.pod_spec_config.with_required_node_affinity(
+            label_key,
+            "In",
+            _normalize_machines(machines),
+            overwrite=overwrite,
+        )
+        return self
+
+    def with_avoided_machines(
+        self,
+        machines: List[str] | str,
+        *,
+        label_key: str = NODE_HOSTNAME_LABEL,
+        overwrite: bool = False,
+    ) -> Self:
+        """Prevent pods from scheduling on machines whose label value is in ``machines``."""
+        self.config.stateful_set_spec.pod_template_spec_config.pod_spec_config.with_required_node_affinity(
+            label_key,
+            "NotIn",
+            _normalize_machines(machines),
+            overwrite=overwrite,
+        )
         return self
 
     def with_network_delay(
@@ -169,6 +214,38 @@ class PodBuilder(BaseModel):
     ) -> Self:
         with_image_for_container(
             config=self.config, image=image, container_name=container_name, overwrite=overwrite
+        )
+        return self
+
+    def with_allowed_machines(
+        self,
+        machines: List[str] | str,
+        *,
+        label_key: str = NODE_HOSTNAME_LABEL,
+        overwrite: bool = False,
+    ) -> Self:
+        """Restrict the pod to machines whose label value is in ``machines``."""
+        self.config.pod_spec_config.with_required_node_affinity(
+            label_key,
+            "In",
+            _normalize_machines(machines),
+            overwrite=overwrite,
+        )
+        return self
+
+    def with_avoided_machines(
+        self,
+        machines: List[str] | str,
+        *,
+        label_key: str = NODE_HOSTNAME_LABEL,
+        overwrite: bool = False,
+    ) -> Self:
+        """Prevent the pod from scheduling on machines whose label value is in ``machines``."""
+        self.config.pod_spec_config.with_required_node_affinity(
+            label_key,
+            "NotIn",
+            _normalize_machines(machines),
+            overwrite=overwrite,
         )
         return self
 
@@ -286,6 +363,38 @@ class PodSpecBuilder(BaseModel):
 
     def with_service_account_name(self, name: str, *, overwrite: bool = False) -> Self:
         self.config.with_service_account_name(name, overwrite=overwrite)
+        return self
+
+    def with_allowed_machines(
+        self,
+        machines: List[str] | str,
+        *,
+        label_key: str = NODE_HOSTNAME_LABEL,
+        overwrite: bool = False,
+    ) -> Self:
+        """Restrict pods to machines whose label value is in ``machines``."""
+        self.config.with_required_node_affinity(
+            label_key,
+            "In",
+            _normalize_machines(machines),
+            overwrite=overwrite,
+        )
+        return self
+
+    def with_avoided_machines(
+        self,
+        machines: List[str] | str,
+        *,
+        label_key: str = NODE_HOSTNAME_LABEL,
+        overwrite: bool = False,
+    ) -> Self:
+        """Prevent pods from scheduling on machines whose label value is in ``machines``."""
+        self.config.with_required_node_affinity(
+            label_key,
+            "NotIn",
+            _normalize_machines(machines),
+            overwrite=overwrite,
+        )
         return self
 
 

--- a/src/deployments/core/configs/pod.py
+++ b/src/deployments/core/configs/pod.py
@@ -3,7 +3,12 @@ from copy import deepcopy
 from typing import Dict, List, Literal, Optional, TypeVar
 
 from kubernetes.client import (
+    V1Affinity,
     V1Container,
+    V1NodeAffinity,
+    V1NodeSelector,
+    V1NodeSelectorRequirement,
+    V1NodeSelectorTerm,
     V1ObjectMeta,
     V1Pod,
     V1PodDNSConfig,
@@ -29,6 +34,7 @@ class PodSpecConfig(BaseModel):
     service_account_name: Optional[str] = None
     security_context: Optional[V1PodSecurityContext] = None
     automount_service_account_token: Optional[bool] = None
+    affinity: Optional[V1Affinity] = None
 
     def with_dns_search(self, dns_search: str, *, overwrite: bool = False):
         if self.dns_config is None:
@@ -133,6 +139,45 @@ class PodSpecConfig(BaseModel):
             )
         self.security_context = context
 
+    def with_required_node_affinity(
+        self,
+        key: str,
+        operator: Literal["In", "NotIn"],
+        values: List[str],
+        *,
+        overwrite: bool = False,
+    ):
+        if not values:
+            raise ValueError("Node affinity values must not be empty.")
+
+        if self.affinity is None:
+            self.affinity = V1Affinity()
+        if self.affinity.node_affinity is None:
+            self.affinity.node_affinity = V1NodeAffinity()
+
+        existing = self.affinity.node_affinity.required_during_scheduling_ignored_during_execution
+        if existing is not None and not overwrite:
+            raise ValueError(
+                f"required node affinity already exists in {type(self)}. "
+                f"key: `{key}` operator: `{operator}` values: `{values}` config: `{self}`"
+            )
+
+        self.affinity.node_affinity.required_during_scheduling_ignored_during_execution = (
+            V1NodeSelector(
+                node_selector_terms=[
+                    V1NodeSelectorTerm(
+                        match_expressions=[
+                            V1NodeSelectorRequirement(
+                                key=key,
+                                operator=operator,
+                                values=values,
+                            )
+                        ]
+                    )
+                ]
+            )
+        )
+
 
 class PodTemplateSpecConfig(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -186,6 +231,7 @@ def build_pod_spec(config: PodSpecConfig) -> V1PodSpec:
         service_account_name=config.service_account_name,
         security_context=config.security_context,
         automount_service_account_token=config.automount_service_account_token,
+        affinity=deepcopy(config.affinity),
     )
 
 

--- a/src/deployments/core/configs/tests/test_pod.py
+++ b/src/deployments/core/configs/tests/test_pod.py
@@ -131,11 +131,43 @@ def test_with_security_context_sets_value():
     assert config.security_context == context
 
 
+def test_with_required_node_affinity_sets_required_expression():
+    config = PodSpecConfig()
+    config.with_required_node_affinity("kubernetes.io/hostname", "NotIn", ["node-05"])
+
+    selector = config.affinity.node_affinity.required_during_scheduling_ignored_during_execution
+    expression = selector.node_selector_terms[0].match_expressions[0]
+    assert expression.key == "kubernetes.io/hostname"
+    assert expression.operator == "NotIn"
+    assert expression.values == ["node-05"]
+
+
+def test_with_required_node_affinity_raises_on_duplicate_without_overwrite():
+    config = PodSpecConfig()
+    config.with_required_node_affinity("kubernetes.io/hostname", "NotIn", ["node-05"])
+
+    with pytest.raises(ValueError):
+        config.with_required_node_affinity("kubernetes.io/hostname", "In", ["node-06"])
+
+
 def test_build_pod_spec_uses_config_values():
     config = PodSpecConfig()
     config.with_dns_search("a.example")
     spec = build_pod_spec(config)
     assert spec.dns_config.searches == ["a.example"]
+
+
+def test_build_pod_spec_uses_node_affinity():
+    config = PodSpecConfig()
+    config.with_required_node_affinity("kubernetes.io/hostname", "In", ["node-01", "node-02"])
+
+    spec = build_pod_spec(config)
+
+    selector = spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution
+    expression = selector.node_selector_terms[0].match_expressions[0]
+    assert expression.key == "kubernetes.io/hostname"
+    assert expression.operator == "In"
+    assert expression.values == ["node-01", "node-02"]
 
 
 def test_build_pod_template_spec_maps_metadata_and_spec():

--- a/src/deployments/core/tests/test_builders.py
+++ b/src/deployments/core/tests/test_builders.py
@@ -117,6 +117,11 @@ def _create_pod_template_spec_with_default_values() -> V1PodTemplateSpec:
     )
 
 
+def _required_node_affinity_expression(pod_spec: V1PodSpec):
+    selector = pod_spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution
+    return selector.node_selector_terms[0].match_expressions[0]
+
+
 # --------------------------------------------------------------------------- #
 # StatefulSetBuilder Tests
 # --------------------------------------------------------------------------- #
@@ -162,6 +167,34 @@ class TestStatefulSetBuilder:
             "cluster": "vaclab",
             "team": "dst",
         }
+
+    def test_with_avoided_machines_sets_not_in_node_affinity(self):
+        """Should prevent pods from scheduling on listed machines."""
+        builder = StatefulSetBuilder()
+        builder.config.namespace = "default"
+
+        result = builder.with_avoided_machines(["node-05", "node-06"])
+        stateful_set = builder.build()
+        expression = _required_node_affinity_expression(stateful_set.spec.template.spec)
+
+        assert result is builder
+        assert expression.key == "kubernetes.io/hostname"
+        assert expression.operator == "NotIn"
+        assert expression.values == ["node-05", "node-06"]
+
+    def test_with_allowed_machines_sets_in_node_affinity(self):
+        """Should restrict pods to listed machines."""
+        builder = StatefulSetBuilder()
+        builder.config.namespace = "default"
+
+        result = builder.with_allowed_machines("node-01")
+        stateful_set = builder.build()
+        expression = _required_node_affinity_expression(stateful_set.spec.template.spec)
+
+        assert result is builder
+        assert expression.key == "kubernetes.io/hostname"
+        assert expression.operator == "In"
+        assert expression.values == ["node-01"]
 
     @pytest.mark.parametrize("overwrite", [False, True])
     def test_with_image_in_container_calls_helper_with_correct_params(self, mocker, overwrite):
@@ -460,6 +493,19 @@ class TestPodBuilder:
         result = builder.build()
         mock_build_pod.assert_called_once_with(builder.config)
         assert isinstance(result, V1Pod)
+
+    def test_with_allowed_machines_sets_in_node_affinity(self):
+        """Should restrict a pod to listed machines."""
+        builder = PodBuilder()
+
+        result = builder.with_allowed_machines(["node-01", "node-02"])
+        pod = builder.build()
+        expression = _required_node_affinity_expression(pod.spec)
+
+        assert result is builder
+        assert expression.key == "kubernetes.io/hostname"
+        assert expression.operator == "In"
+        assert expression.values == ["node-01", "node-02"]
 
     def test_dependency_reconciles_on_field_change(self, mocker):
         class ChildBuilder(PodBuilder):
@@ -803,6 +849,19 @@ class TestPodSpecBuilder:
 
         assert isinstance(result, PodSpecBuilder)
         assert builder.config.service_account_name == "default"
+
+    def test_with_avoided_machines_sets_not_in_node_affinity(self):
+        """Should prevent pods from scheduling on listed machines."""
+        builder = PodSpecBuilder()
+
+        result = builder.with_avoided_machines("node-05")
+        pod_spec = builder.build()
+        expression = _required_node_affinity_expression(pod_spec)
+
+        assert result is builder
+        assert expression.key == "kubernetes.io/hostname"
+        assert expression.operator == "NotIn"
+        assert expression.values == ["node-05"]
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Today node-02 was missbehaving today, this was making deployments not to work for some quick tests so I decided that it would be nice to add an option to select or avoid specific machines in experiments, like doing:
```python
builder = builder.with_allowed_machines(...)
```